### PR TITLE
Primary and Candidate Keys

### DIFF
--- a/Kvasir/Intellisense.xml
+++ b/Kvasir/Intellisense.xml
@@ -71,6 +71,49 @@
         <member name="M:Kvasir.Schema.BasicField.Kvasir#Schema#IField#GenerateDeclaration(Kvasir.Transcription.Internal.IBuilderCollection)">
             <inheritdoc/>
         </member>
+        <member name="T:Kvasir.Schema.CandidateKey">
+            <summary>
+              An <see cref="T:Kvasir.Schema.IKey"/> representing a <c>UNIQUE</c> constraint on a Table in a back-end relational database.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Schema.CandidateKey.Name">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Schema.CandidateKey.#ctor">
+            <summary>
+              Constructs a new nameless <see cref="T:Kvasir.Schema.CandidateKey"/>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Schema.CandidateKey.#ctor(Kvasir.Schema.KeyName)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Schema.CandidateKey"/> with a name.
+            </summary>
+            <param name="name">
+              The <see cref="P:Kvasir.Schema.CandidateKey.Name"/> of the new <see cref="T:Kvasir.Schema.CandidateKey"/>.
+            </param>
+        </member>
+        <member name="M:Kvasir.Schema.CandidateKey.AddField(Kvasir.Schema.IField)">
+            <summary>
+              Adds a new <see cref="T:Kvasir.Schema.IField"/> to this <see cref="T:Kvasir.Schema.CandidateKey"/>.
+            </summary>
+            <param name="field">
+              The new <see cref="T:Kvasir.Schema.IField"/>.
+            </param>
+            <remarks>
+              If <paramref name="field"/> has the same name (using as case-insensitive comparison) as any
+              <see cref="T:Kvasir.Schema.IField"/> that is already part of this <see cref="T:Kvasir.Schema.CandidateKey"/>, no action is performed.
+            </remarks>
+        </member>
+        <member name="M:Kvasir.Schema.CandidateKey.GetEnumerator">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Schema.CandidateKey.Kvasir#Schema#IKey#GenerateDeclaration(Kvasir.Transcription.Internal.IBuilderCollection)">
+            <inheritdoc/>
+            <pre>
+              At least one <see cref="T:Kvasir.Schema.IField"/> has been <see cref="M:Kvasir.Schema.CandidateKey.AddField(Kvasir.Schema.IField)">added</see> to this
+              <see cref="T:Kvasir.Schema.CandidateKey"/>.
+            </pre>
+        </member>
         <member name="T:Kvasir.Schema.Constraints.AndClause">
             <summary>
               A compound <see cref="T:Kvasir.Schema.Constraints.Clause"/> that represents the logical conjunction between two constituent
@@ -1313,6 +1356,107 @@
         <member name="F:Kvasir.Schema.IsNullable.Yes">
             <summary>Indicates that an <see cref="T:Kvasir.Schema.IField"/> is nullable</summary>
         </member>
