### PR TITLE
Enum IsValid Extension Method

### DIFF
--- a/Kvasir/Intellisense.xml
+++ b/Kvasir/Intellisense.xml
@@ -977,5 +977,69 @@
               The raw contents of this <see cref="T:Cybele.ConceptString`1"/>.
             </value>
         </member>
+        <member name="T:Cybele.Extensions.EnumExtensions">
+            <summary>
+              A collection of methods that extend user-defined <see cref="T:System.Enum"/> types.
+            </summary>
+        </member>
+        <member name="M:Cybele.Extensions.EnumExtensions.IsValid``1(``0)">
+            <summary>
+              Determines if an enumerator is valid.
+            </summary>
+            <typeparam name="TEnum">
+              [deduced] The type of <paramref name="enumerator"/>.
+            </typeparam>
+            <param name="enumerator">
+              The enumerator whose validity to determine.
+            </param>
+            <returns>
+              <see langword="true"/> if <paramref name="enumerator"/> is a valid enumerator; otherwise,
+              <see langword="false"/>.
+            </returns>
+            <remarks>
+              <para>
+                This method is intended primarily as a defensive helper to ensure that enumerators provided to an API
+                are among those that the author of the enumerator intended to be used. Because enums are simply type
+                system wrappers around integers, it is legal to convert an arbitrary integer into a enumeration even
+                if no name was assigned to that value in the enumeration's declaration. Passing such a value to an API
+                often implicitly violates preconditions, especially when <c>switch</c> statements are employed that
+                assume an enumerator is one of the explicitly defined constants.
+              </para>
+              <para>
+                When dealing with "regular" enums (as opposed to <see cref="T:System.FlagsAttribute">"flag"</see> enums), this
+                method works identically to <see cref="M:System.Enum.IsDefined(System.Type,System.Object)"/>. Specifically, an enumerator of
+                a "regular" enum is valid if and only if its value is that of one of the named constants in the enum's
+                declaration. This is not affected by enumeration aliasing (i.e. having more than one named constant
+                for the same value).
+              </para>
+              <para>
+                When dealing with a <see cref="T:System.FlagsAttribute">"flag"</see> enum, the behavior of this method diverges
+                from that of <see cref="M:System.Enum.IsDefined(System.Type,System.Object)"/> to provide a response that is more in line with
+                most users' expectations. An enumerator of a <see cref="T:System.FlagsAttribute">"flag"</see> enum is valid if
+                and only if its value is a combination of one or more of the named constants in the enum's declaration.
+                This means that un-aliased combinations will be treated as valid by this method, whereas
+                <see cref="M:System.Enum.IsDefined(System.Type,System.Object)"/> recognizes only those values specified in the enum's
+                declaration. Note that <see cref="T:System.FlagsAttribute">"flag"</see> enums do not receive a <c>None</c>
+                enumerator automatically; as such, an enumerator with numeric value <c>0</c> is only valid if such a
+                constant is explicitly defined by the enumeration.
+              </para>
+            </remarks>
+        </member>
+        <member name="M:Cybele.Extensions.EnumExtensions.AsInt64``1(``0)">
+            <summary>
+              Reinterprets the bit pattern of the numeric value of an enumerator as the bit pattern for a <c>64</c>-bit
+              signed integer (i.e. a <see cref="T:System.Int64"/>).
+            </summary>
+            <typeparam name="TEnum">
+              [deduced] The type of <paramref name="enumerator"/>.
+            </typeparam>
+            <param name="enumerator">
+              The enumerator whose bit pattern to reinterpret.
+            </param>
+            <returns>
+              A <see cref="T:System.Int64"/> whose bit pattern is the same as the bit pattern of <paramref name="enumerator"/>,
+              possibly with some extra leading <c>0</c>s.
+            </returns>
+        </member>
     </members>
 </doc>

--- a/Kvasir/Schema/BasicField.cs
+++ b/Kvasir/Schema/BasicField.cs
@@ -1,4 +1,5 @@
-﻿using Optional;
+﻿using Cybele.Extensions;
+using Optional;
 using System;
 using System.Diagnostics;
 
