### PR TITLE
DataConverter

### DIFF
--- a/src/Kvasir/Core/DataConverter.cs
+++ b/src/Kvasir/Core/DataConverter.cs
@@ -1,0 +1,227 @@
+﻿using Ardalis.GuardClauses;
+using Optional;
+using Optional.Unsafe;
+using System;
+
+using ConvFn = System.Converter<object?, object?>;
+
+namespace Kvasir.Core {
+    /// <summary>
+    ///   A utility for converting objects of one type into objects of another type, and possibly vice-versa.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     A <see cref="DataConverter"/> represents a possibly reversible function that maps instance of one CLR type
+    ///     into instances of another. This mapping can be relatively simple (i.e. formatting a string to be
+    ///     <c>ALL CAPS</c>) or relatively complex (establishing a database connection from an user-defined structure).
+    ///     This allows flexibility in the definition of the conversion mechanism without burdening the user on the
+    ///     potential complexities that underlie that logic. The client is presented with a simple conversion interface
+    ///     with which they can perform transformations.
+    ///   </para>
+    ///   <para>
+    ///     A <see cref="DataConverter"/>, at a minimum, must support conversion of every instance of some "source
+    ///     type" into instances of some "result type." This forward conversion can only fail when the source instance
+    ///     is malformed or in some other invalid state: conversion of a valid source instance can never result in an
+    ///     exception. Optionally, DataConverts can provide for converting <i>back</i> from instances of the "result"
+    ///     type into instances of the "source" type; this is known as a "bidirectional" converter, and the specifics
+    ///     of the reversal mechanism (e.g. what happens when two or more source instances map to the same result
+    ///     instance, which is then reversed) are defined by the underlying conversion mechanic. Clients should thus be
+    ///     careful when using the <see cref="Revert(object?)"/> API, as <c>Revert(Convert(X))</c> is not required to
+    ///     yield <c>X</c>.
+    ///   </para>
+    ///   <para>
+    ///     Both the conversion and reversion APIs operate in type-erased contexts. <see cref="DataConverter"/> will
+    ///     throw a runtime exception if an input object does not match the expected type; the class further guarantees
+    ///     that the returned value, though type-erased, can be safely cast.
+    ///   </para>
+    /// </remarks>
+    public sealed class DataConverter {
+        /// <summary>
+        ///   The <see cref="Type"/> of the input objects in the forward conversion supported by this
+        ///   <see cref="DataConverter"/>.
+        /// </summary>
+        public Type SourceType { get; }
+
+        /// <summary>
+        ///   The <see cref="Type"/> of the output objects in the forward conversion supported by this
+        ///   <see cref="DataConverter"/>.
+        /// </summary>
+        public Type ResultType { get; }
+
+        /// <summary>
+        ///   Whether or not this <see cref="DataConverter"/> supports
+        ///   <see cref="Revert(object?)">reverse conversion</see>.
+        /// </summary>
+        public bool IsBidirectional => revert_.HasValue;
+
+        /// <summary>
+        ///   Creates a new <see cref="DataConverter"/> that is not <see cref="IsBidirectional">bidirectional</see>.
+        /// </summary>
+        /// <typeparam name="TSource">
+        ///   The <see cref="SourceType"/> of the new <see cref="DataConverter"/>.
+        /// </typeparam>
+        /// <typeparam name="TResult">
+        ///   The <see cref="ResultType"/> of the new <see cref="DataConverter"/>.
+        /// </typeparam>
+        /// <param name="convert">
+        ///   The function by which the new <see cref="DataConverter"/> is to convert instances of
+        ///   <see cref="SourceType"/> (i.e. <typeparamref name="TSource"/>) into instances of <see cref="ResultType"/>
+        ///   (i.e. <typeparamref name="TResult"/>).
+        /// </param>
+        /// <returns>
+        ///   A new unidirectional <see cref="DataConverter"/> that converts from instances of
+        ///   <typeparamref name="TSource"/> into instances of <typeparamref name="TResult"/> using
+        ///   <paramref name="convert"/>.
+        /// </returns>
+        public static DataConverter Create<TSource, TResult>(Converter<TSource, TResult> convert) {
+            #pragma warning disable CS8604          // Possible null reference argument.
+            ConvFn fwd = o => convert((TSource?)o);
+            var bwd = Option.None<ConvFn>();
+            #pragma warning restore CS8604          // Possible null reference argument.
+
+            return new DataConverter(typeof(TSource), typeof(TResult), fwd, bwd);
+        }
+
+        /// <summary>
+        ///   Creates a new <see cref="DataConverter"/> that is <see cref="IsBidirectional">bidirectional</see>.
+        /// </summary>
+        /// <typeparam name="TSource">
+        ///   The <see cref="SourceType"/> of the new <see cref="DataConverter"/>.
+        /// </typeparam>
+        /// <typeparam name="TResult">
+        ///   The <see cref="ResultType"/> of the new <see cref="DataConverter"/>.
+        /// </typeparam>
+        /// <param name="convert">
+        ///   The function by which the new <see cref="DataConverter"/> is to convert instances of
+        ///   <see cref="SourceType"/> (i.e. <typeparamref name="TSource"/>) into instances of <see cref="ResultType"/>
+        ///   (i.e. <typeparamref name="TResult"/>).
+        /// </param>
+        /// <param name="revert">
+        ///   The function by which the new <see cref="DataConverter"/> is to convert instances of
+        ///   <see cref="ResultType"/> (i.e. <typeparamref name="TResult"/>) into instances of <see cref="SourceType"/>
+        ///   (i.e. <typeparamref name="TSource"/>).
+        /// </param>
+        /// <returns>
+        ///   A new bidirectional <see cref="DataConverter"/> that converts from instances of
+        ///   <typeparamref name="TSource"/> into instances of <typeparamref name="TResult"/> using
+        ///   <paramref name="convert"/> and vice-versa using <paramref name="revert"/>.
+        public static DataConverter Create<TSource, TResult>(Converter<TSource, TResult> convert,
+            Converter<TResult, TSource> revert) {
+
+            #pragma warning disable CS8604          // Possible null reference argument.
+            ConvFn fwd = o => convert((TSource?)o);
+            var bwd = Option.Some<ConvFn>(o => revert((TResult?)o));
+            #pragma warning restore CS8604          // Possible null reference argument.
+
+            return new DataConverter(typeof(TSource), typeof(TResult), fwd, bwd);
+        }
+
+        /// <summary>
+        ///   Converts an instance of <see cref="SourceType"/> into an instance of <see cref="ResultType"/>.
+        /// </summary>
+        /// <param name="source">
+        ///   The source object.
+        /// </param>
+        /// <returns>
+        ///   The coversion of <paramref name="source"/> into an instance of <see cref="ResultType"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   if <paramref name="source"/> is neither an instance of <see cref="SourceType"/> nor a derived class or an
+        ///   implementation thereof
+        ///     --or--
+        ///   if <paramref name="source"/> cannot be converted.
+        /// </exception>
+        public object? Convert(object? source) {
+            if (source is not null && !SourceType.IsInstanceOfType(source)) {
+                var msg = $"Cannot convert object of type {source.GetType()}: expected {SourceType}";
+                throw new ArgumentException(msg, nameof(source));
+            }
+
+            return convert_(source);
+        }
+
+        /// <summary>
+        ///   Converts an instance of <see cref="ResultType"/> back into an instance of <see cref="SourceType"/>.
+        /// </summary>
+        /// <remarks>
+        ///   Because the underlying conversion mechanism need not be bijective (that is, multiple different source
+        ///   objects can convert into the same result object), the <see cref="Revert(object?)"/> API does not
+        ///   necessarily present a true inversion. For a given result object <c>R</c>, the only guarantees are that
+        ///   repeated calls to the API will yield the same source object and that <c>Convert(Revert(R)) == R</c>.
+        /// </remarks>
+        /// <param name="result">
+        ///   The result object.
+        /// </param>
+        /// <returns>
+        ///   The reversion of <paramref name="result"/> into an instance of <see cref="SourceType"/>.
+        /// </returns>
+        /// <exception cref="NotSupportedException">
+        ///   if this <see cref="DataConverter"/> is not <see cref="IsBidirectional">bidirectional</see>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   if <paramref name="result"/> is neither an instance of <see cref="ResultType"/> nor a derived class or an
+        ///   implementation thereof
+        ///     --or--
+        ///   if <paramref name="result"/> cannot be reverted.
+        /// </exception>
+        public object? Revert(object? result) {
+            if (!IsBidirectional) {
+                var msg = $"Reverse conversion is not supported by this {nameof(DataConverter)}";
+                throw new NotSupportedException(msg);
+            }
+            else if (result is not null && !ResultType.IsInstanceOfType(result)) {
+                var msg = $"Cannot revert object of type {result.GetType()}: expected {ResultType}";
+                throw new ArgumentException(msg, nameof(result));
+            }
+
+            var fn = revert_.ValueOrFailure();
+            return fn(result);
+        }
+
+        /// <summary>
+        ///   Creates a new <see cref="DataConverter"/> that represents an bidirectional identity conversion.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The type on which the identity converter is to operate.
+        /// </typeparam>
+        /// <returns>
+        ///   A new bidirectional <see cref="DataConverter"/> that performs identity conversion.
+        /// </returns>
+        public static DataConverter Identity<T>() {
+            return Create<T, T>(t => t, t => t);
+        }
+
+        /// <summary>
+        ///   Constructs a new <see cref="DataConverter"/>.
+        /// </summary>
+        /// <param name="sourceType">
+        ///   The <see cref="SourceType"/> of the new <see cref="DataConverter"/>.
+        /// </param>
+        /// <param name="resultType">
+        ///   The <see cref="ResultType"/> of the new <see cref="DataConverter"/>.
+        /// </param>
+        /// <param name="fwd">
+        ///   The function by which the new <see cref="DataConverter"/> is to convert instances of
+        ///   <see cref="SourceType"/> into instances of <see cref="ResultType"/>.
+        /// </param>
+        /// <param name="bwd">
+        ///   The function by which the new <see cref="DataConverter"/> is to convert instances of
+        ///   <see cref="ResultType"/> into instances of <see cref="SourceType"/>, if such a function is supported.
+        /// </param>
+        private DataConverter(Type sourceType, Type resultType, ConvFn fwd, Option<ConvFn> bwd) {
+            Guard.Against.Null(sourceType, nameof(sourceType));
+            Guard.Against.Null(resultType, nameof(resultType));
+            Guard.Against.Null(fwd, nameof(fwd));
+            Guard.Against.Null(bwd, nameof(bwd));
+
+            SourceType = sourceType;
+            ResultType = resultType;
+            convert_ = fwd;
+            revert_ = bwd;
+        }
+
+
+        private readonly ConvFn convert_;
+        private readonly Option<ConvFn> revert_;
+    }
+}

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -4,6 +4,150 @@
         <name>Kvasir</name>
     </assembly>
     <members>