+        <member name="T:Kvasir.Schema.IKey">
+            <summary>
+              The interface representing a single Key in a back-end relational database.
+            </summary>
+            <remarks>
+              This interface can only be implemented by classes within the <see cref="N:Kvasir"/> assembly.
+            </remarks>
+        </member>
+        <member name="P:Kvasir.Schema.IKey.Name">
+            <value>
+              The name of this <see cref="T:Kvasir.Schema.IKey"/>.
+            </value>
+        </member>
+        <member name="M:Kvasir.Schema.IKey.GetEnumerator">
+            <summary>
+              Produces an enumerator that iterates over the set of <see cref="T:Kvasir.Schema.IField">Fields</see> that comprise this
+              <see cref="T:Kvasir.Schema.IKey"/>. The order of iteration is not defined but is guaranteed to be the same for repeated
+              iterations.
+            </summary>
+            <returns>
+              An enumerator that iterates over the set of <see cref="T:Kvasir.Schema.IField">Fields</see> that comprise this
+              <see cref="T:Kvasir.Schema.IKey"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Schema.IKey.GenerateDeclaration(Kvasir.Transcription.Internal.IBuilderCollection)">
+            <summary>
+              Generates a <see cref="T:Kvasir.Transcription.Internal.SqlSnippet"/> that declares this <see cref="T:Kvasir.Schema.IKey"/> as part of a <c>CREATE
+              TABLE</c> statement.
+            </summary>
+            <param name="syntax">
+              The <see cref="T:Kvasir.Transcription.Internal.IBuilderCollection"/> exposing the <see cref="T:Kvasir.Transcription.Internal.IDeclBuilder">IDeclBuilders</see> that this
+              <see cref="T:Kvasir.Schema.IKey"/> should use to generate its declaratory <see cref="T:Kvasir.Transcription.Internal.SqlSnippet"/>.
+            </param>
+            <returns>
+              A <see cref="T:Kvasir.Transcription.Internal.SqlSnippet"/> that declares this <see cref="T:Kvasir.Schema.IKey"/> within a <c>CREATE TABLE</c>
+              statement according to the syntax rules of <paramref name="syntax"/>.
+            </returns>
+        </member>
+        <member name="T:Kvasir.Schema.KeyName">
+            <summary>
+              The name of an <see cref="T:Kvasir.Schema.IKey"/>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Schema.KeyName.#ctor(System.String)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Schema.KeyName"/>.
+            </summary>
+            <param name="name">
+              The name. Any leading and trailing whitespace is trimmed.
+            </param>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="name"/> is the empty string or consists only of whitespace characters.
+            </exception>
+        </member>
+        <member name="T:Kvasir.Schema.PrimaryKey">
+            <summary>
+              An <see cref="T:Kvasir.Schema.IKey"/> representing a <c>PRIMARY KEY</c> constraint on a Table in a back-end relational
+              database.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Schema.PrimaryKey.Name">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Schema.PrimaryKey.#ctor">
+            <summary>
+              Constructs a new nameless <see cref="T:Kvasir.Schema.CandidateKey"/>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Schema.PrimaryKey.#ctor(Kvasir.Schema.KeyName)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Schema.CandidateKey"/> with a name.
+            </summary>
+            <param name="name">
+              The <see cref="P:Kvasir.Schema.PrimaryKey.Name"/> of the new <see cref="T:Kvasir.Schema.CandidateKey"/>.
+            </param>
+        </member>
+        <member name="M:Kvasir.Schema.PrimaryKey.AddField(Kvasir.Schema.IField)">
+            <summary>
+              Adds a new <see cref="T:Kvasir.Schema.IField"/> to this <see cref="T:Kvasir.Schema.CandidateKey"/>.
+            </summary>
+            <param name="field">
+              The new <see cref="T:Kvasir.Schema.IField"/>.
+            </param>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="field"/> is <see cref="P:Kvasir.Schema.IField.Nullability">nullable</see>.
+            </exception>
+            <remarks>
+              If <paramref name="field"/> has the same name (using as case-insensitive comparison) as any
+              <see cref="T:Kvasir.Schema.IField"/> that is already part of this <see cref="T:Kvasir.Schema.CandidateKey"/>, no action is performed.
+            </remarks>
+        </member>
+        <member name="M:Kvasir.Schema.PrimaryKey.GetEnumerator">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Schema.PrimaryKey.Kvasir#Schema#IKey#GenerateDeclaration(Kvasir.Transcription.Internal.IBuilderCollection)">
+            <inheritdoc/>
+            <pre>
+              At least one <see cref="T:Kvasir.Schema.IField"/> has been <see cref="M:Kvasir.Schema.PrimaryKey.AddField(Kvasir.Schema.IField)">added</see> to this
+              <see cref="T:Kvasir.Schema.PrimaryKey"/>.
+            </pre>
+        </member>
         <member name="T:Kvasir.Transcription.Internal.IBuilderCollection">
             <summary>
               A collection of <see cref="T:Kvasir.Transcription.Internal.IDeclBuilder">IDeclBuilders</see> for generating the declaratory
@@ -1336,6 +1480,16 @@
             </summary>
             <returns>
               An <see cref="T:Kvasir.Transcription.Internal.IConstraintDeclBuilder"/> in its initial (or "reset") state that uses the rules of this
