### PR TITLE
Extraction Plan

### DIFF
--- a/src/Cybele/Extensions/IEnumerable.cs
+++ b/src/Cybele/Extensions/IEnumerable.cs
@@ -42,6 +42,75 @@ namespace Cybele.Extensions {
         }
 
         /// <summary>
+        ///   Checks if some function (e.g. a property accessor) returns the same value for all elements of an
+        ///   enumerable, using the default <see cref="IEqualityComparer{T}"/> for the function's return type.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   [deduced] The type of element in the enumerable.
+        /// </typeparam>
+        /// <typeparam name="U">
+        ///   [deduced] The type of value returned by the function.
+        /// </typeparam>
+        /// <param name="self">
+        ///   The <see cref="IEnumerable{T}"/> on which the extension method is invoked.
+        /// </param>
+        /// <param name="func">
+        ///   The function.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if, according to the default <see cref="EqualityComparer{T}"/> for
+        ///   <typeparamref name="U"/>, <paramref name="func"/> returns equal values for all elements of
+        ///   <paramref name="self"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool AllSame<T, U>(this IEnumerable<T> self, Func<T, U> func) {
+            Guard.Against.Null(self, nameof(self));
+            Guard.Against.Null(func, nameof(func));
+            return AllSame(self, func, EqualityComparer<U>.Default);
+        }
+
+        /// <summary>
+        ///   Checks if some function (e.g. a property accessor) returns the same value for all elements of an
+        ///   enumerable, using a specific <see cref="IEqualityComparer{T}"/> for the function's return type.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   [deduced] The type of element in the enumerable.
+        /// </typeparam>
+        /// <typeparam name="U">
+        ///   [deduced] The type of value returned by the function.
+        /// </typeparam>
+        /// <param name="self">
+        ///   The <see cref="IEnumerable{T}"/> on which the extension method is invoked.
+        /// </param>
+        /// <param name="func">
+        ///   The function.
+        /// </param>
+        /// <param name="comparer">
+        ///   The <see cref="EqualityComparer{T}"/> with which to compare the return values of <paramref name="func"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if, according to <paramref name="comparer"/>, <paramref name="func"/> returns
+        ///   equal values for all elements of <paramref name="self"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool AllSame<T, U>(this IEnumerable<T> self, Func<T, U> func, IEqualityComparer<U> comparer) {
+            Guard.Against.Null(self, nameof(self));
+            Guard.Against.Null(func, nameof(func));
+            Guard.Against.Null(comparer, nameof(comparer));
+
+            var enumerator = self.GetEnumerator();
+            if (!enumerator.MoveNext()) {
+                return true;
+            }
+
+            var target = func(enumerator.Current);
+            while (enumerator.MoveNext()) {
+                if (!comparer.Equals(target, func(enumerator.Current))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
         ///   Checks if any element of an enumerable passes a given predicate. The index of the element is passed to
         ///   the predicate along with the element for evaluation.
         /// </summary>

--- a/src/Cybele/Extensions/MemberInfo.cs
+++ b/src/Cybele/Extensions/MemberInfo.cs
@@ -6,7 +6,7 @@ namespace Cybele.Extensions {
     ///   A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
     ///   of the <see cref="MemberInfo"/> class.
     /// </summary>
-    public static class TypeExtensions {
+    public static partial class TypeExtensions {
         /// <summary>
         ///   Determines if a member (e.g. a <see cref="Type"/> or a <see cref="PropertyInfo"/>) is annotated with a
         ///   particular <see cref="Attribute"/>.

--- a/src/Cybele/Extensions/Type.cs
+++ b/src/Cybele/Extensions/Type.cs
@@ -1,0 +1,52 @@
+﻿using Ardalis.GuardClauses;
+using System;
+using System.Linq;
+
+namespace Cybele.Extensions {
+    /// <summary>
+    ///   A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
+    ///   of the <see cref="System.Reflection.MemberInfo"/> class.
+    /// </summary>
+    public static partial class TypeExtensions {
+        /// <summary>
+        ///   Determines if an instance of one <see cref="Type"/> would also be an instance of another
+        ///   <see cref="Type"/> based on an identity, inheritance, or interface implementation relationship.
+        /// </summary>
+        /// <param name="derivedType">
+        ///   The hypothetical descendant <see cref="Type"/>.
+        /// </param>
+        /// <param name="ancestorType">
+        ///   The hypothetical ancestor <see cref="Type"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="ancestorType"/> is identical to <paramref name="derivedType"/>,
+        ///   is a base class of <paramref name="derivedType"/>, or is an interface of <paramref name="derivedType"/>;
+        ///   otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsInstanceOf(this Type derivedType, Type ancestorType) {
+            Guard.Against.Null(ancestorType, nameof(ancestorType));
+            Guard.Against.Null(derivedType, nameof(derivedType));
+
+            if (ancestorType == typeof(object)) {
+                // We need this branch called out explicitly because Interfaces do not have object in their inheritance
+                // hierarchy, so the "standard" algorithm (i.e. the following branches) would result in a false
+                // negative. As set up currently, there is an extra check when recursing through the parents; this
+                // could easily be refactored out with a helper function or a for loop if so desired.
+                return true;
+            }
+            else if (ancestorType == derivedType) {
+                return true;
+            }
+            else if (derivedType.GetInterfaces().Contains(ancestorType)) {
+                return true;
+            }
+            else {
+                var parent = derivedType.BaseType;
+                if (parent is not null) {
+                    return IsInstanceOf(parent, ancestorType);
+                }
+                return false;
+            }
+        }
+    }
+}

--- a/src/Cybele/Intellisense.xml
+++ b/src/Cybele/Intellisense.xml
@@ -378,6 +378,54 @@
               <c>(index, element)</c> pairs of <paramref name="self"/>; otherwise, <see langword="false"/>.
             </returns>
         </member>
+        <member name="M:Cybele.Extensions.IEnumerableExtensions.AllSame``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})">
+            <summary>
+              Checks if some function (e.g. a property accessor) returns the same value for all elements of an
+              enumerable, using the default <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> for the function's return type.
+            </summary>
+            <typeparam name="T">
+              [deduced] The type of element in the enumerable.
+            </typeparam>
+            <typeparam name="U">
+              [deduced] The type of value returned by the function.
+            </typeparam>
+            <param name="self">
+              The <see cref="T:System.Collections.Generic.IEnumerable`1"/> on which the extension method is invoked.
+            </param>
+            <param name="func">
+              The function.
+            </param>
+            <returns>
+              <see langword="true"/> if, according to the default <see cref="T:System.Collections.Generic.EqualityComparer`1"/> for
+              <typeparamref name="U"/>, <paramref name="func"/> returns equal values for all elements of
+              <paramref name="self"/>; otherwise, <see langword="false"/>.
+            </returns>
+        </member>
+        <member name="M:Cybele.Extensions.IEnumerableExtensions.AllSame``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})">
+            <summary>
+              Checks if some function (e.g. a property accessor) returns the same value for all elements of an
+              enumerable, using a specific <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> for the function's return type.
+            </summary>
+            <typeparam name="T">
+              [deduced] The type of element in the enumerable.
+            </typeparam>
+            <typeparam name="U">
+              [deduced] The type of value returned by the function.
+            </typeparam>
+            <param name="self">
+              The <see cref="T:System.Collections.Generic.IEnumerable`1"/> on which the extension method is invoked.
+            </param>
+            <param name="func">
+              The function.
+            </param>
+            <param name="comparer">
+              The <see cref="T:System.Collections.Generic.EqualityComparer`1"/> with which to compare the return values of <paramref name="func"/>.
+            </param>
+            <returns>
+              <see langword="true"/> if, according to <paramref name="comparer"/>, <paramref name="func"/> returns
+              equal values for all elements of <paramref name="self"/>; otherwise, <see langword="false"/>.
+            </returns>
+        </member>
         <member name="M:Cybele.Extensions.IEnumerableExtensions.Any``1(System.Collections.Generic.IEnumerable{``0},System.Func{System.Int32,``0,System.Boolean})">
             <summary>
               Checks if any element of an enumerable passes a given predicate. The index of the element is passed to
@@ -491,6 +539,10 @@
               A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
               of the <see cref="T:System.Reflection.MemberInfo"/> class.
             </summary>
+            <summary>
+              A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
+              of the <see cref="T:System.Reflection.MemberInfo"/> class.
+            </summary>
         </member>
         <member name="M:Cybele.Extensions.TypeExtensions.HasAttribute``1(System.Reflection.MemberInfo)">
             <summary>
@@ -506,6 +558,23 @@
             <returns>
               <see langword="true"/> if <paramref name="self"/> is member that is annotated with at least one instance
               of <typeparamref name="TAttribute"/>, possibly inherited; otherwise, <see langword="false"/>.
+            </returns>
+        </member>
+        <member name="M:Cybele.Extensions.TypeExtensions.IsInstanceOf(System.Type,System.Type)">
+            <summary>
+              Determines if an instance of one <see cref="T:System.Type"/> would also be an instance of another
+              <see cref="T:System.Type"/> based on an identity, inheritance, or interface implementation relationship.
+            </summary>
+            <param name="derivedType">
+              The hypothetical descendant <see cref="T:System.Type"/>.
+            </param>
+            <param name="ancestorType">
+              The hypothetical ancestor <see cref="T:System.Type"/>.
+            </param>
+            <returns>
+              <see langword="true"/> if <paramref name="ancestorType"/> is identical to <paramref name="derivedType"/>,
+              is a base class of <paramref name="derivedType"/>, or is an interface of <paramref name="derivedType"/>;
+              otherwise, <see langword="false"/>.
             </returns>
         </member>
     </members>

--- a/src/Kvasir/Core/DataConverter.cs
+++ b/src/Kvasir/Core/DataConverter.cs
@@ -105,13 +105,12 @@ namespace Kvasir.Core {
         ///   A new bidirectional <see cref="DataConverter"/> that converts from instances of
         ///   <typeparamref name="TSource"/> into instances of <typeparamref name="TResult"/> using
         ///   <paramref name="convert"/> and vice-versa using <paramref name="revert"/>.
+	/// </returns>
         public static DataConverter Create<TSource, TResult>(Converter<TSource, TResult> convert,
             Converter<TResult, TSource> revert) {
 
-            #pragma warning disable CS8604          // Possible null reference argument.
-            ConvFn fwd = o => convert((TSource?)o);
-            var bwd = Option.Some<ConvFn>(o => revert((TResult?)o));
-            #pragma warning restore CS8604          // Possible null reference argument.
+            ConvFn fwd = o => o is null ? null : convert((TSource)o);
+            var bwd = Option.Some<ConvFn>(o => o is null ? null : revert((TResult)o));
 
             return new DataConverter(typeof(TSource), typeof(TResult), fwd, bwd);
         }

--- a/src/Kvasir/Extraction/ExtractionPlan.cs
+++ b/src/Kvasir/Extraction/ExtractionPlan.cs
@@ -1,0 +1,52 @@
+﻿using Cybele.Extensions;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Kvasir.Extraction {
+    /// <summary>
+    ///   An <see cref="IExtractionPlan"/> comprised of sub-plans that, collectively, extract one or more values from
+    ///   an input object.
+    /// </summary>
+    public sealed class ExtractionPlan : IExtractionPlan {
+        /// <inheritdoc/>
+        public Type ExpectedSource { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="ExtractionPlan"/>.
+        /// </summary>
+        /// <param name="steps">
+        ///   The constituent steps that make up the new <see cref="ExtractionPlan"/> in the order in which they are
+        ///   to be executed.
+        /// </param>
+        /// <pre>
+        ///   <paramref name="steps"/> is not empty
+        ///     --and--
+        ///   each element of <paramref name="steps"/> has the same <see cref="ExpectedSource"/>.
+        /// </pre>
+        internal ExtractionPlan(IEnumerable<IExtractionPlan> steps) {
+            Debug.Assert(steps is not null);
+            Debug.Assert(!steps.IsEmpty());
+            Debug.Assert(steps.AllSame(p => p.ExpectedSource));
+
+            ExpectedSource = steps.First().ExpectedSource;
+            steps_ = steps;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<DBValue> Execute(object? source) {
+            Debug.Assert(source is null || ExpectedSource.IsInstanceOfType(source));
+
+            var result = Enumerable.Empty<DBValue>();
+            foreach (var step in steps_) {
+                result = result.Concat(step.Execute(source));
+            }
+            return result;
+        }
+
+
+        private readonly IEnumerable<IExtractionPlan> steps_;
+    }
+}

--- a/src/Kvasir/Extraction/IExtractionPlan.cs
+++ b/src/Kvasir/Extraction/IExtractionPlan.cs
@@ -1,0 +1,33 @@
+﻿using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+
+namespace Kvasir.Extraction {
+    /// <summary>
+    ///   The interface describing how to extract one or more values from the properties of an input object.
+    /// </summary>
+    public interface IExtractionPlan {
+        /// <summary>
+        ///   The expected <see cref="Type"/> of the source object on which this <see cref="IExtractionPlan"/> can be
+        ///   executed.
+        /// </summary>
+        public Type ExpectedSource { get; }
+
+        /// <summary>
+        ///   Execute this <see cref="IExtractionPlan"/> on an input object, extracting one or more values from its
+        ///   properties.
+        /// </summary>
+        /// <param name="source">
+        ///   The source object.
+        /// </param>
+        /// <pre>
+        ///   <see cref="ExpectedSource"/> is the same as the type of <paramref name="source"/> or is a base class or
+        ///   interface thereof.
+        /// </pre>
+        /// <returns>
+        ///   An ordered sequence of values extracted from <paramref name="source"/> according to this
+        ///   <see cref="IExtractionPlan"/>.
+        /// </returns>
+        IEnumerable<DBValue> Execute(object? source);
+    }
+}

--- a/src/Kvasir/Extraction/RecursiveExtractionPlan.cs
+++ b/src/Kvasir/Extraction/RecursiveExtractionPlan.cs
@@ -1,0 +1,74 @@
+﻿using Cybele.Extensions;
+using Kvasir.Core;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Kvasir.Extraction {
+    /// <summary>
+    ///   An <see cref="IExtractionPlan"/> that recursively executes an <see cref="IExtractionPlan"/> on a single
+    ///   extracted value.
+    /// </summary>
+    public sealed class RecursiveExtractionPlan : IExtractionPlan {
+        /// <inheritdoc/>
+        public Type ExpectedSource { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="RecursiveExtractionPlan"/>.
+        /// </summary>
+        /// <param name="property">
+        ///   The <see cref="PropertyInfo"/> describing the property whose value is to be initially extracted by the
+        ///   new <see cref="RecursiveExtractionPlan"/>. That extracted value is then the input to the recursive plan.
+        /// </param>
+        /// <param name="converter">
+        ///   The converter to apply to the extracted value. If no conversion is necessary, use an
+        ///   <see cref="DataConverter.Identity{T}">identity conversion</see>.
+        /// </param>
+        /// <param name="recursiveSteps">
+        ///   The <see cref="IExtractionPlan"/> to be recursively executed on the extracted value.
+        /// </param>
+        /// <pre>
+        ///   The <see cref="IExtractionPlan.ExpectedSource">expected source type</see> of
+        ///   <paramref name="recursiveSteps"/> is the same as the property type of <paramref name="property"/> or is
+        ///   a base class or interface thereof
+        ///     --and--
+        ///   The <see cref="DataConverter.SourceType">SourceType</see> of <paramref name="converter"/> is the same as
+        ///   the <see cref="PropertyInfo.PropertyType">ReflectedType</see> of <paramref name="property"/>
+        /// </pre>
+        internal RecursiveExtractionPlan(PropertyInfo property, DataConverter converter,
+            IExtractionPlan recursiveSteps) {
+
+            Debug.Assert(property is not null);
+            Debug.Assert(converter is not null);
+            Debug.Assert(recursiveSteps is not null);
+            Debug.Assert(property.ReflectedType is not null);
+            Debug.Assert(property.PropertyType.IsInstanceOf(converter.SourceType));
+            Debug.Assert(converter.SourceType.IsInstanceOf(recursiveSteps.ExpectedSource));
+
+            ExpectedSource = property.ReflectedType!;
+            property_ = property;
+            converter_ = converter;
+            recursiveSteps_ = recursiveSteps;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<DBValue> Execute(object? source) {
+            Debug.Assert(source is null || ExpectedSource.IsInstanceOfType(source));
+
+            if (source is null) {
+                return recursiveSteps_.Execute(null);
+            }
+
+            var raw = property_.GetValue(source);
+            var converted = converter_.Convert(raw);
+            return recursiveSteps_.Execute(converted);
+        }
+
+
+        private readonly PropertyInfo property_;
+        private readonly DataConverter converter_;
+        private readonly IExtractionPlan recursiveSteps_;
+    }
+}

--- a/src/Kvasir/Extraction/SingleExtractionStep.cs
+++ b/src/Kvasir/Extraction/SingleExtractionStep.cs
@@ -1,0 +1,81 @@
+﻿using Cybele.Extensions;
+using Kvasir.Core;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Kvasir.Extraction {
+    /// <summary>
+    ///   An <see cref="IExtractionPlan"/> in which only a single property's value is read via reflection.
+    /// </summary>
+    public sealed class SingleExtractionStep : IExtractionPlan {
+        /// <inheritdoc/>
+        public Type ExpectedSource { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="SingleExtractionStep"/>.
+        /// </summary>
+        /// <param name="property">
+        ///   The <see cref="PropertyInfo"/> describing the property whose value is to be extracted by the new
+        ///   <see cref="SingleExtractionStep"/>.
+        /// </param>
+        /// <param name="converter">
+        ///   The converter to apply to the extracted value. If no conversion is necessary, use an
+        ///   <see cref="DataConverter.Identity{T}">identity conversion</see>.
+        /// </param>
+        /// <pre>
+        ///   The <see cref="DataConverter.SourceType">SourceType</see> of <paramref name="converter"/> is the same as
+        ///   the <see cref="PropertyInfo.PropertyType">ReflectedType</see> of <paramref name="property"/>
+        ///     --and--
+        ///   The <see cref="DataConverter.ResultType">ResultType</see> of <paramref name="converter"/> is supported by
+        ///   the Framework.
+        /// </pre>
+        internal SingleExtractionStep(PropertyInfo property, DataConverter converter) {
+            Debug.Assert(property is not null);
+            Debug.Assert(converter is not null);
+            Debug.Assert(property.ReflectedType is not null);
+            Debug.Assert(property.PropertyType.IsInstanceOf(converter.SourceType));
+            Debug.Assert(DBType.IsSupported(converter.ResultType));
+
+            ExpectedSource = property.ReflectedType;
+            property_ = property;
+            converter_ = converter;
+        }
+
+        /// <summary>
+        ///   Execute this <see cref="IExtractionPlan"/> on an input object, extracting the single configured value
+        ///   from one of its properties.
+        /// </summary>
+        /// <param name="source">
+        ///   The source object.
+        /// </param>
+        /// <pre>
+        ///   <see cref="ExpectedSource"/> is the same as the type of <paramref name="source"/> or is a base class or
+        ///   interface thereof.
+        /// </pre>
+        /// <returns>
+        ///   The value extracted from <paramref name="source"/> according to this <see cref="SingleExtractionStep"/>.
+        /// </returns>
+        public DBValue Execute(object? source) {
+            Debug.Assert(source is null || ExpectedSource.IsInstanceOfType(source));
+
+            if (source is null) {
+                return DBValue.Create(converter_.Convert(null));
+            }
+
+            var raw = property_.GetValue(source);
+            return DBValue.Create(converter_.Convert(raw));
+        }
+
+        /// <inheritdoc/>
+        IEnumerable<DBValue> IExtractionPlan.Execute(object? source) {
+            return new List<DBValue>() { Execute(source) };
+        }
+
+
+        private readonly PropertyInfo property_;
+        private readonly DataConverter converter_;
+    }
+}

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -74,7 +74,32 @@
               <paramref name="convert"/>.
             </returns>
         </member>
-        <!-- Badly formed XML comment ignored for member "M:Kvasir.Core.DataConverter.Create``2(System.Converter{``0,``1},System.Converter{``1,``0})" -->
+        <member name="M:Kvasir.Core.DataConverter.Create``2(System.Converter{``0,``1},System.Converter{``1,``0})">
+            <summary>
+              Creates a new <see cref="T:Kvasir.Core.DataConverter"/> that is <see cref="P:Kvasir.Core.DataConverter.IsBidirectional">bidirectional</see>.
+            </summary>
+            <typeparam name="TSource">
+              The <see cref="P:Kvasir.Core.DataConverter.SourceType"/> of the new <see cref="T:Kvasir.Core.DataConverter"/>.
+            </typeparam>
+            <typeparam name="TResult">
+              The <see cref="P:Kvasir.Core.DataConverter.ResultType"/> of the new <see cref="T:Kvasir.Core.DataConverter"/>.
+            </typeparam>
+            <param name="convert">
+              The function by which the new <see cref="T:Kvasir.Core.DataConverter"/> is to convert instances of
+              <see cref="P:Kvasir.Core.DataConverter.SourceType"/> (i.e. <typeparamref name="TSource"/>) into instances of <see cref="P:Kvasir.Core.DataConverter.ResultType"/>
+              (i.e. <typeparamref name="TResult"/>).
+            </param>
+            <param name="revert">
+              The function by which the new <see cref="T:Kvasir.Core.DataConverter"/> is to convert instances of
+              <see cref="P:Kvasir.Core.DataConverter.ResultType"/> (i.e. <typeparamref name="TResult"/>) into instances of <see cref="P:Kvasir.Core.DataConverter.SourceType"/>
+              (i.e. <typeparamref name="TSource"/>).
+            </param>
+            <returns>
+              A new bidirectional <see cref="T:Kvasir.Core.DataConverter"/> that converts from instances of
+              <typeparamref name="TSource"/> into instances of <typeparamref name="TResult"/> using
+              <paramref name="convert"/> and vice-versa using <paramref name="revert"/>.
+            </returns>
+        </member>
         <member name="M:Kvasir.Core.DataConverter.Convert(System.Object)">
             <summary>
               Converts an instance of <see cref="P:Kvasir.Core.DataConverter.SourceType"/> into an instance of <see cref="P:Kvasir.Core.DataConverter.ResultType"/>.
@@ -147,6 +172,143 @@
               The function by which the new <see cref="T:Kvasir.Core.DataConverter"/> is to convert instances of
               <see cref="P:Kvasir.Core.DataConverter.ResultType"/> into instances of <see cref="P:Kvasir.Core.DataConverter.SourceType"/>, if such a function is supported.
             </param>
+        </member>
+        <member name="T:Kvasir.Extraction.ExtractionPlan">
+            <summary>
+              An <see cref="T:Kvasir.Extraction.IExtractionPlan"/> comprised of sub-plans that, collectively, extract one or more values from
+              an input object.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Extraction.ExtractionPlan.ExpectedSource">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Extraction.ExtractionPlan.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Extraction.IExtractionPlan})">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Extraction.ExtractionPlan"/>.
+            </summary>
+            <param name="steps">
+              The constituent steps that make up the new <see cref="T:Kvasir.Extraction.ExtractionPlan"/> in the order in which they are
+              to be executed.
+            </param>
+            <pre>
+              <paramref name="steps"/> is not empty
+                --and--
+              each element of <paramref name="steps"/> has the same <see cref="P:Kvasir.Extraction.ExtractionPlan.ExpectedSource"/>.
+            </pre>
+        </member>
+        <member name="M:Kvasir.Extraction.ExtractionPlan.Execute(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Kvasir.Extraction.IExtractionPlan">
+            <summary>
+              The interface describing how to extract one or more values from the properties of an input object.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Extraction.IExtractionPlan.ExpectedSource">
+            <summary>
+              The expected <see cref="T:System.Type"/> of the source object on which this <see cref="T:Kvasir.Extraction.IExtractionPlan"/> can be
+              executed.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Extraction.IExtractionPlan.Execute(System.Object)">
+            <summary>
+              Execute this <see cref="T:Kvasir.Extraction.IExtractionPlan"/> on an input object, extracting one or more values from its
+              properties.
+            </summary>
+            <param name="source">
+              The source object.
+            </param>
+            <pre>
+              <see cref="P:Kvasir.Extraction.IExtractionPlan.ExpectedSource"/> is the same as the type of <paramref name="source"/> or is a base class or
+              interface thereof.
+            </pre>
+            <returns>
+              An ordered sequence of values extracted from <paramref name="source"/> according to this
+              <see cref="T:Kvasir.Extraction.IExtractionPlan"/>.
+            </returns>
+        </member>
+        <member name="T:Kvasir.Extraction.RecursiveExtractionPlan">
+            <summary>
+              An <see cref="T:Kvasir.Extraction.IExtractionPlan"/> that recursively executes an <see cref="T:Kvasir.Extraction.IExtractionPlan"/> on a single
+              extracted value.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Extraction.RecursiveExtractionPlan.ExpectedSource">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Extraction.RecursiveExtractionPlan.#ctor(System.Reflection.PropertyInfo,Kvasir.Core.DataConverter,Kvasir.Extraction.IExtractionPlan)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Extraction.RecursiveExtractionPlan"/>.
+            </summary>
+            <param name="property">
+              The <see cref="T:System.Reflection.PropertyInfo"/> describing the property whose value is to be initially extracted by the
+              new <see cref="T:Kvasir.Extraction.RecursiveExtractionPlan"/>. That extracted value is then the input to the recursive plan.
+            </param>
+            <param name="converter">
+              The converter to apply to the extracted value. If no conversion is necessary, use an
+              <see cref="M:Kvasir.Core.DataConverter.Identity``1">identity conversion</see>.
+            </param>
+            <param name="recursiveSteps">
+              The <see cref="T:Kvasir.Extraction.IExtractionPlan"/> to be recursively executed on the extracted value.
+            </param>
+            <pre>
+              The <see cref="P:Kvasir.Extraction.IExtractionPlan.ExpectedSource">expected source type</see> of
+              <paramref name="recursiveSteps"/> is the same as the property type of <paramref name="property"/> or is
+              a base class or interface thereof
+                --and--
+              The <see cref="P:Kvasir.Core.DataConverter.SourceType">SourceType</see> of <paramref name="converter"/> is the same as
+              the <see cref="P:System.Reflection.PropertyInfo.PropertyType">ReflectedType</see> of <paramref name="property"/>
+            </pre>
+        </member>
+        <member name="M:Kvasir.Extraction.RecursiveExtractionPlan.Execute(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Kvasir.Extraction.SingleExtractionStep">
+            <summary>
+              An <see cref="T:Kvasir.Extraction.IExtractionPlan"/> in which only a single property's value is read via reflection.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Extraction.SingleExtractionStep.ExpectedSource">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Extraction.SingleExtractionStep.#ctor(System.Reflection.PropertyInfo,Kvasir.Core.DataConverter)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Extraction.SingleExtractionStep"/>.
+            </summary>
+            <param name="property">
+              The <see cref="T:System.Reflection.PropertyInfo"/> describing the property whose value is to be extracted by the new
+              <see cref="T:Kvasir.Extraction.SingleExtractionStep"/>.
+            </param>
+            <param name="converter">
+              The converter to apply to the extracted value. If no conversion is necessary, use an
+              <see cref="M:Kvasir.Core.DataConverter.Identity``1">identity conversion</see>.
+            </param>
+            <pre>
+              The <see cref="P:Kvasir.Core.DataConverter.SourceType">SourceType</see> of <paramref name="converter"/> is the same as
+              the <see cref="P:System.Reflection.PropertyInfo.PropertyType">ReflectedType</see> of <paramref name="property"/>
+                --and--
+              The <see cref="P:Kvasir.Core.DataConverter.ResultType">ResultType</see> of <paramref name="converter"/> is supported by
+              the Framework.
+            </pre>
+        </member>
+        <member name="M:Kvasir.Extraction.SingleExtractionStep.Execute(System.Object)">
+            <summary>
+              Execute this <see cref="T:Kvasir.Extraction.IExtractionPlan"/> on an input object, extracting the single configured value
+              from one of its properties.
+            </summary>
+            <param name="source">
+              The source object.
+            </param>
+            <pre>
+              <see cref="P:Kvasir.Extraction.SingleExtractionStep.ExpectedSource"/> is the same as the type of <paramref name="source"/> or is a base class or
+              interface thereof.
+            </pre>
+            <returns>
+              The value extracted from <paramref name="source"/> according to this <see cref="T:Kvasir.Extraction.SingleExtractionStep"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Extraction.SingleExtractionStep.Kvasir#Extraction#IExtractionPlan#Execute(System.Object)">
+            <inheritdoc/>
         </member>
         <member name="T:Kvasir.Schema.BasicField">
             <summary>

--- a/test/UnitTests/Cybele/Extensions/IEnumerable.cs
+++ b/test/UnitTests/Cybele/Extensions/IEnumerable.cs
@@ -245,4 +245,95 @@ namespace UT.Cybele.Extensions {
             meetsNone.Should().BeFalse();
         }
     }
+
+    [TestClass, TestCategory("IEnumerable: AllSame")]
+    public sealed class IEnumerable_AllSame : ExtensionTests {
+        [TestMethod] public void EmptyAllSameDefaultComparer() {
+            // Arrange
+            var empty = new List<string>();
+
+            // Act
+            var allSame = empty.AllSame(s => s.Length);
+
+            // Assert
+            allSame.Should().BeTrue();
+        }
+
+        [TestMethod] public void SingleAllSameDefaultComparer() {
+            // Arrange
+            var cities = new List<string>() { "Anaheim" };
+
+            // Act
+            var allSame = cities.AllSame(s => s.ToUpper());
+
+            // Assert
+            allSame.Should().BeTrue();
+        }
+
+        [TestMethod] public void MultipleAllSameDefaultComparer() {
+            // Arrange
+            var cities = new List<string>() { "Baton Rouge", "Laredo", "Madison", "Santa Fe" };
+
+            // Act
+            var allSame = cities.AllSame(s => s[1]);
+
+            // Assert
+            allSame.Should().BeTrue();
+        }
+
+        [TestMethod] public void MultipleNotAllSameDefaultComparer() {
+            // Arrange
+            var cities = new List<string>() { "Shreveport", "Tallahassee", "Tampa", "Waco", "Tucson" };
+
+            // Act
+            var allSame = cities.AllSame(s => s.Length);
+
+            // Assert
+            allSame.Should().BeFalse();
+        }
+
+        [TestMethod] public void EmptyAllSameCustomComparer() {
+            // Arrange
+            var empty = new List<string>();
+
+            // Act
+            var allSame = empty.AllSame(s => s.ToLower(), StringComparer.OrdinalIgnoreCase);
+
+            // Assert
+            allSame.Should().BeTrue();
+        }
+
+        [TestMethod] public void SingleAllSameCustomComparer() {
+            // Arrange
+            var cities = new List<string>() { "Jackson" };
+
+            // Act
+            var allSame = cities.AllSame(s => s.ToUpper(), StringComparer.OrdinalIgnoreCase);
+
+            // Assert
+            allSame.Should().BeTrue();
+        }
+
+        [TestMethod] public void MultipleAllSameCustomComparer() {
+            // Arrange
+            var cities = new List<string>() { "Glendale", "PLANO" };
+
+            // Act
+            var allSame = cities.AllSame(s => s[1].ToString(), StringComparer.OrdinalIgnoreCase);
+
+            // Assert
+            allSame.Should().BeTrue();
+        }
+
+        [TestMethod] public void MultipleNotAllSameCustomComparer() {
+            // Arrange
+            var cities = new List<string>() { "Winston-Salem", "North Las Vegas", "Bismarck" };
+
+            // Act
+            var allSame = cities.AllSame(s => s, StringComparer.OrdinalIgnoreCase);
+
+            // Assert
+            allSame.Should().BeFalse();
+        }
+    }
 }

--- a/test/UnitTests/Cybele/Extensions/Type.cs
+++ b/test/UnitTests/Cybele/Extensions/Type.cs
@@ -1,0 +1,152 @@
+﻿using Cybele.Extensions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace UT.Cybele.Extensions {
+    [TestClass, TestCategory("Type: IsInstanceOf")]
+    public sealed class Type_IsInstanceOf : ExtensionTests {
+        [TestMethod] public void Identity() {
+            // Arrange
+            var type = typeof(string);
+
+            // Act
+            var result = type.IsInstanceOf(type);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [TestMethod] public void DerivedClassIsInstanceOfBase() {
+            // Arrange
+            var parent = typeof(Exception);
+            var child = typeof(ArgumentNullException);
+
+            // Act
+            var result = child.IsInstanceOf(parent);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [TestMethod] public void BaseClassIsNotInstanceOfDerived() {
+            // Arrange
+            var parent = typeof(Exception);
+            var child = typeof(ArgumentNullException);
+
+            // Act
+            var result = parent.IsInstanceOf(child);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [TestMethod] public void ImplementationIsInstanceOfInterface() {
+            // Arrange
+            var intfc = typeof(IEquatable<string>);
+            var impl = typeof(string);
+
+            // Act
+            var result = impl.IsInstanceOf(intfc);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [TestMethod] public void InterfaceIsNotInstanceOfImplementation() {
+            // Arrange
+            var intfc = typeof(IEquatable<string>);
+            var impl = typeof(string);
+
+            // Act
+            var result = intfc.IsInstanceOf(impl);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [TestMethod] public void WhatIsInstanceOfObject() {
+            // Arrange
+            var obj = typeof(object);
+
+            // Act
+            var classResult = typeof(string).IsInstanceOf(obj);
+            var structResult = typeof(DateTime).IsInstanceOf(obj);
+            var primitiveResult = typeof(short).IsInstanceOf(obj);
+            var enumResult = typeof(Color).IsInstanceOf(obj);
+            var delegateResult = typeof(Func<int, int>).IsInstanceOf(obj);
+            var interfaceResult = typeof(IDisposable).IsInstanceOf(obj);
+
+            // Assert
+            classResult.Should().BeTrue();
+            structResult.Should().BeTrue();
+            primitiveResult.Should().BeTrue();
+            enumResult.Should().BeTrue();
+            delegateResult.Should().BeTrue();
+            interfaceResult.Should().BeTrue();
+        }
+
+        [TestMethod] public void WhatIsInstanceOfValueType() {
+            // Arrange
+            var vt = typeof(ValueType);
+
+            // Act
+            var classResult = typeof(string).IsInstanceOf(vt);
+            var structResult = typeof(DateTime).IsInstanceOf(vt);
+            var primitiveResult = typeof(short).IsInstanceOf(vt);
+            var enumResult = typeof(Color).IsInstanceOf(vt);
+            var delegateResult = typeof(Func<int, int>).IsInstanceOf(vt);
+            var interfaceResult = typeof(IDisposable).IsInstanceOf(vt);
+
+            // Assert
+            classResult.Should().BeFalse();
+            structResult.Should().BeTrue();
+            primitiveResult.Should().BeTrue();
+            enumResult.Should().BeTrue();
+            delegateResult.Should().BeFalse();
+            interfaceResult.Should().BeFalse();
+        }
+
+        [TestMethod] public void WhatIsInstanceOfEnum() {
+            // Arrange
+            var enumeration = typeof(Enum);
+
+            // Act
+            var classResult = typeof(string).IsInstanceOf(enumeration);
+            var structResult = typeof(DateTime).IsInstanceOf(enumeration);
+            var primitiveResult = typeof(short).IsInstanceOf(enumeration);
+            var enumResult = typeof(Color).IsInstanceOf(enumeration);
+            var delegateResult = typeof(Func<int, int>).IsInstanceOf(enumeration);
+            var interfaceResult = typeof(IDisposable).IsInstanceOf(enumeration);
+
+            // Assert
+            classResult.Should().BeFalse();
+            structResult.Should().BeFalse();
+            primitiveResult.Should().BeFalse();
+            enumResult.Should().BeTrue();
+            delegateResult.Should().BeFalse();
+            interfaceResult.Should().BeFalse();
+        }
+
+        [TestMethod] public void WhatIsInstanceOfDelegate() {
+            // Arrange
+            var dgte = typeof(Delegate);
+
+            // Act
+            var classResult = typeof(string).IsInstanceOf(dgte);
+            var structResult = typeof(DateTime).IsInstanceOf(dgte);
+            var primitiveResult = typeof(short).IsInstanceOf(dgte);
+            var enumResult = typeof(Color).IsInstanceOf(dgte);
+            var delegateResult = typeof(Func<int, int>).IsInstanceOf(dgte);
+            var interfaceResult = typeof(IDisposable).IsInstanceOf(dgte);
+
+            // Assert
+            classResult.Should().BeFalse();
+            structResult.Should().BeFalse();
+            primitiveResult.Should().BeFalse();
+            enumResult.Should().BeFalse();
+            delegateResult.Should().BeTrue();
+            interfaceResult.Should().BeFalse();
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Core/DataConverter.cs
+++ b/test/UnitTests/Kvasir/Core/DataConverter.cs
@@ -184,24 +184,30 @@ namespace UT.Kvasir.Core {
 
         [TestMethod] public void ConvertNull() {
             // Arrange
-            var converter = DataConverter.Identity<string>();
+            var classConverter = DataConverter.Identity<string>();
+            var structConverter = DataConverter.Identity<int>();
 
             // Act
-            var conversion = converter.Convert(null);
+            var classConversion = classConverter.Convert(null);
+            var structConversion = structConverter.Convert(null);
 
             // Assert
-            conversion.Should().BeNull();
+            classConversion.Should().BeNull();
+            structConversion.Should().BeNull();
         }
 
         [TestMethod] public void RevertNull() {
             // Arrange
-            var converter = DataConverter.Identity<string>();
+            var classConverter = DataConverter.Identity<string>();
+            var structConverter = DataConverter.Identity<int>();
 
             // Act
-            var reversion = converter.Revert(null);
+            var classReversion = classConverter.Revert(null);
+            var structReversion = structConverter.Revert(null);
 
             // Assert
-            reversion.Should().BeNull();
+            classReversion.Should().BeNull();
+            structReversion.Should().BeNull();
         }
     }
 }

--- a/test/UnitTests/Kvasir/Extraction/Extraction.cs
+++ b/test/UnitTests/Kvasir/Extraction/Extraction.cs
@@ -1,0 +1,364 @@
+﻿using FluentAssertions;
+using Kvasir.Core;
+using Kvasir.Extraction;
+using Kvasir.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UT.Kvasir.Extraction {
+    [TestClass]
+    public class SingleStepExtractionPlanTests {
+        [TestMethod, TestCategory("Single Step")]
+        public void Construction() {
+            // Arrange
+            var property = typeof(string).GetProperty(nameof(string.Length))!;
+            var converter = DataConverter.Identity<int>();
+
+            // Act
+            var plan = new SingleExtractionStep(property, converter);
+
+            // Assert
+            plan.ExpectedSource.Should().Be(typeof(string));
+        }
+
+        [TestMethod, TestCategory("Single Step")]
+        public void ExtractFromActualWithoutConversion() {
+            // Arrange
+            var property = typeof(string).GetProperty(nameof(string.Length))!;
+            var converter = DataConverter.Identity<int>();
+            var plan = new SingleExtractionStep(property, converter);
+            var source = "Corpus Christi";
+
+            // Act
+            var value = plan.Execute(source);
+
+            // Assert
+            value.Should().Be(DBValue.Create(converter.Convert(source.Length)));
+        }
+
+        [TestMethod, TestCategory("Single Step")]
+        public void ExtractFromActualWithConversion() {
+            // Arrange
+            var property = typeof(string).GetProperty(nameof(string.Length))!;
+            var converter = DataConverter.Create<int, string>(i => i.ToString());
+            var plan = new SingleExtractionStep(property, converter);
+            var source = "Sioux City";
+
+            // Act
+            var value = (plan as IExtractionPlan).Execute(source);
+
+            // Assert
+            value.Count().Should().Be(1);
+            value.First().Should().Be(DBValue.Create(converter.Convert(source.Length)));
+        }
+
+        [TestMethod, TestCategory("Single Step")]
+        public void ExtractFromDerived() {
+            // Arrange
+            var property = typeof(Exception).GetProperty(nameof(Exception.Message))!;
+            var converter = DataConverter.Identity<string>();
+            var plan = new SingleExtractionStep(property, converter);
+            var source = new NullReferenceException("Galveston");
+
+            // Act
+            var value = plan.Execute(source);
+
+            // Assert
+            value.Should().Be(DBValue.Create(converter.Convert(source.Message)));
+        }
+
+        [TestMethod, TestCategory("Single Step")]
+        public void ExtractFromImplementation() {
+            // Arrange
+            var property = typeof(ICollection<string>).GetProperty(nameof(ICollection<string>.Count))!;
+            var converter = DataConverter.Identity<int>();
+            var plan = new SingleExtractionStep(property, converter);
+            var source = new List<string>() { "Philadelphia", "Dayton", "Savannah", "Salem", "Annapolis" };
+
+            // Act
+            var value = plan.Execute(source);
+
+            // Assert
+            value.Should().Be(DBValue.Create(converter.Convert(source.Count)));
+        }
+
+        [TestMethod, TestCategory("Single Step")]
+        public void ExtractFromNull() {
+            // Arrange
+            var property = typeof(string).GetProperty(nameof(string.Length))!;
+            var converter = DataConverter.Identity<int>();
+            var plan = new SingleExtractionStep(property, converter);
+            string? source = null;
+
+            // Act
+            var value = plan.Execute(source);
+
+            // Assert
+            value.Should().Be(DBValue.NULL);
+        }
+    }
+
+    [TestClass]
+    public class RecursiveExtractionPlanTets {
+        [TestMethod, TestCategory("Recursive")]
+        public void ConstructionIdenticalConnection() {
+            // Arrange
+            var property = typeof(Exception).GetProperty(nameof(Exception.Message))!;
+            var converter = DataConverter.Identity<string>();
+            var mockRest = new Mock<IExtractionPlan>();
+            mockRest.Setup(p => p.ExpectedSource).Returns(typeof(string));
+
+            // Act
+            var plan = new RecursiveExtractionPlan(property, converter, mockRest.Object);
+
+            // Assert
+            plan.ExpectedSource.Should().Be(typeof(Exception));
+        }
+
+        [TestMethod, TestCategory("Recursive")]
+        public void ConstructBaseClassConnection() {
+            // Arrange
+            var property = typeof(Exception).GetProperty(nameof(Exception.Message))!;
+            var converter = DataConverter.Identity<string>();
+            var mockRest = new Mock<IExtractionPlan>();
+            mockRest.Setup(p => p.ExpectedSource).Returns(typeof(object));
+
+            // Act
+            var plan = new RecursiveExtractionPlan(property, converter, mockRest.Object);
+
+            // Assert
+            plan.ExpectedSource.Should().Be(typeof(Exception));
+        }
+
+        [TestMethod, TestCategory("Recursive")]
+        public void ConstructInterfaceConnection() {
+            // Arrange
+            var property = typeof(Exception).GetProperty(nameof(Exception.Message))!;
+            var converter = DataConverter.Identity<string>();
+            var mockRest = new Mock<IExtractionPlan>();
+            mockRest.Setup(p => p.ExpectedSource).Returns(typeof(IEquatable<string>));
+
+            // Act
+            var plan = new RecursiveExtractionPlan(property, converter, mockRest.Object);
+
+            // Assert
+            plan.ExpectedSource.Should().Be(typeof(Exception));
+        }
+
+        [TestMethod, TestCategory("Recursive")]
+        public void ExtractFromActualWithoutConversion() {
+            // Arrange
+            var property = typeof(string).GetProperty(nameof(string.Length))!;
+            var converter = DataConverter.Identity<int>();
+            var mockRest = new Mock<IExtractionPlan>();
+            mockRest.Setup(p => p.ExpectedSource).Returns(typeof(int));
+            mockRest.Setup(p => p.Execute(It.IsAny<object>())).Returns(new List<DBValue>());
+            var plan = new RecursiveExtractionPlan(property, converter, mockRest.Object);
+            var source = "Manchester";
+
+            // Act
+            plan.Execute(source);
+
+            // Assert
+            mockRest.Verify(p => p.Execute(source.Length));
+        }
+
+        [TestMethod, TestCategory("Recursive")]
+        public void ExtractFromActualWithConversion() {
+            // Arrange
+            var property = typeof(string).GetProperty(nameof(string.Length))!;
+            var converter = DataConverter.Create<int, string>(i => i.ToString());
+            var mockRest = new Mock<IExtractionPlan>();
+            mockRest.Setup(p => p.ExpectedSource).Returns(typeof(int));
+            mockRest.Setup(p => p.Execute(It.IsAny<object>())).Returns(new List<DBValue>());
+            var plan = new RecursiveExtractionPlan(property, converter, mockRest.Object);
+            var source = "Lexington";
+
+            // Act
+            plan.Execute(source);
+
+            // Assert
+            mockRest.Verify(p => p.Execute(converter.Convert(source.Length)));
+        }
+
+        [TestMethod, TestCategory("Recursive")]
+        public void ExtractFromDerived() {
+            // Arrange
+            var property = typeof(Exception).GetProperty(nameof(Exception.Message))!;
+            var converter = DataConverter.Identity<string>();
+            var mockRest = new Mock<IExtractionPlan>();
+            mockRest.Setup(p => p.ExpectedSource).Returns(typeof(string));
+            mockRest.Setup(p => p.Execute(It.IsAny<object>())).Returns(new List<DBValue>());
+            var plan = new RecursiveExtractionPlan(property, converter, mockRest.Object);
+            var source = new NullReferenceException("Mesa");
+
+            // Act
+            plan.Execute(source);
+
+            // Assert
+            mockRest.Verify(p => p.Execute(source.Message));
+        }
+
+        [TestMethod, TestCategory("Recursive")]
+        public void ExtractFromImplementation() {
+            // Arrange
+            var property = typeof(ICollection<string>).GetProperty(nameof(ICollection<string>.Count))!;
+            var converter = DataConverter.Identity<int>();
+            var mockRest = new Mock<IExtractionPlan>();
+            mockRest.Setup(p => p.ExpectedSource).Returns(typeof(int));
+            mockRest.Setup(p => p.Execute(It.IsAny<object>())).Returns(new List<DBValue>());
+            var plan = new RecursiveExtractionPlan(property, converter, mockRest.Object);
+            var source = new List<string>() { "Long Beach", "St. Paul", "Chattanooga", "Dallas" };
+
+            // Act
+            plan.Execute(source);
+
+            // Assert
+            mockRest.Verify(p => p.Execute(source.Count));
+        }
+
+        [TestMethod, TestCategory("Recursive")]
+        public void ExtractFromNull() {
+            // Arrange
+            var property = typeof(string).GetProperty(nameof(string.Length))!;
+            var converter = DataConverter.Identity<int>();
+            var mockRest = new Mock<IExtractionPlan>();
+            mockRest.Setup(p => p.ExpectedSource).Returns(typeof(int));
+            mockRest.Setup(p => p.Execute(It.IsAny<object>())).Returns(new List<DBValue>());
+            var plan = new RecursiveExtractionPlan(property, converter, mockRest.Object);
+            string? source = null;
+
+            // Act
+            plan.Execute(source);
+
+            // Assert
+            mockRest.Verify(p => p.Execute(null));
+        }
+    }
+
+    [TestClass]
+    public class ExtractionPlanTests {
+        [TestMethod, TestCategory("Full Plan")]
+        public void Construction() {
+            // Arrange
+            var mockPlan1 = new Mock<IExtractionPlan>();
+            mockPlan1.Setup(p => p.ExpectedSource).Returns(typeof(string));
+            var mockPlan2 = new Mock<IExtractionPlan>();
+            mockPlan2.Setup(p => p.ExpectedSource).Returns(typeof(string));
+            var mockPlans = new List<IExtractionPlan>() { mockPlan1.Object, mockPlan2.Object };
+
+            // Act
+            var plan = new ExtractionPlan(mockPlans);
+
+            // Assert
+            plan.ExpectedSource.Should().Be(typeof(string));
+        }
+
+        [TestMethod, TestCategory("Full Plan")]
+        public void ExtractFromActual() {
+            // Arrange
+            var plan1Results = new List<DBValue>() { DBValue.Create(50), DBValue.Create("ABC") };
+            var mockPlan1 = new Mock<IExtractionPlan>();
+            mockPlan1.Setup(p => p.ExpectedSource).Returns(typeof(string));
+            mockPlan1.Setup(p => p.Execute(It.IsAny<object>())).Returns(plan1Results);
+            var plan2Results = new List<DBValue>() { DBValue.Create("DEF"), DBValue.Create('-'), DBValue.NULL };
+            var mockPlan2 = new Mock<IExtractionPlan>();
+            mockPlan2.Setup(p => p.ExpectedSource).Returns(typeof(string));
+            mockPlan2.Setup(p => p.Execute(It.IsAny<object>())).Returns(plan2Results);
+            var mockPlans = new List<IExtractionPlan>() { mockPlan1.Object, mockPlan2.Object };
+            var plan = new ExtractionPlan(mockPlans);
+            var source = "Hialeah";
+
+            // Act
+            var results = plan.Execute(source);
+
+            // Assert
+            results.Count().Should().Be(plan1Results.Count() + plan2Results.Count());
+            results.Should().StartWith(plan1Results);
+            results.Should().EndWith(plan2Results);
+            mockPlan1.Verify(p => p.Execute(source));
+            mockPlan2.Verify(p => p.Execute(source));
+        }
+
+        [TestMethod, TestCategory("Full Plan")]
+        public void ExtractFromDerived() {
+            // Arrange
+            var plan1Results = new List<DBValue>() { DBValue.Create(50), DBValue.Create("ABC") };
+            var mockPlan1 = new Mock<IExtractionPlan>();
+            mockPlan1.Setup(p => p.ExpectedSource).Returns(typeof(Exception));
+            mockPlan1.Setup(p => p.Execute(It.IsAny<object>())).Returns(plan1Results);
+            var plan2Results = new List<DBValue>() { DBValue.Create("DEF"), DBValue.Create('-'), DBValue.NULL };
+            var mockPlan2 = new Mock<IExtractionPlan>();
+            mockPlan2.Setup(p => p.ExpectedSource).Returns(typeof(Exception));
+            mockPlan2.Setup(p => p.Execute(It.IsAny<object>())).Returns(plan2Results);
+            var mockPlans = new List<IExtractionPlan>() { mockPlan1.Object, mockPlan2.Object };
+            var plan = new ExtractionPlan(mockPlans);
+            var source = new NullReferenceException("Anchorage");
+
+            // Act
+            var results = plan.Execute(source);
+
+            // Assert
+            results.Count().Should().Be(plan1Results.Count() + plan2Results.Count());
+            results.Should().StartWith(plan1Results);
+            results.Should().EndWith(plan2Results);
+            mockPlan1.Verify(p => p.Execute(source));
+            mockPlan2.Verify(p => p.Execute(source));
+        }
+
+        [TestMethod, TestCategory("Full Plan")]
+        public void ExtractFromImplementation() {
+            // Arrange
+            var plan1Results = new List<DBValue>() { DBValue.Create(50), DBValue.Create("ABC") };
+            var mockPlan1 = new Mock<IExtractionPlan>();
+            mockPlan1.Setup(p => p.ExpectedSource).Returns(typeof(IEquatable<string>));
+            mockPlan1.Setup(p => p.Execute(It.IsAny<object>())).Returns(plan1Results);
+            var plan2Results = new List<DBValue>() { DBValue.Create("DEF"), DBValue.Create('-'), DBValue.NULL };
+            var mockPlan2 = new Mock<IExtractionPlan>();
+            mockPlan2.Setup(p => p.ExpectedSource).Returns(typeof(IEquatable<string>));
+            mockPlan2.Setup(p => p.Execute(It.IsAny<object>())).Returns(plan2Results);
+            var mockPlans = new List<IExtractionPlan>() { mockPlan1.Object, mockPlan2.Object };
+            var plan = new ExtractionPlan(mockPlans);
+            var source = "Colorado Springs";
+
+            // Act
+            var results = plan.Execute(source);
+
+            // Assert
+            results.Count().Should().Be(plan1Results.Count() + plan2Results.Count());
+            results.Should().StartWith(plan1Results);
+            results.Should().EndWith(plan2Results);
+            mockPlan1.Verify(p => p.Execute(source));
+            mockPlan2.Verify(p => p.Execute(source));
+        }
+
+        [TestMethod, TestCategory("Full Plan")]
+        public void ExtractFromNull() {
+            // Arrange
+            var plan1Results = new List<DBValue>() { DBValue.Create(50), DBValue.Create("ABC") };
+            var mockPlan1 = new Mock<IExtractionPlan>();
+            mockPlan1.Setup(p => p.ExpectedSource).Returns(typeof(string));
+            mockPlan1.Setup(p => p.Execute(It.IsAny<object>())).Returns(plan1Results);
+            var plan2Results = new List<DBValue>() { DBValue.Create("DEF"), DBValue.Create('-'), DBValue.NULL };
+            var mockPlan2 = new Mock<IExtractionPlan>();
+            mockPlan2.Setup(p => p.ExpectedSource).Returns(typeof(string));
+            mockPlan2.Setup(p => p.Execute(It.IsAny<object>())).Returns(plan2Results);
+            var mockPlans = new List<IExtractionPlan>() { mockPlan1.Object, mockPlan2.Object };
+            var plan = new ExtractionPlan(mockPlans);
+            string? source = null;
+
+            // Act
+            var results = plan.Execute(source);
+
+            // Assert
+            results.Count().Should().Be(plan1Results.Count() + plan2Results.Count());
+            results.Should().StartWith(plan1Results);
+            results.Should().EndWith(plan2Results);
+            mockPlan1.Verify(p => p.Execute(source));
+            mockPlan2.Verify(p => p.Execute(source));
+        }
+    }
+}

--- a/test/UnitTests/_TestCities.txt
+++ b/test/UnitTests/_TestCities.txt
@@ -4,13 +4,19 @@
 Akron
 Albuquerque
 Amarillo
+Anaheim
+Anchorage
 Ann Arbor
+Annapolis
 Atlanta
 Atlantic City
 Augusta
+Austin
 Baltimore
+Baton Rouge
 Biloxi
 Birmingham
+Bismarck
 Boise
 Boston
 Buffalo
@@ -18,9 +24,14 @@ Canton
 Carson City
 Charleston
 Charlotte
+Chattanooga
 Chicago
 Cincinnati
 Cleveland
+Colorado Springs
+Corpus Christi
+Dallas
+Dayton
 Denver
 Des Moines
 Dover
@@ -29,25 +40,35 @@ Fairbanks
 Flagstaff
 Fort Wayne
 Fresno
+Galveston
+Glendale
 Green Bay
 Greensboro
 Hartford
 Helena
+Hialeah
 Honolulu
 Houston
 Indianapolis
 Ithaca
+Jackson
 Jacksonville
 Jersey City
 Juneau
 Kansas City
 Lansing
 Laramie
+Laredo
 Las Vegas
+Lexington
 Little Rock
+Long Beach
 Los Angeles
 Louisville
+Madison
+Manchester
 Memphis
+Mesa
 Miami
 Milwaukee
 Minneapolis
@@ -59,30 +80,44 @@ New Haven
 New Orleans
 New York City
 Norfolk
+North Las Vegas
 Oakland
 Oklahoma City
 Omaha
 Orlando
 Peoria
+Philadelphia
 Phoenix
 Pittsburgh
+Plano
 Portland
 Raleigh
 Reno
+Salem
 San Antonio
 San Diego
 San Francisco
 San Jose
+Santa Fe
+Savannah
 Seattle
+Shreveport
+Sioux City
 Spokane
 Springfield
 St. Louis
+St. Paul
 Tacoma
+Tallahassee
+Tampa
 Toledo
 Topeka
 Trenton
+Tucson
 Tulsa
 Virginia Beach
+Waco
 Washington, D.C.
 Wichita
+Winston-Salem
 Ypsilanti


### PR DESCRIPTION
This commit adds the logic for building ExtractionPlans, which are pipelines for pulling values out of an input object.
The IExtractionPlan instances leverage DataConverters to perform any necessary transformations and return collections of
ready-to-write DBValues. Note that the ExtractionPlans are not responsible for understanding how to create a plan: that
will be the responsibility of the translation layer, with these components solely responsible for the execution pieces.

Additionally, this commit adds two new extension methods (IEnumerable.AllSame and Type.IsInstanceOf) that were needed by
the ExtractionPlan implementations. Lastly, a bug in the DataConverter logic related to the conversion of null when a
value type is expected was fixed, and the unit tests were accordingly updated.