+        <member name="T:Kvasir.Core.DataConverter">
+            <summary>
+              A utility for converting objects of one type into objects of another type, and possibly vice-versa.
+            </summary>
+            <remarks>
+              <para>
+                A <see cref="T:Kvasir.Core.DataConverter"/> represents a possibly reversible function that maps instance of one CLR type
+                into instances of another. This mapping can be relatively simple (i.e. formatting a string to be
+                <c>ALL CAPS</c>) or relatively complex (establishing a database connection from an user-defined structure).
+                This allows flexibility in the definition of the conversion mechanism without burdening the user on the
+                potential complexities that underlie that logic. The client is presented with a simple conversion interface
+                with which they can perform transformations.
+              </para>
+              <para>
+                A <see cref="T:Kvasir.Core.DataConverter"/>, at a minimum, must support conversion of every instance of some "source
+                type" into instances of some "result type." This forward conversion can only fail when the source instance
+                is malformed or in some other invalid state: conversion of a valid source instance can never result in an
+                exception. Optionally, DataConverts can provide for converting <i>back</i> from instances of the "result"
+                type into instances of the "source" type; this is known as a "bidirectional" converter, and the specifics
+                of the reversal mechanism (e.g. what happens when two or more source instances map to the same result
+                instance, which is then reversed) are defined by the underlying conversion mechanic. Clients should thus be
+                careful when using the <see cref="M:Kvasir.Core.DataConverter.Revert(System.Object)"/> API, as <c>Revert(Convert(X))</c> is not required to
+                yield <c>X</c>.
+              </para>
+              <para>
+                Both the conversion and reversion APIs operate in type-erased contexts. <see cref="T:Kvasir.Core.DataConverter"/> will
+                throw a runtime exception if an input object does not match the expected type; the class further guarantees
+                that the returned value, though type-erased, can be safely cast.
+              </para>
+            </remarks>
+        </member>
+        <member name="P:Kvasir.Core.DataConverter.SourceType">
+            <summary>
+              The <see cref="T:System.Type"/> of the input objects in the forward conversion supported by this
+              <see cref="T:Kvasir.Core.DataConverter"/>.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Core.DataConverter.ResultType">
+            <summary>
+              The <see cref="T:System.Type"/> of the output objects in the forward conversion supported by this
+              <see cref="T:Kvasir.Core.DataConverter"/>.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Core.DataConverter.IsBidirectional">
+            <summary>
+              Whether or not this <see cref="T:Kvasir.Core.DataConverter"/> supports
+              <see cref="M:Kvasir.Core.DataConverter.Revert(System.Object)">reverse conversion</see>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Core.DataConverter.Create``2(System.Converter{``0,``1})">
+            <summary>
+              Creates a new <see cref="T:Kvasir.Core.DataConverter"/> that is not <see cref="P:Kvasir.Core.DataConverter.IsBidirectional">bidirectional</see>.
+            </summary>
+            <typeparam name="TSource">
+              The <see cref="P:Kvasir.Core.DataConverter.SourceType"/> of the new <see cref="T:Kvasir.Core.DataConverter"/>.
+            </typeparam>
+            <typeparam name="TResult">
+              The <see cref="P:Kvasir.Core.DataConverter.ResultType"/> of the new <see cref="T:Kvasir.Core.DataConverter"/>.
+            </typeparam>
+            <param name="convert">
+              The function by which the new <see cref="T:Kvasir.Core.DataConverter"/> is to convert instances of
+              <see cref="P:Kvasir.Core.DataConverter.SourceType"/> (i.e. <typeparamref name="TSource"/>) into instances of <see cref="P:Kvasir.Core.DataConverter.ResultType"/>
+              (i.e. <typeparamref name="TResult"/>).
+            </param>
+            <returns>
+              A new unidirectional <see cref="T:Kvasir.Core.DataConverter"/> that converts from instances of
+              <typeparamref name="TSource"/> into instances of <typeparamref name="TResult"/> using
+              <paramref name="convert"/>.
+            </returns>
+        </member>
+        <!-- Badly formed XML comment ignored for member "M:Kvasir.Core.DataConverter.Create``2(System.Converter{``0,``1},System.Converter{``1,``0})" -->
+        <member name="M:Kvasir.Core.DataConverter.Convert(System.Object)">
+            <summary>
+              Converts an instance of <see cref="P:Kvasir.Core.DataConverter.SourceType"/> into an instance of <see cref="P:Kvasir.Core.DataConverter.ResultType"/>.
+            </summary>
+            <param name="source">
+              The source object.
+            </param>
+            <returns>
+              The coversion of <paramref name="source"/> into an instance of <see cref="P:Kvasir.Core.DataConverter.ResultType"/>.
+            </returns>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="source"/> is neither an instance of <see cref="P:Kvasir.Core.DataConverter.SourceType"/> nor a derived class or an
+              implementation thereof
+                --or--
+              if <paramref name="source"/> cannot be converted.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Core.DataConverter.Revert(System.Object)">
+            <summary>
+              Converts an instance of <see cref="P:Kvasir.Core.DataConverter.ResultType"/> back into an instance of <see cref="P:Kvasir.Core.DataConverter.SourceType"/>.
+            </summary>
+            <remarks>
+              Because the underlying conversion mechanism need not be bijective (that is, multiple different source
+              objects can convert into the same result object), the <see cref="M:Kvasir.Core.DataConverter.Revert(System.Object)"/> API does not
+              necessarily present a true inversion. For a given result object <c>R</c>, the only guarantees are that
+              repeated calls to the API will yield the same source object and that <c>Convert(Revert(R)) == R</c>.
+            </remarks>
+            <param name="result">
+              The result object.
+            </param>
+            <returns>
+              The reversion of <paramref name="result"/> into an instance of <see cref="P:Kvasir.Core.DataConverter.SourceType"/>.
+            </returns>
+            <exception cref="T:System.NotSupportedException">
+              if this <see cref="T:Kvasir.Core.DataConverter"/> is not <see cref="P:Kvasir.Core.DataConverter.IsBidirectional">bidirectional</see>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="result"/> is neither an instance of <see cref="P:Kvasir.Core.DataConverter.ResultType"/> nor a derived class or an
+              implementation thereof
+                --or--
+              if <paramref name="result"/> cannot be reverted.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Core.DataConverter.Identity``1">
+            <summary>
+              Creates a new <see cref="T:Kvasir.Core.DataConverter"/> that represents an bidirectional identity conversion.
+            </summary>
+            <typeparam name="T">
+              The type on which the identity converter is to operate.
+            </typeparam>
+            <returns>
+              A new bidirectional <see cref="T:Kvasir.Core.DataConverter"/> that performs identity conversion.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Core.DataConverter.#ctor(System.Type,System.Type,System.Converter{System.Object,System.Object},Optional.Option{System.Converter{System.Object,System.Object}})">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Core.DataConverter"/>.
+            </summary>
+            <param name="sourceType">
+              The <see cref="P:Kvasir.Core.DataConverter.SourceType"/> of the new <see cref="T:Kvasir.Core.DataConverter"/>.
+            </param>
+            <param name="resultType">
+              The <see cref="P:Kvasir.Core.DataConverter.ResultType"/> of the new <see cref="T:Kvasir.Core.DataConverter"/>.
+            </param>
+            <param name="fwd">
+              The function by which the new <see cref="T:Kvasir.Core.DataConverter"/> is to convert instances of
+              <see cref="P:Kvasir.Core.DataConverter.SourceType"/> into instances of <see cref="P:Kvasir.Core.DataConverter.ResultType"/>.
+            </param>
+            <param name="bwd">
+              The function by which the new <see cref="T:Kvasir.Core.DataConverter"/> is to convert instances of
+              <see cref="P:Kvasir.Core.DataConverter.ResultType"/> into instances of <see cref="P:Kvasir.Core.DataConverter.SourceType"/>, if such a function is supported.
+            </param>
+        </member>
         <member name="T:Kvasir.Schema.BasicField">
             <summary>
               A Field whose data type has no intrinsic constraints beyond those imposed by the back-end storage.