+              <see cref="T:Kvasir.Transcription.Internal.IBuilderCollection"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Transcription.Internal.IBuilderCollection.KeyDeclBuilder">
+            <summary>
+              Exposes an <see cref="T:Kvasir.Transcription.Internal.IKeyDeclBuilder"/> using the syntax of this <see cref="T:Kvasir.Transcription.Internal.IBuilderCollection"/> that
+              is in its initial (or "reset") state.
+            </summary>
+            <returns>
+              An <see cref="T:Kvasir.Transcription.Internal.IKeyDeclBuilder"/> in its initial (or "reset") state that uses the rules of this
               <see cref="T:Kvasir.Transcription.Internal.IBuilderCollection"/>.
             </returns>
         </member>
@@ -1471,6 +1625,36 @@
             <param name="enumerators">
               The list of alloed values.
             </param>
+        </member>
+        <member name="T:Kvasir.Transcription.Internal.IKeyDeclBuilder">
+            <summary>
+              An <see cref="T:Kvasir.Transcription.Internal.IDeclBuilder"/> that builds declaratory <see cref="T:Kvasir.Transcription.Internal.SqlSnippet">SqlSnippets</see> for internal
+              (as opposed to foreign) Keys.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Transcription.Internal.IKeyDeclBuilder.SetName(Kvasir.Schema.KeyName)">
+            <summary>
+              Sets the name of the Key whose declaration is represented by the current state of this
+              <see cref="T:Kvasir.Transcription.Internal.IKeyDeclBuilder"/>.
+            </summary>
+            <param name="name">
+              The name.
+            </param>
+        </member>
+        <member name="M:Kvasir.Transcription.Internal.IKeyDeclBuilder.AddField(Kvasir.Schema.FieldName)">
+            <summary>
+              Adds an <see cref="T:Kvasir.Schema.IField"/> by name to the collection of Fields that make up the Key whose declaration
+              is represented by the current state of this <see cref="T:Kvasir.Transcription.Internal.IKeyDeclBuilder"/>.
+            </summary>
+            <param name="fieldName">
+              The name of the Field.
+            </param>
+        </member>
+        <member name="M:Kvasir.Transcription.Internal.IKeyDeclBuilder.SetAsPrimary">
+            <summary>
+              Sets the Key whose declaration is represented by the current state of this <see cref="T:Kvasir.Transcription.Internal.IKeyDeclBuilder"/>
+              as a <c>PRIMARY KEY</c>.
+            </summary>
         </member>
         <member name="T:Kvasir.Transcription.Internal.SqlSnippet">
             <summary>