@@ -65,6 +66,7 @@ namespace Kvasir.Schema {
         /// </exception>
         internal BasicField(FieldName name, DBType dataType, IsNullable nullability, Option<DBValue> defaultValue) {
             Debug.Assert(dataType != DBType.Enumeration);
+            Debug.Assert(nullability.IsValid());
 
             // Check #1: If the Field is non-nullable, then the default value must either be a NONE instance or a SOME
             // instance that contains a value other than DBValue.NULL.

--- a/Kvasir/Schema/EnumField.cs
+++ b/Kvasir/Schema/EnumField.cs
@@ -1,4 +1,5 @@
-﻿using Optional;
+﻿using Cybele.Extensions;
+using Optional;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -54,6 +55,8 @@ namespace Kvasir.Schema {
         /// </exception>
         internal EnumField(FieldName name, IsNullable nullability, Option<DBValue> defaultValue,
             IEnumerable<DBValue> enumerators) {
+
+            Debug.Assert(nullability.IsValid());
 
             // Check #1: If the Field is non-nullable, then the default value must either be a NONE instance or a SOME
             // instance that contains a value other than DBValue.NULL.

--- a/Kvasir/Utility/Extensions/EnumExtensions.cs
+++ b/Kvasir/Utility/Extensions/EnumExtensions.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Cybele.Extensions {
+    /// <summary>
+    ///   A collection of methods that extend user-defined <see cref="Enum"/> types.
+    /// </summary>
+    public static class EnumExtensions {
+        /// <summary>
+        ///   Determines if an enumerator is valid.
+        /// </summary>
+        /// <typeparam name="TEnum">
+        ///   [deduced] The type of <paramref name="enumerator"/>.
+        /// </typeparam>
+        /// <param name="enumerator">
+        ///   The enumerator whose validity to determine.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="enumerator"/> is a valid enumerator; otherwise,
+        ///   <see langword="false"/>.
+        /// </returns>
+        /// <remarks>
+        ///   <para>
+        ///     This method is intended primarily as a defensive helper to ensure that enumerators provided to an API
+        ///     are among those that the author of the enumerator intended to be used. Because enums are simply type
+        ///     system wrappers around integers, it is legal to convert an arbitrary integer into a enumeration even
+        ///     if no name was assigned to that value in the enumeration's declaration. Passing such a value to an API
+        ///     often implicitly violates preconditions, especially when <c>switch</c> statements are employed that
+        ///     assume an enumerator is one of the explicitly defined constants.
+        ///   </para>
+        ///   <para>
+        ///     When dealing with "regular" enums (as opposed to <see cref="FlagsAttribute">"flag"</see> enums), this
+        ///     method works identically to <see cref="Enum.IsDefined(Type, object)"/>. Specifically, an enumerator of
+        ///     a "regular" enum is valid if and only if its value is that of one of the named constants in the enum's
+        ///     declaration. This is not affected by enumeration aliasing (i.e. having more than one named constant
+        ///     for the same value).
+        ///   </para>
+        ///   <para>
+        ///     When dealing with a <see cref="FlagsAttribute">"flag"</see> enum, the behavior of this method diverges
+        ///     from that of <see cref="Enum.IsDefined(Type, object)"/> to provide a response that is more in line with
+        ///     most users' expectations. An enumerator of a <see cref="FlagsAttribute">"flag"</see> enum is valid if
+        ///     and only if its value is a combination of one or more of the named constants in the enum's declaration.
+        ///     This means that un-aliased combinations will be treated as valid by this method, whereas
+        ///     <see cref="Enum.IsDefined(Type, object)"/> recognizes only those values specified in the enum's
+        ///     declaration. Note that <see cref="FlagsAttribute">"flag"</see> enums do not receive a <c>None</c>
+        ///     enumerator automatically; as such, an enumerator with numeric value <c>0</c> is only valid if such a
+        ///     constant is explicitly defined by the enumeration.
+        ///   </para>
+        /// </remarks>
+        public static bool IsValid<TEnum>(this TEnum enumerator) where TEnum : Enum {
+            var enumType = typeof(TEnum);
+            var underlyingCode = enumerator.GetTypeCode();
+            var numeric = enumerator.AsInt64();
+            
+            // Memoize the results of the flag check so that we only perform the reflection once per enum type
+            if (!isFlagsMemoizer_.TryGetValue(enumType, out bool isFlags)) {
+                isFlags = !(enumType.GetCustomAttribute<FlagsAttribute>() is null);
+                isFlagsMemoizer_[enumType] = isFlags;
+            }
+
+            // If the enum type is a regular enum, as opposed to a flags enum, then this function should behave the
+            // same as Enum.IsDefined. We also use this check for when the input enumerator value is 0, because relying
+            // on the ensuing bitwise arithmetic would produce potential false positives if a zero-flags combination
+            // were not explicitly defined.
+            if (!isFlags || numeric == 0L) {
+                return Enum.IsDefined(enumType, enumerator);
+            }
+
+            // Memoize the results of the bit aggregation so that we only perform the reflection and bitwise arithetic
+            // once per enum type
+            if (!bitsMemoizer_.TryGetValue(enumType, out long aggregateBits)) {
+                aggregateBits = Enum.GetValues(enumType).Cast<TEnum>().Aggregate(0L, (i, f) => i | f.AsInt64());
+                bitsMemoizer_[enumType] = aggregateBits;
+            }
+
+            // We use a bitwise arithmetic trick to determine if the provided enumerator is valid by ensuring that all
+            // of the "on" bits are also "on" in the aggregation
+            return (aggregateBits | numeric) == aggregateBits;
+        }
+
+        /// <summary>
+        ///   Reinterprets the bit pattern of the numeric value of an enumerator as the bit pattern for a <c>64</c>-bit
+        ///   signed integer (i.e. a <see cref="long"/>).
+        /// </summary>
+        /// <typeparam name="TEnum">
+        ///   [deduced] The type of <paramref name="enumerator"/>.
+        /// </typeparam>
+        /// <param name="enumerator">
+        ///   The enumerator whose bit pattern to reinterpret.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="long"/> whose bit pattern is the same as the bit pattern of <paramref name="enumerator"/>,
+        ///   possibly with some extra leading <c>0</c>s.
+        /// </returns>
+        private static long AsInt64<TEnum>(this TEnum enumerator) where TEnum : Enum {
+            // Signed and unsigned bytes, shorts, and ints can be converted to a signed long without risk for data
+            // loss: the range of unsigned long covers all possible values. This is not the case for signed long,
+            // however, due to the potential for overflow. We have to box the enumerator into a ValueType first because
+            // we can't cast the generic TEnum instance directly to a numeric type.
+            var bytes = enumerator.GetTypeCode() == TypeCode.UInt64 ?
+                        BitConverter.GetBytes((ulong)Convert.ChangeType(enumerator, typeof(ulong))) :
+                        BitConverter.GetBytes((long)Convert.ChangeType(enumerator, typeof(long)));
+
+            return BitConverter.ToInt64(bytes);
+        }
+
+
+        private static readonly Dictionary<Type, bool> isFlagsMemoizer_ = new Dictionary<Type, bool>();
+        private static readonly Dictionary<Type, long> bitsMemoizer_ = new Dictionary<Type, long>();
+    }
+}

--- a/Test/Cybele/Extensions/Enum.cs
+++ b/Test/Cybele/Extensions/Enum.cs
@@ -1,0 +1,250 @@
+﻿using Cybele.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace Test.Cybele.Extensions {
+    [TestClass]
+    public class EnumExtensionTests {
+        [TestMethod, TestCategory("IsValid")]
+        public void ZeroEnumerator() {
+            var color0 = Color.Black;
+            var day0 = (Day)0;
+            var month0 = (Month)0;
+            var diacritic0 = Diacritic.None;
+            var military0 = Military.Civilian;
+            var position0 = (BaseballPosition)0;
+            var latino0 = (Latino)0;
+            var resource0 = BonusResource.None;
+
+            Assert.AreEqual(color0, (Color)0);
+            Assert.AreEqual(diacritic0, (Diacritic)0);
+            Assert.AreEqual(military0, (Military)0);
+            Assert.AreEqual(resource0, (BonusResource)0);
+
+            Assert.IsTrue(color0.IsValid());
+            Assert.IsFalse(day0.IsValid());
+            Assert.IsFalse(month0.IsValid());
+            Assert.IsTrue(diacritic0.IsValid());
+            Assert.IsTrue(military0.IsValid());
+            Assert.IsFalse(position0.IsValid());
+            Assert.IsFalse(latino0.IsValid());
+            Assert.IsTrue(resource0.IsValid());
+        }
+
+        [TestMethod, TestCategory("IsValid")]
+        public void ValidNonFlagEnumerator() {
+            static void TestEach<TEnum>() where TEnum : Enum {
+                foreach (var e in typeof(TEnum).GetEnumValues()) {
+                    var enumerator = (TEnum)e!;
+                    Assert.IsTrue(enumerator.IsValid());
+                }
+            }
+
+            TestEach<Day>();
+            TestEach<Month>();
+            TestEach<Military>();
+            TestEach<BonusResource>();
+        }
+
+        [TestMethod, TestCategory("IsValid")]
+        public void ValidFlagEnumerator() {
+            static void TestEach<TEnum>() where TEnum : Enum {
+                foreach (var e in typeof(TEnum).GetEnumValues().Cast<TEnum>()) {
+                    Assert.IsTrue(e.IsValid());
+                }
+            }
+
+            TestEach<Color>();
+            TestEach<Diacritic>();
+            TestEach<BaseballPosition>();
+            TestEach<Latino>();
+        }
+
+        [TestMethod, TestCategory("IsValid")]
+        public void ValidFlagCombination() {
+            static void TestCombinations<TEnum>() where TEnum : Enum {
+                var flags = typeof(TEnum).GetEnumValues().Cast<TEnum>().ToArray();
+                for (int i = 0; i < 10; ++i) {
+                    dynamic value = default(TEnum)!;
+                    for (int j = 0; j < rand.Next(2, flags.Length + 1); ++j) {
+                        value |= flags[rand.Next(0, flags.Length)];
+                    }
+
+                    var testValue = (TEnum)value;
+                    Assert.IsTrue(testValue.IsValid());
+                }
+            }
+
+            TestCombinations<Color>();
+            TestCombinations<Diacritic>();
+            TestCombinations<BaseballPosition>();
+            TestCombinations<Latino>();
+        }
+
+        [TestMethod, TestCategory("IsValid")]
+        public void InvalidNonFlagEnumerator() {
+            var invalidDay0 = (Day)11;
+            var invalidDay1 = (Day)(-6);
+            var invalidMonth0 = (Month)short.MaxValue;
+            var invalidMonth1 = (Month)2710;
+            var invalidMilitary0 = (Military)(-874);
+            var invalidMilitary1 = (Military)188281;
+            var invalidBonusResource0 = (BonusResource)566;
+            var invalidBonusResource1 = (BonusResource)ulong.MaxValue;
+
+            Assert.IsFalse(invalidDay0.IsValid());
+            Assert.IsFalse(invalidDay1.IsValid());
+            Assert.IsFalse(invalidMonth0.IsValid());
+            Assert.IsFalse(invalidMonth1.IsValid());
+            Assert.IsFalse(invalidMilitary0.IsValid());
+            Assert.IsFalse(invalidMilitary1.IsValid());
+            Assert.IsFalse(invalidBonusResource0.IsValid());
+            Assert.IsFalse(invalidBonusResource1.IsValid());
+        }
+
+        [TestMethod, TestCategory("IsValid")]
+        public void InvalidFlagEnumerator() {
+            var invalidColor0 = (Color)(1 << 4);
+            var invalidColor1 = (Color)(1 << 7);
+            var invalidBaseballPosition0 = (BaseballPosition)(1u << 15);
+            var invalidBaseballPosition1 = (BaseballPosition)(1u << 29);
+            var invalidLatino0 = (Latino)(1L << 12);
+            var invalidLatino1 = (Latino)(1L << 57);
+
+            Assert.IsFalse(invalidColor0.IsValid());
+            Assert.IsFalse(invalidColor1.IsValid());
+            Assert.IsFalse(invalidBaseballPosition0.IsValid());
+            Assert.IsFalse(invalidBaseballPosition1.IsValid());
+            Assert.IsFalse(invalidLatino0.IsValid());
+            Assert.IsFalse(invalidLatino1.IsValid());
+        }
+
+        [TestMethod, TestCategory("IsValid")]
+        public void InvalidFlagCombination() {
+            var invalidColor = (Color)(byte.MaxValue);
+            var invalidBaseballPosition = (BaseballPosition)(1u << 15 | 1u << 7 | 1u << 22 | 1u << 1 | 1u << 30);
+            var invalidLatino = (Latino)(1L << 16 | 1L << 24 | 1L << 0);
+
+            Assert.IsFalse(invalidColor.IsValid());
+            Assert.IsFalse(invalidBaseballPosition.IsValid());
+            Assert.IsFalse(invalidLatino.IsValid());
+        }
+
+
+        [Flags] private enum Color : byte {
+            Black = 0,
+            Red = 1 << 1,
+            Yellow = 1 << 2,
+            Blue = 1 << 3,
+            White = Red | Yellow | Blue
+        }
+        private enum Day : sbyte {
+            Monday = 1,
+            Tuesday = 2,
+            Wednesday = 3,
+            Thursday = 4,
+            Friday = 5,
+            Saturday = 6,
+            Sunday = 7
+        }
+        private enum Month : ushort {
+            January = 4,
+            February = 21,
+            March = 199,
+            April = 357,
+            May = 1001,
+            June = 1002,
+            July = 2322,
+            August = 3496,
+            September = 4898,
+            October = 5187,
+            November = 5995,
+            December = 6374
+        }
+        [Flags] private enum Diacritic : short {
+            None = 0,
+            AcuteAccent = 1 << 0,
+            GraveAccent = 1 << 1,
+            Diaeresis = 1 << 2,
+            Circumflex = 1 << 3,
+            Cedilla = 1 << 4,
+            Macron = 1 << 5,
+            Overring = 1 << 6,
+            Underdot = 1 << 7,
+            Caron = 1 << 8,
+            Tilde = 1 << 9,
+            Breve = 1 << 10,
+            Ogonek = 1 << 11,
+            HookAbove = 1 << 12,
+            Throughbar = 1 << 13,
+            RoughBreathing = 1 << 14,
+            SmoothBreathing = -32768
+        }
+        private enum Military : int {
+            Civilian = 0,
+            Army = 1,
+            Navy = 25712,
+            Marines = -663,
+            AirForce = int.MaxValue,
+            CoastGuard = int.MinValue,
+            SpaceForce = 4000001,
+            ROTC = -2177096
+        }
+        [Flags] public enum BaseballPosition : uint {
+            StartingPitcher = 1u << 31,
+            ReliefPitcher = 1u << 18,
+            Closer = 1u << 4,
+            Catcher = 1u << 27,
+            FirstBaseman = 1u << 11,
+            SecondBaseman = 1u << 19,
+            ThirdBaseman = 1u << 9,
+            Shortstop = 1u << 0,
+            LeftFielder = 1u << 30,
+            CenterFielder = 1u << 22,
+            RightFielder = 1u << 16,
+            DesignatedHitter = 1u << 8
+        }
+        [Flags] public enum Latino : long {
+            Mexican = 1L << 1,
+            Dominican = 1L << 3,
+            Panamanian = 1L << 5,
+            Salvadoran = 1L << 7,
+            Nicaraguan = 1L << 9,
+            Argentine = 1L << 11,
+            Cuban = 1L << 13,
+            PuertoRican = 1L << 15,
+            Guatemalan = 1L << 17,
+            CostaRican = 1L << 19,
+            Chilean = 1L << 21,
+            Colombian = 1L << 23,
+            Venezuelan = 1L << 25,
+            Bolivian = 1L << 27,
+            Peruvian = 1L << 29,
+            Ecuadoran = 1L << 31,
+            Honduran = 1L << 33,
+            Paraguayan = 1L << 35,
+            Uruguayan = 1L << 37,
+            Nahua = 1L << 39,
+            Mayan = 1L << 41,
+            Chicano = 1L << 43
+        }
+        public enum BonusResource : ulong {
+            None = 0,
+            Bananas,
+            Cattle,
+            Copper,
+            Crabs,
+            Deer,
+            Fish,
+            Maize,
+            Rice,
+            Sheep,
+            Stone,
+            Wheat
+        }
+
+
+        private static readonly Random rand = new Random(02291996);
+    }
+}


### PR DESCRIPTION
Adds an extension method on types constraint to Enum that checks it an enumerator is valid. This is inteded to be used
as a defensive check to guard against arbitrary numeric casts being passed to APIs that expect defined constants. The
utility is currently employed in BasicField and EnumField for the Nullability input enum on construction.