--- a/test/UnitTests/Kvasir/Core/DataConverter.cs
+++ b/test/UnitTests/Kvasir/Core/DataConverter.cs
@@ -1,0 +1,207 @@
+﻿using FluentAssertions;
+using Kvasir.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UT.Kvasir.Core {
+    [TestClass, TestCategory("DataConverter")]
+    public class DataConverterTests {
+        [TestMethod] public void CreateUnidirectional() {
+            // Arrange
+            Converter<int, string> fn = i => i.ToString();
+
+            // Act
+            var converter = DataConverter.Create(fn);
+
+            // Assert
+            converter.SourceType.Should().Be(typeof(int));
+            converter.ResultType.Should().Be(typeof(string));
+            converter.IsBidirectional.Should().BeFalse();
+        }
+
+        [TestMethod] public void CreateBidirectional() {
+            // Arrange
+            Converter<int, string> fwd = i => i.ToString();
+            Converter<string, int> bwd = s => int.Parse(s);
+
+            // Act
+            var converter = DataConverter.Create(fwd, bwd);
+
+            // Assert
+            converter.SourceType.Should().Be(typeof(int));
+            converter.ResultType.Should().Be(typeof(string));
+            converter.IsBidirectional.Should().BeTrue();
+        }
+
+        [TestMethod] public void ForwardConversionActualType() {
+            // Arrange
+            Converter<string, int> fn = s => s.Length;
+            var converter = DataConverter.Create(fn);
+            var source = "Indianapolis";
+
+            // Act
+            var expected = fn(source);
+            var conversion = converter.Convert(source);
+
+            // Assert
+            conversion!.GetType().Should().Be(typeof(int));
+            conversion.Should().Be(expected);
+        }
+
+        [TestMethod] public void ForwardConversionDerivedType() {
+            // Arrange
+            Converter<Exception, string> fn = e => e.Message;
+            var converter = DataConverter.Create(fn);
+            var source = new ArgumentNullException("San Jose");
+
+            // Act
+            var expected = fn(source);
+            var conversion = converter.Convert(source);
+
+            // Assert
+            conversion!.GetType().Should().Be(typeof(string));
+            conversion.Should().Be(expected);
+        }
+
+        [TestMethod] public void ForwardConversionImplementationType() {
+            // Arrange
+            Converter<IReadOnlyList<string>, int> fn = e => e.Count;
+            var converter = DataConverter.Create(fn);
+            var source = new List <string>() { "Greensboro", "Amarillo", "Augusta", "New York City" };
+
+            // Act
+            var expected = fn(source);
+            var conversion = converter.Convert(source);
+
+            // Assert
+            conversion!.GetType().Should().Be(typeof(int));
+            conversion.Should().Be(expected);
+        }
+
+        [TestMethod] public void BackwardConversionActualType() {
+            // Arrange
+            Converter<string, int> fwd = s => s.Length;
+            Converter<int, string> bwd = i => string.Concat(Enumerable.Repeat('+', i));
+            var converter = DataConverter.Create(fwd, bwd);
+            var result = 13;
+
+            // Act
+            var expected = bwd(result);
+            var reversion = converter.Revert(result);
+
+            // Assert
+            reversion!.GetType().Should().Be(typeof(string));
+            reversion.Should().Be(expected);
+        }
+
+        [TestMethod] public void BackwardConversionDerivedType() {
+            // Arrange
+            Converter<string, Exception> fwd = s => new Exception(s);
+            Converter<Exception, string> bwd = e => e.Message;
+            var converter = DataConverter.Create(fwd, bwd);
+            var result = new ArgumentNullException("Ypsilanti");
+
+            // Act
+            var expected = bwd(result);
+            var reversion = converter.Revert(result);
+
+            // Assert
+            reversion!.GetType().Should().Be(typeof(string));
+            reversion.Should().Be(expected);
+        }
+
+        [TestMethod] public void BackwardConversionImplementationType() {
+            // Arrange
+            Converter<int, IReadOnlyList<string>> fwd = i => Enumerable.Repeat("???", i).ToList();
+            Converter<IReadOnlyList<string>, int> bwd = e => e.Count;
+            var converter = DataConverter.Create(fwd, bwd);
+            var result = new List<string>() { "Toledo", "Norfolk", "Carson City", "Minneapolis", "Miami" };
+
+            // Act
+            var expected = bwd(result);
+            var reversion = converter.Revert(result);
+
+            // Assert
+            reversion!.GetType().Should().Be(typeof(int));
+            reversion.Should().Be(expected);
+        }
+        
+        [TestMethod] public void BackwardConversionNotSupported() {
+            // Arrange
+            Converter<string, int> fn = s => s.Length;
+            var converter = DataConverter.Create(fn);
+
+            // Act
+            Action action = () => converter.Revert(57);
+
+            // Assert
+            action.Should().ThrowExactly<NotSupportedException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void ForwardConversionUnrelatedType() {
+            // Arrange
+            Converter<string, int> fwd = s => s.Length;
+            var converter = DataConverter.Create(fwd);
+
+            // Act
+            Action action = () => converter.Convert(DateTime.Today);
+
+            // Assert
+            action.Should().ThrowExactly<ArgumentException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void BackwardConversionUnrelatedType() {
+            // Arrange
+            Converter<string, int> fwd = s => s.Length;
+            Converter<int, string> bwd = i => string.Concat(Enumerable.Repeat('+', i));
+            var converter = DataConverter.Create(fwd, bwd);
+
+            // Act
+            Action action = () => converter.Revert(DateTime.Today);
+
+            // Assert
+            action.Should().ThrowExactly<ArgumentException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void IdentityConversion() {
+            // Arrange
+            var converter = DataConverter.Identity<double>();
+            var source = 88.5;
+
+            // Act
+            var conversion = converter.Convert(source);
+            var reversion = converter.Revert(conversion);
+
+            // Assert
+            converter.SourceType.Should().Be(typeof(double));
+            converter.ResultType.Should().Be(typeof(double));
+            converter.IsBidirectional.Should().BeTrue();
+            conversion.Should().Be(source);
+            reversion.Should().Be(source);
+        }
+
+        [TestMethod] public void ConvertNull() {
+            // Arrange
+            var converter = DataConverter.Identity<string>();
+
+            // Act
+            var conversion = converter.Convert(null);
+
+            // Assert
+            conversion.Should().BeNull();
+        }
+
+        [TestMethod] public void RevertNull() {
+            // Arrange
+            var converter = DataConverter.Identity<string>();
+
+            // Act
+            var reversion = converter.Revert(null);
+
+            // Assert
+            reversion.Should().BeNull();
+        }
+    }
+}

--- a/test/UnitTests/_TestCities.txt
+++ b/test/UnitTests/_TestCities.txt
@@ -3,9 +3,11 @@
 
 Akron
 Albuquerque
+Amarillo
 Ann Arbor
 Atlanta
 Atlantic City
+Augusta
 Baltimore
 Biloxi
 Birmingham
@@ -13,6 +15,7 @@ Boise
 Boston
 Buffalo
 Canton
+Carson City
 Charleston
 Charlotte
 Chicago
@@ -27,10 +30,12 @@ Flagstaff
 Fort Wayne
 Fresno
 Green Bay
+Greensboro
 Hartford
 Helena
 Honolulu
 Houston
+Indianapolis
 Ithaca
 Jacksonville
 Jersey City
@@ -43,13 +48,17 @@ Little Rock
 Los Angeles
 Louisville
 Memphis
+Miami
 Milwaukee
+Minneapolis
 Montgomery
 Montpelier
 Myrtle Beach
 Nashville
 New Haven
 New Orleans
+New York City
+Norfolk
 Oakland
 Oklahoma City
 Omaha
@@ -63,14 +72,17 @@ Reno
 San Antonio
 San Diego
 San Francisco
+San Jose
 Seattle
 Spokane
 Springfield
 St. Louis
 Tacoma
+Toledo
 Topeka
 Trenton
 Tulsa
 Virginia Beach
 Washington, D.C.
 Wichita
+Ypsilanti


### PR DESCRIPTION
This commit introduces the DataConverter utility, which is a wrapper to assist with the transformation of data between
representations. A DataConverter supports, at a minimum, one-way conversion from some source type into some result type;
optionally, it can also support reverse conversion from the result type into the source type. The conversion APIs are
necessarily type erased (operating solely on object?), but there are runtime type checks on top of any checks performed
during casting. This utility will be leveraged by the Extraction Layer to convert enumerators into strings/integers,
among other conversion possibilities.