--- a/Kvasir/Schema/CandidateKey.cs
+++ b/Kvasir/Schema/CandidateKey.cs
@@ -1,0 +1,79 @@
+﻿using Kvasir.Transcription.Internal;
+using Optional;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kvasir.Schema {
+    /// <summary>
+    ///   An <see cref="IKey"/> representing a <c>UNIQUE</c> constraint on a Table in a back-end relational database.
+    /// </summary>
+    public sealed class CandidateKey : IKey {
+        /// <inheritdoc/>
+        public Option<KeyName> Name { get; }
+
+        /// <summary>
+        ///   Constructs a new nameless <see cref="CandidateKey"/>.
+        /// </summary>
+        public CandidateKey() {
+            Name = Option.None<KeyName>();
+            members_ = new List<IField>();
+        }
+
+        /// <summary>
+        ///   Constructs a new <see cref="CandidateKey"/> with a name.
+        /// </summary>
+        /// <param name="name">
+        ///   The <see cref="Name"/> of the new <see cref="CandidateKey"/>.
+        /// </param>
+        public CandidateKey(KeyName name) {
+            Name = Option.Some<KeyName>(name);
+            members_ = new List<IField>();
+        }
+
+        /// <summary>
+        ///   Adds a new <see cref="IField"/> to this <see cref="CandidateKey"/>.
+        /// </summary>
+        /// <param name="field">
+        ///   The new <see cref="IField"/>.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="field"/> has the same name (using as case-insensitive comparison) as any
+        ///   <see cref="IField"/> that is already part of this <see cref="CandidateKey"/>, no action is performed.
+        /// </remarks>
+        public void AddField(IField field) {
+            if (!members_.Any(f => f.Name == field.Name)) {
+                members_.Add(field);
+            }
+        }
+
+        /// <inheritdoc/>
+        public IEnumerator<IField> GetEnumerator() {
+            return members_.GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        /// <pre>
+        ///   At least one <see cref="IField"/> has been <see cref="AddField(IField)">added</see> to this
+        ///   <see cref="CandidateKey"/>.
+        /// </pre>
+        SqlSnippet IKey.GenerateDeclaration(IBuilderCollection syntax) {
+            var builder = syntax.KeyDeclBuilder();
+            Name.MatchSome(n => builder.SetName(n));
+            foreach (var field in this) {
+                builder.AddField(field.Name);
+            }
+
+            return builder.Build();
+        }
+
+
+        // I considered making this some kind of ISet as an optimization for the duplication checking, but this was
+        // difficult due to the need to have a sort order (order of insertion) independent of the duplicate checking
+        // predicate (Field name). The idea as to use an ISet<(int, IField)> with a comparer that returned 0 for pairs
+        // with same-named second items and the comparison value of the first item otherwise, but any kind of binary
+        // search using such a comparer could be made to fail. I don't anticipate Keys being that large, so using a
+        // simple IList with a linear search on insert should be fine.
+        private readonly List<IField> members_;
+    }
+}

--- a/Kvasir/Schema/IKey.cs
+++ b/Kvasir/Schema/IKey.cs
@@ -1,0 +1,68 @@
+﻿using Cybele;
+using Kvasir.Transcription.Internal;
+using Optional;
+using System;
+using System.Collections.Generic;
+
+namespace Kvasir.Schema {
+    /// <summary>
+    ///   The interface representing a single Key in a back-end relational database.
+    /// </summary>
+    /// <remarks>
+    ///   This interface can only be implemented by classes within the <see cref="Kvasir"/> assembly.
+    /// </remarks>
+    public interface IKey {
+        /// <value>
+        ///   The name of this <see cref="IKey"/>.
+        /// </value>
+        Option<KeyName> Name { get; }
+
+        /// <summary>
+        ///   Produces an enumerator that iterates over the set of <see cref="IField">Fields</see> that comprise this
+        ///   <see cref="IKey"/>. The order of iteration is not defined but is guaranteed to be the same for repeated
+        ///   iterations.
+        /// </summary>
+        /// <returns>
+        ///   An enumerator that iterates over the set of <see cref="IField">Fields</see> that comprise this
+        ///   <see cref="IKey"/>.
+        /// </returns>
+        IEnumerator<IField> GetEnumerator();
+
+        /// <summary>
+        ///   Generates a <see cref="SqlSnippet"/> that declares this <see cref="IKey"/> as part of a <c>CREATE
+        ///   TABLE</c> statement.
+        /// </summary>
+        /// <param name="syntax">
+        ///   The <see cref="IBuilderCollection"/> exposing the <see cref="IDeclBuilder">IDeclBuilders</see> that this
+        ///   <see cref="IKey"/> should use to generate its declaratory <see cref="SqlSnippet"/>.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="SqlSnippet"/> that declares this <see cref="IKey"/> within a <c>CREATE TABLE</c>
+        ///   statement according to the syntax rules of <paramref name="syntax"/>.
+        /// </returns>
+        internal SqlSnippet GenerateDeclaration(IBuilderCollection syntax);
+    }
+
+    /// <summary>
+    ///   The name of an <see cref="IKey"/>.
+    /// </summary>
+    public sealed class KeyName : ConceptString<KeyName> {
+        /// <summary>
+        ///   Constructs a new <see cref="KeyName"/>.
+        /// </summary>
+        /// <param name="name">
+        ///   The name. Any leading and trailing whitespace is trimmed.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   if <paramref name="name"/> is the empty string or consists only of whitespace characters.
+        /// </exception>
+        public KeyName(string name)
+            : base(name.Trim()) {
+
+            if (string.IsNullOrWhiteSpace(Contents)) {
+                var msg = "The name of a Field must have non-zero length when leading/trailing whitespace is ignored";
+                throw new ArgumentException(msg);
+            }
+        }
+    }
+}

--- a/Kvasir/Schema/PrimaryKey.cs
+++ b/Kvasir/Schema/PrimaryKey.cs
@@ -1,0 +1,85 @@
+﻿using Kvasir.Transcription.Internal;
+using Optional;
+using System;
+using System.Collections.Generic;
+
+namespace Kvasir.Schema {
+    /// <summary>
+    ///   An <see cref="IKey"/> representing a <c>PRIMARY KEY</c> constraint on a Table in a back-end relational
+    ///   database.
+    /// </summary>
+    public sealed class PrimaryKey : IKey {
+        /// <inheritdoc/>
+        public Option<KeyName> Name => impl_.Name;
+
+        /// <summary>
+        ///   Constructs a new nameless <see cref="CandidateKey"/>.
+        /// </summary>
+        public PrimaryKey() {
+            impl_ = new CandidateKey();
+        }
+
+        /// <summary>
+        ///   Constructs a new <see cref="CandidateKey"/> with a name.
+        /// </summary>
+        /// <param name="name">
+        ///   The <see cref="Name"/> of the new <see cref="CandidateKey"/>.
+        /// </param>
+        public PrimaryKey(KeyName name) {
+            impl_ = new CandidateKey(name);
+        }
+
+        /// <summary>
+        ///   Adds a new <see cref="IField"/> to this <see cref="CandidateKey"/>.
+        /// </summary>
+        /// <param name="field">
+        ///   The new <see cref="IField"/>.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   if <paramref name="field"/> is <see cref="IField.Nullability">nullable</see>.
+        /// </exception>
+        /// <remarks>
+        ///   If <paramref name="field"/> has the same name (using as case-insensitive comparison) as any
+        ///   <see cref="IField"/> that is already part of this <see cref="CandidateKey"/>, no action is performed.
+        /// </remarks>
+        public void AddField(IField field) {
+            if (field.Nullability == IsNullable.Yes) {
+                var msg = $"Field '{field.Name}' cannot be used in a Primary Key because it is nullable";
+                throw new ArgumentException(msg);
+            }
+
+            impl_.AddField(field);
+        }
+
+        /// <inheritdoc/>
+        public IEnumerator<IField> GetEnumerator() {
+            return impl_.GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        /// <pre>
+        ///   At least one <see cref="IField"/> has been <see cref="AddField(IField)">added</see> to this
+        ///   <see cref="PrimaryKey"/>.
+        /// </pre>
+        SqlSnippet IKey.GenerateDeclaration(IBuilderCollection syntax) {
+            // This code is copy-pasted from the similar function on CandidateKey, which sucks (DRY) but I'm not sure
+            // the best way to eliminate the duplication without significantly complicating the class desig. One option
+            // is to add an additional member function to CandidateKey in the vein of Clauses' "AddDeclarationTo", but
+            // that would only be needed as an implementation detail and therefore feels wrong. Another option is to
+            // inherit Primary Key from Candidate Key; that would probably work, but I'm trying to avoid inheriting
+            // non-abstract classes.
+
+            var builder = syntax.KeyDeclBuilder();
+            builder.SetAsPrimary();
+            Name.MatchSome(n => builder.SetName(n));
+            foreach (var field in this) {
+                builder.AddField(field.Name);
+            }
+
+            return builder.Build();
+        }
+
+
+        private readonly CandidateKey impl_;
+    }
+}

--- a/Kvasir/Transcription/IBuilderCollection.cs
+++ b/Kvasir/Transcription/IBuilderCollection.cs
@@ -23,5 +23,15 @@
         ///   <see cref="IBuilderCollection"/>.
         /// </returns>
         IConstraintDeclBuilder ConstraintDeclBuilder();
+
+        /// <summary>
+        ///   Exposes an <see cref="IKeyDeclBuilder"/> using the syntax of this <see cref="IBuilderCollection"/> that
+        ///   is in its initial (or "reset") state.
+        /// </summary>
+        /// <returns>
+        ///   An <see cref="IKeyDeclBuilder"/> in its initial (or "reset") state that uses the rules of this
+        ///   <see cref="IBuilderCollection"/>.
+        /// </returns>
+        IKeyDeclBuilder KeyDeclBuilder();
     }
 }

--- a/Kvasir/Transcription/IKeyDeclBuilder.cs
+++ b/Kvasir/Transcription/IKeyDeclBuilder.cs
@@ -1,0 +1,33 @@
+﻿using Kvasir.Schema;
+
+namespace Kvasir.Transcription.Internal {
+    /// <summary>
+    ///   An <see cref="IDeclBuilder"/> that builds declaratory <see cref="SqlSnippet">SqlSnippets</see> for internal
+    ///   (as opposed to foreign) Keys.
+    /// </summary>
+    internal interface IKeyDeclBuilder : IDeclBuilder {
+        /// <summary>
+        ///   Sets the name of the Key whose declaration is represented by the current state of this
+        ///   <see cref="IKeyDeclBuilder"/>.
+        /// </summary>
+        /// <param name="name">
+        ///   The name.
+        /// </param>
+        void SetName(KeyName name);
+
+        /// <summary>
+        ///   Adds an <see cref="IField"/> by name to the collection of Fields that make up the Key whose declaration
+        ///   is represented by the current state of this <see cref="IKeyDeclBuilder"/>.
+        /// </summary>
+        /// <param name="fieldName">
+        ///   The name of the Field.
+        /// </param>
+        void AddField(FieldName fieldName);
+
+        /// <summary>
+        ///   Sets the Key whose declaration is represented by the current state of this <see cref="IKeyDeclBuilder"/>
+        ///   as a <c>PRIMARY KEY</c>.
+        /// </summary>
+        void SetAsPrimary();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿[![Ubuntu Build (travis-ci.com)](https://img.shields.io/travis/com/justin-millman/Kvasir?label=Ubuntu%20Build&logo=ubuntu)](https://travis-ci.com/justin-millman/Kvasir)
 [![Windows Build (appveyor.com)](https://img.shields.io/appveyor/build/justin-millman/Kvasir/master?label=Windows%20Build&logo=windows)](https://ci.appveyor.com/project/justin-millman/kvasir)
-[![Code Coverage (coveralls.com)](https://img.shields.io/coveralls/github/justin-millman/Kvasir/master)](https://coveralls.io/github/justin-millman/KVasir)
+[![Code Coverage (coveralls.com)](https://img.shields.io/coveralls/github/justin-millman/Kvasir/master)](https://coveralls.io/github/justin-millman/Kvasir)
 [![License](https://img.shields.io/github/license/justin-millman/Kvasir)](https://github.com/justin-millman/Kvasir/blob/master/LICENSE.txt)
 [![Languages](https://img.shields.io/github/languages/count/justin-millman/Kvasir?color=blueviolet)](https://github.com/justin-millman/Kvasir)
 [![Code Size](https://img.shields.io/github/languages/code-size/justin-millman/Kvasir)](https://github.com/justin-millman/Kvasir)

--- a/Test/Kvasir/Schema/Keys.cs
+++ b/Test/Kvasir/Schema/Keys.cs
@@ -1,0 +1,159 @@
+﻿using Kvasir.Schema;
+using Kvasir.Transcription.Internal;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Test.Mocks;
+
+namespace Test.Kvasir.Schema {
+    [TestClass]
+    public class KeyTests {
+        [TestMethod, TestCategory("CandidateKey")]
+        public void CandidateKeyNoName() {
+            var mock = new Mock<IField>();
+            mock.Setup(f => f.Name).Returns(new FieldName("StudentID"));
+
+            var key = new CandidateKey();
+            key.AddField(mock.Object);
+            Assert.IsFalse(key.Name.HasValue);
+
+            var expected = new SqlSnippet("CONSTRAINT /unnamed/ UNIQUE (StudentID)");
+            var actual = (key as IKey).GenerateDeclaration(new MockBuilders());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod, TestCategory("CandidateKey")]
+        public void CandidateKeyWithName() {
+            var mock = new Mock<IField>();
+            mock.Setup(f => f.Name).Returns(new FieldName("SSN"));
+
+            var name = new KeyName("KEY_SSN");
+            var key = new CandidateKey(name);
+            key.AddField(mock.Object);
+
+            Assert.IsTrue(key.Name.Contains(name));
+            var expected = new SqlSnippet("CONSTRAINT KEY_SSN UNIQUE (SSN)");
+            var actual = (key as IKey).GenerateDeclaration(new MockBuilders());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod, TestCategory("CandidateKey")]
+        public void CandidateKeyAddDuplicateField() {
+            var mockA = new Mock<IField>();
+            mockA.Setup(f => f.Name).Returns(new FieldName("Channel"));
+            var mockB = new Mock<IField>();
+            mockB.Setup(f => f.Name).Returns(new FieldName("IsNews"));
+
+            var key = new CandidateKey();
+            key.AddField(mockA.Object);
+            key.AddField(mockB.Object);
+            key.AddField(mockB.Object);
+            key.AddField(mockA.Object);
+            key.AddField(mockB.Object);
+
+            var expected = new SqlSnippet("CONSTRAINT /unnamed/ UNIQUE (Channel, IsNews)");
+            var actual = (key as IKey).GenerateDeclaration(new MockBuilders());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod, TestCategory("CandidateKey")]
+        public void CandidateKeyAddRepeatNameDifferentField() {
+            var mockA = new Mock<IField>();
+            mockA.Setup(f => f.Name).Returns(new FieldName("ISBN"));
+            var mockB = new Mock<IField>();
+            mockB.Setup(f => f.Name).Returns(mockA.Object.Name);
+
+            var key = new CandidateKey();
+            key.AddField(mockA.Object);
+            key.AddField(mockB.Object);
+
+            var expected = new SqlSnippet("CONSTRAINT /unnamed/ UNIQUE (ISBN)");
+            var actual = (key as IKey).GenerateDeclaration(new MockBuilders());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod, TestCategory("PrimaryKey")]
+        public void PrimaryKeyNoName() {
+            var mock = new Mock<IField>();
+            mock.Setup(f => f.Name).Returns(new FieldName("StudentID"));
+            mock.Setup(f => f.Nullability).Returns(IsNullable.No);
+
+            var key = new PrimaryKey();
+            key.AddField(mock.Object);
+            Assert.IsFalse(key.Name.HasValue);
+
+            var expected = new SqlSnippet("CONSTRAINT /unnamed/ PRIMARY-KEY (StudentID)");
+            var actual = (key as IKey).GenerateDeclaration(new MockBuilders());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod, TestCategory("PrimaryKey")]
+        public void PrimaryKeyWithName() {
+            var mock = new Mock<IField>();
+            mock.Setup(f => f.Name).Returns(new FieldName("SSN"));
+            mock.Setup(f => f.Nullability).Returns(IsNullable.No);
+
+            var name = new KeyName("PKEY_SSN");
+            var key = new PrimaryKey(name);
+            key.AddField(mock.Object);
+
+            Assert.IsTrue(key.Name.Contains(name));
+            var expected = new SqlSnippet("CONSTRAINT PKEY_SSN PRIMARY-KEY (SSN)");
+            var actual = (key as IKey).GenerateDeclaration(new MockBuilders());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod, TestCategory("PrimaryKey")]
+        public void PrimaryKeyAddDuplicateField() {
+            var mockA = new Mock<IField>();
+            mockA.Setup(f => f.Name).Returns(new FieldName("Channel"));
+            mockA.Setup(f => f.Nullability).Returns(IsNullable.No);
+            var mockB = new Mock<IField>();
+            mockB.Setup(f => f.Name).Returns(new FieldName("IsNews"));
+            mockB.Setup(f => f.Nullability).Returns(IsNullable.No);
+
+            var key = new PrimaryKey();
+            key.AddField(mockA.Object);
+            key.AddField(mockB.Object);
+            key.AddField(mockB.Object);
+            key.AddField(mockA.Object);
+            key.AddField(mockB.Object);
+
+            var expected = new SqlSnippet("CONSTRAINT /unnamed/ PRIMARY-KEY (Channel, IsNews)");
+            var actual = (key as IKey).GenerateDeclaration(new MockBuilders());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod, TestCategory("PrimaryKey")]
+        public void PrimaryKeyAddRepeatNameDifferentField() {
+            var mockA = new Mock<IField>();
+            mockA.Setup(f => f.Name).Returns(new FieldName("ISBN"));
+            mockA.Setup(f => f.Nullability).Returns(IsNullable.No);
+            var mockB = new Mock<IField>();
+            mockB.Setup(f => f.Name).Returns(mockA.Object.Name);
+            mockB.Setup(f => f.Nullability).Returns(IsNullable.No);
+
+            var key = new PrimaryKey();
+            key.AddField(mockA.Object);
+            key.AddField(mockB.Object);
+
+            var expected = new SqlSnippet("CONSTRAINT /unnamed/ PRIMARY-KEY (ISBN)");
+            var actual = (key as IKey).GenerateDeclaration(new MockBuilders());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod, TestCategory("PrimaryKey")]
+        public void PrimaryKeyNullableField() {
+            var mock = new Mock<IField>();
+            mock.Setup(f => f.Name).Returns(new FieldName("SaturatedFat"));
+            mock.Setup(f => f.Nullability).Returns(IsNullable.Yes);
+
+            var key = new PrimaryKey();
+            void action() => key.AddField(mock.Object);
+            var exception = Assert.ThrowsException<ArgumentException>(action);
+            Assert.AreNotEqual(String.Empty, exception.Message);
+        }
+    }
+}

--- a/Test/Kvasir/Schema/Names.cs
+++ b/Test/Kvasir/Schema/Names.cs
@@ -72,5 +72,40 @@ namespace Test.Kvasir.Schema {
             var exception = Assert.ThrowsException<ArgumentException>(action);
             Assert.AreNotEqual(string.Empty, exception.Message);
         }
+
+
+        [TestMethod, TestCategory("KeyName")]
+        public void ValidKeyNameNoTrim() {
+            var contents = "KEY_StartEndPair";
+            var name = new KeyName(contents);
+
+            Assert.AreEqual(contents, (string?)name);
+        }
+
+        [TestMethod, TestCategory("KeyName")]
+        public void ValidKeyNameTrim() {
+            var contents = "     PK_SAG_Name ";
+            var name = new KeyName(contents);
+
+            Assert.AreEqual(contents.Trim(), (string?)name);
+        }
+
+        [TestMethod, TestCategory("KeyName")]
+        public void EmptyStringKeyName() {
+            var empty = string.Empty;
+
+            void action() => new KeyName(empty);
+            var exception = Assert.ThrowsException<ArgumentException>(action);
+            Assert.AreNotEqual(string.Empty, exception.Message);
+        }
+
+        [TestMethod, TestCategory("KeyName")]
+        public void WhitespaceOnlyKeyName() {
+            var whitespace = "    \n     \n\t  ";
+
+            void action() => new KeyName(whitespace);
+            var exception = Assert.ThrowsException<ArgumentException>(action);
+            Assert.AreNotEqual(string.Empty, exception.Message);
+        }
     }
 }

--- a/Test/Mocks/Builders.cs
+++ b/Test/Mocks/Builders.cs
@@ -12,6 +12,9 @@ namespace Test.Mocks {
         public IConstraintDeclBuilder ConstraintDeclBuilder() {
             return new MockConstraintSyntaxGenerator();
         }
+        public IKeyDeclBuilder KeyDeclBuilder() {
+            return new MockKeySyntaxGenerator();
+        }
     }
 
     internal sealed class MockFieldSyntaxGenerator : IFieldDeclBuilder {
@@ -57,7 +60,6 @@ namespace Test.Mocks {
         private string defaultValue_;
         private string restriction_;
     }
-
     internal sealed class MockConstraintSyntaxGenerator : IConstraintDeclBuilder {
         public MockConstraintSyntaxGenerator() {
             tokens_ = new Stack<string>();
@@ -142,5 +144,37 @@ namespace Test.Mocks {
         private string name_;
         private static readonly string AND = "<AND>";
         private static readonly string OR = "<OR>";
+    }
+    internal sealed class MockKeySyntaxGenerator : IKeyDeclBuilder {
+        public MockKeySyntaxGenerator() {
+            name_ = "/unnamed/";
+            fields_ = new List<string>();
+            primacy_ = "UNIQUE";
+        }
+        public SqlSnippet Build() {
+            return new SqlSnippet($"CONSTRAINT {name_} {primacy_} ({string.Join(", ", fields_)})");
+        }
+        public void Reset() {
+            name_ = "/unnamed/";
+            fields_.Clear();
+            primacy_ = "UNIQUE";
+        }
+        public void SetName(KeyName name) {
+            name_ = (string)name!;
+        }
+        public void AddField(FieldName fieldName) {
+            var name = (string)fieldName!;
+            if (!fields_.Contains(name)) {
+                fields_.Add(name);
+            }
+        }
+        public void SetAsPrimary() {
+            primacy_ = "PRIMARY-KEY";
+        }
+
+
+        private string name_;
+        private readonly List<string> fields_;
+        private string primacy_;
     }
 }


### PR DESCRIPTION
This commit builds the Schema representations of Candidate Keys (for UNIQUE constraints) and Primary Keys. The latter is
simply a called-out instance of the former, with the only non-semantic difference (other than different C# types) being
in the generated constraint declaration. The classes are fairly minimal and will be used by the Table implementation,
which will require exactly one Primary Key and zero or more Candidate Keys.