### PR TITLE
Reconstitution Plan

### DIFF
--- a/src/Cybele/Extensions/Type.cs
+++ b/src/Cybele/Extensions/Type.cs
@@ -27,6 +27,10 @@ namespace Cybele.Extensions {
             Guard.Against.Null(ancestorType, nameof(ancestorType));
             Guard.Against.Null(derivedType, nameof(derivedType));
 
+            if (ancestorType.IsGenericType && ancestorType.GetGenericTypeDefinition() == typeof(Nullable<>)) {
+                ancestorType = ancestorType.GetGenericArguments()[0];
+            }
+
             if (ancestorType == typeof(object)) {
                 // We need this branch called out explicitly because Interfaces do not have object in their inheritance
                 // hierarchy, so the "standard" algorithm (i.e. the following branches) would result in a false

--- a/src/Kvasir/Extraction/DecomposingExtractionStep.cs
+++ b/src/Kvasir/Extraction/DecomposingExtractionStep.cs
@@ -34,7 +34,7 @@ namespace Kvasir.Extraction {
         ///   The <see cref="IFieldExtractor.FieldType">FieldType</see> of <paramref name="extractor"/> is a data type
         ///   not supported by the Framework.
         /// </pre>
-        public DecomposingExtractionStep(IFieldExtractor extractor, IEnumerable<IExtractionStep> decomposition) {
+        internal DecomposingExtractionStep(IFieldExtractor extractor, IEnumerable<IExtractionStep> decomposition) {
             Guard.Against.Null(extractor, nameof(extractor));
             Guard.Against.Null(decomposition, nameof(decomposition));
             Debug.Assert(!decomposition.IsEmpty());

--- a/src/Kvasir/Extraction/EntityExtractionPlan.cs
+++ b/src/Kvasir/Extraction/EntityExtractionPlan.cs
@@ -40,7 +40,7 @@ namespace Kvasir.Extraction {
         ///   by <paramref name="steps"/> (note that this is not necessarily the number of elements in
         ///   <paramref name="steps"/>, as an <see cref="IExtractionStep"/> may produce multiple values).
         /// </pre>
-        public EntityExtractionPlan(IEnumerable<IExtractionStep> steps, IEnumerable<DataConverter> converters) {
+        internal EntityExtractionPlan(IEnumerable<IExtractionStep> steps, IEnumerable<DataConverter> converters) {
             Guard.Against.Null(steps, nameof(steps));
             Guard.Against.Null(converters, nameof(converters));
             Debug.Assert(!steps.IsEmpty());

--- a/src/Kvasir/Extraction/PrimitiveExtractionStep.cs
+++ b/src/Kvasir/Extraction/PrimitiveExtractionStep.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 
 namespace Kvasir.Extraction {
     /// <summary>
-    ///   A <see cref="IExtractionStep"/> that produces a single, primitive value.
+    ///   An <see cref="IExtractionStep"/> that produces a single, primitive value.
     /// </summary>
     public sealed class PrimitiveExtractionStep : IExtractionStep {
         /// <inheritdoc/>
@@ -33,7 +33,7 @@ namespace Kvasir.Extraction {
         ///   The <see cref="IFieldExtractor.FieldType">FieldType</see> of <paramref name="extractor"/> is a data type
         ///   supported by the Framework.
         /// </pre>
-        public PrimitiveExtractionStep(IFieldExtractor extractor, DataConverter converter) {
+        internal PrimitiveExtractionStep(IFieldExtractor extractor, DataConverter converter) {
             Guard.Against.Null(extractor, nameof(extractor));
             Guard.Against.Null(converter, nameof(converter));
             Debug.Assert(extractor.FieldType.IsInstanceOf(converter.SourceType));

--- a/src/Kvasir/Extraction/ReadPropertyExtractor.cs
+++ b/src/Kvasir/Extraction/ReadPropertyExtractor.cs
@@ -24,7 +24,7 @@ namespace Kvasir.Extraction {
         /// <pre>
         ///   <paramref name="property"/> is a readable instance property.
         /// </pre>
-        public ReadPropertyExtractor(PropertyInfo property) {
+        internal ReadPropertyExtractor(PropertyInfo property) {
             Guard.Against.Null(property, nameof(property));
             Debug.Assert(property.CanRead);
             Debug.Assert(!property.GetGetMethod()!.IsStatic);

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -350,7 +350,7 @@
         </member>
         <member name="T:Kvasir.Extraction.PrimitiveExtractionStep">
             <summary>
-              A <see cref="T:Kvasir.Extraction.IExtractionStep"/> that produces a single, primitive value.
+              An <see cref="T:Kvasir.Extraction.IExtractionStep"/> that produces a single, primitive value.
             </summary>
         </member>
         <member name="P:Kvasir.Extraction.PrimitiveExtractionStep.ExpectedSource">
@@ -403,6 +403,322 @@
             </pre>
         </member>
         <member name="M:Kvasir.Extraction.ReadPropertyExtractor.Execute(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Kvasir.Reconstitution.ByConstructorCreator">
+            <summary>
+              An <see cref="T:Kvasir.Reconstitution.IObjectCreator"/> that produces a single, complex CLR object by invoking a constructor via
+              reflection.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Reconstitution.ByConstructorCreator.Target">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Reconstitution.ByConstructorCreator.#ctor(System.Reflection.ConstructorInfo,System.Collections.Generic.IEnumerable{Kvasir.Reconstitution.IReconstitutor})">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Reconstitution.ByConstructorCreator"/>.
+            </summary>
+            <param name="ctor">
+              The <see cref="T:System.Reflection.ConstructorInfo"/> describing the constructor to be invoked.
+            </param>
+            <param name="argReconstitutors">
+              A list of <see cref="T:Kvasir.Reconstitution.IReconstitutor">Reconstitutors</see> to be used to create the arguments to the
+              reflection invocation of <paramref name="ctor"/>, in the order in which they are listed.
+            </param>
+            <pre>
+              <paramref name="argReconstitutors"/> is not empty
+                --and--
+              The <see cref="P:Kvasir.Reconstitution.IReconstitutor.Target">target type</see> of each element of
+              <paramref name="argReconstitutors"/> is compatible with the corresponding argument to
+              <paramref name="ctor"/>.
+            </pre>
+        </member>
+        <member name="M:Kvasir.Reconstitution.ByConstructorCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+            <inheritdoc/>
+        </member>
+        <member name="T:Kvasir.Reconstitution.EntityReconstitutionPlan">
+            <summary>
+              A description of the way in which data for a particular Entity type is to be extracted from a back-end
+              database, transformed, and reimagined as an Entity data object.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Reconstitution.EntityReconstitutionPlan.Target">
+            <summary>
+              The <see cref="T:System.Type"/> of CLR object produced by this <see cref="T:Kvasir.Reconstitution.EntityReconstitutionPlan"/>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Reconstitution.EntityReconstitutionPlan.#ctor(Kvasir.Reconstitution.IReconstitutor,System.Collections.Generic.IEnumerable{Kvasir.Core.DataConverter})">
+            <summary>
+              Construct a new <see cref="T:Kvasir.Reconstitution.EntityReconstitutionPlan"/>.
+            </summary>
+            <param name="reconstitutor">
+              The <see cref="T:Kvasir.Reconstitution.IReconstitutor"/> with which to produce the CLR object when the new
+              <see cref="T:Kvasir.Reconstitution.EntityReconstitutionPlan"/> is executed.
+            </param>
+            <param name="reverters">
+              The ordered sequence of <see cref="T:Kvasir.Core.DataConverter">data converters</see> that extrinsically transform the
+              values extracted from the back-end database..
+            </param>
+            <pre>
+              <paramref name="reverters"/> is not empty
+                --and--
+              each element of <paramref name="reverters"/> is a bidirectional <see cref="T:Kvasir.Core.DataConverter"/>.
+            </pre>
+        </member>
+        <member name="M:Kvasir.Reconstitution.EntityReconstitutionPlan.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+            <summary>
+              Execute this <see cref="T:Kvasir.Reconstitution.EntityReconstitutionPlan"/> to create a brand new CLR object from a "row" of
+              datbase values.
+            </summary>
+            <param name="rawValues">
+              The database values from which to reconstitute a CLR object.
+            </param>
+            <pre>
+              <paramref name="rawValues"/> is not empty.
+            </pre>
+            <returns>
+              A CLR object of type <see cref="P:Kvasir.Reconstitution.EntityReconstitutionPlan.Target"/> that, when run through the dedicated extractor for
+              <see cref="P:Kvasir.Reconstitution.EntityReconstitutionPlan.Target"/>, produces <paramref name="rawValues"/>.
+            </returns>
+        </member>
+        <member name="T:Kvasir.Reconstitution.IMutationStep">
+            <summary>
+              The interface that defines how an existing CLR object is modified based on a list of values extraced from a
+              back-end relational database
+            </summary>
+            <remarks>
+              <para>
+                The process of creating a CLR object from a "row" of database values is a two-step process. In the first
+                step, the object is <i>created</i>; that is, some valid CLR object is brought into existence according to
+                the APIs exposed by the target type. In the second step, that object is modified so that its state reflects
+                the full slate of values in the "row." This two-step dance allows for the use of, for exaple, read-only
+                properties in conjunction with constructors, which is a more natural object model for most users (as
+                compared to requiring that all properties be writeable).
+              </para>
+              <para>
+                The <see cref="T:Kvasir.Reconstitution.IMutationStep"/> interface describes the shape of the second step in the object-building
+                process only. The guarantee of the interface is that the provided subject, modified in place, will be in a
+                state that fully reflects the provided database state.
+              </para>
+            </remarks>
+            <seealso cref="T:Kvasir.Reconstitution.IObjectCreator"/>
+            <seealso cref="T:Kvasir.Reconstitution.Reconstitutor"/>
+        </member>
+        <member name="P:Kvasir.Reconstitution.IMutationStep.ExpectedSubject">
+            <summary>
+              The <see cref="T:System.Type"/> of object on which this <see cref="T:Kvasir.Reconstitution.IMutationStep"/> is expected to operate.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Reconstitution.IMutationStep.Execute(System.Object,System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+            <summary>
+              Execute this <see cref="T:Kvasir.Reconstitution.IMutationStep"/> to modify an existing CLR object in-place.
+            </summary>
+            <param name="subject">
+              The non-<see langword="null"/> object to mutate.
+            </param>
+            <param name="rawValues">
+              The raw database values with which to perform the mutation.
+            </param>
+            <pre>
+              <paramref name="subject"/> is an instance of <see cref="P:Kvasir.Reconstitution.IMutationStep.ExpectedSubject"/>.
+            </pre>
+        </member>
+        <member name="T:Kvasir.Reconstitution.IObjectCreator">
+            <summary>
+              The interface that defines how a CLR object is created from a list of values extraced from a back-end
+              relational database
+            </summary>
+            <remarks>
+              <para>
+                The process of creating a CLR object from a "row" of database values is a two-step process. In the first
+                step, the object is <i>created</i>; that is, some valid CLR object is brought into existence according to
+                the APIs exposed by the target type. In the second step, that object is modified so that its state reflects
+                the full slate of values in the "row." This two-step dance allows for the use of, for exaple, read-only
+                properties in conjunction with constructors, which is a more natural object model for most users (as
+                compared to requiring that all properties be writeable).
+              </para>
+              <para>
+                The <see cref="T:Kvasir.Reconstitution.IObjectCreator"/> interface describes the shape of the first step in the object-building
+                process only. The guarantee of the interface is that a produced object is valid according to the domain
+                object being created, though it is not necessarily fully reflective of the database state.
+              </para>
+            </remarks>
+            <seealso cref="T:Kvasir.Reconstitution.IMutationStep"/>
+            <seealso cref="T:Kvasir.Reconstitution.Reconstitutor"/>
+        </member>
+        <member name="P:Kvasir.Reconstitution.IObjectCreator.Target">
+            <summary>
+              The <see cref="T:System.Type"/> of CLR object created by this <see cref="T:Kvasir.Reconstitution.IObjectCreator"/>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Reconstitution.IObjectCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+            <summary>
+              Execute this <see cref="T:Kvasir.Reconstitution.IObjectCreator"/> to create a brand new CLR object.
+            </summary>
+            <param name="rawValues">
+              The raw database values from which to perform the reconstitution.
+            </param>
+            <pre>
+              <paramref name="rawValues"/> constitutes a collection of values that were produced by an extraction run
+              over an instance of <see cref="P:Kvasir.Reconstitution.IObjectCreator.Target"/>, with relevant values aligned to position <c>0</c>.
+            </pre>
+            <returns>
+              An object of type <see cref="P:Kvasir.Reconstitution.IObjectCreator.Target"/> created from <paramref name="rawValues"/> according to the rules
+              of this <see cref="T:Kvasir.Reconstitution.IObjectCreator"/>. If the relevant slots of <paramref name="rawValues"/> correspond to
+              a <see langword="null"/> object, <see langword="null"/> is returned.
+            </returns>
+        </member>
+        <member name="T:Kvasir.Reconstitution.IReconstitutor">
+            <summary>
+              The interface that defines the mechanism by which a "row" of database values is converted into an equivalent
+              CLR object.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Reconstitution.IReconstitutor.Target">
+            <summary>
+              The <see cref="T:System.Type"/> of object produced by this <see cref="T:Kvasir.Reconstitution.Reconstitutor"/>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Reconstitution.IReconstitutor.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+            <summary>
+              Execute this <see cref="T:Kvasir.Reconstitution.IReconstitutor"/> to create a brand new CLR object from a "row" of datbase
+              values.
+            </summary>
+            <param name="rawValues">
+              The database values from which to reconstitute a CLR object.
+            </param>
+            <pre>
+              <paramref name="rawValues"/> is not empty.
+            </pre>
+            <returns>
+              A CLR object of type <see cref="P:Kvasir.Reconstitution.IReconstitutor.Target"/> that, when run through the dedicated extractor for
+              <see cref="P:Kvasir.Reconstitution.IReconstitutor.Target"/>, produces <paramref name="rawValues"/>.
+            </returns>
+        </member>
+        <member name="T:Kvasir.Reconstitution.PrimitiveCreator">
+            <summary>
+              An <see cref="T:Kvasir.Reconstitution.IObjectCreator"/> that produces a single, primitive value.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Reconstitution.PrimitiveCreator.Target">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Reconstitution.PrimitiveCreator.#ctor(System.Index,Kvasir.Core.DataConverter)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Reconstitution.PrimitiveCreator"/>.
+            </summary>
+            <param name="index">
+              The index in the to-be-provided array of database values at which the target primitive value resides.
+            </param>
+            <param name="reverter">
+              A <see cref="T:Kvasir.Core.DataConverter"/> defining how to undo the transform performed on the primitive value. If no
+              transformation was applied on storage, an <see cref="M:Kvasir.Core.DataConverter.Identity``1">identity conversion</see>
+              should be provided.
+            </param>
+            <pre>
+              <paramref name="reverter"/> supports bidirectional conversion
+                --and--
+              The <see cref="P:Kvasir.Core.DataConverter.ResultType"/> of <paramref name="reverter"/> is a data type supported by the
+              Framework.
+            </pre>
+        </member>
+        <member name="M:Kvasir.Reconstitution.PrimitiveCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+            <inheritdoc/>
+        </member>
+        <member name="T:Kvasir.Reconstitution.Reconstitutor">
+            <summary>
+              The standard form of <see cref="T:Kvasir.Reconstitution.IReconstitutor"/>, which presumes that the provided data will consist exactly
+              of the expected values (i.e. aligned to index <c>0</c>, with nothing extraneous).
+            </summary>
+        </member>
+        <member name="P:Kvasir.Reconstitution.Reconstitutor.Target">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Reconstitution.Reconstitutor.#ctor(Kvasir.Reconstitution.IObjectCreator,System.Collections.Generic.IEnumerable{Kvasir.Reconstitution.IMutationStep})">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Reconstitution.Reconstitutor"/>.
+            </summary>
+            <param name="creator">
+              The <see cref="T:Kvasir.Reconstitution.IObjectCreator"/> with which to create the CLR object shell.
+            </param>
+            <param name="mutators">
+              A list of zero or more <see cref="T:Kvasir.Reconstitution.IMutationStep">IMutationSteps</see> to be applied to the object created
+              by <paramref name="creator"/>.
+            </param>
+            <pre>
+              The <see cref="P:Kvasir.Reconstitution.IMutationStep.ExpectedSubject">expected subject type</see> of each element of
+              <paramref name="mutators"/> is the same as the <see cref="P:Kvasir.Reconstitution.IObjectCreator.Target">target type</see> of
+              <paramref name="creator"/>.
+            </pre>
+        </member>
+        <member name="M:Kvasir.Reconstitution.Reconstitutor.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+            <inheritdoc/>
+        </member>
+        <member name="T:Kvasir.Reconstitution.ReconstitutorFacade">
+            <summary>
+              An <see cref="T:Kvasir.Reconstitution.IReconstitutor"/> that provides a view over a "row" of data to another
+              <see cref="T:Kvasir.Reconstitution.IReconstitutor"/> that is concerned with only a specific subset of values.
+            </summary>
+            <remarks>
+              Fundamentally, the process for reconstituting an object of type <c>T</c> is independent of the manner in
+              which <c>T</c> an instance of <c>T</c> is stored in the back-end database. Specifically, it is independent of
+              the Table, the position in the "row," and the names of the back-end Fields. To mirror this independence in
+              the Reconstitution Layer requires a mechanism by which individual owning entities can indicate that an
+              instance of <c>T</c> is stored at varying offsets. The <see cref="T:Kvasir.Reconstitution.ReconstitutorFacade"/> fulfills this
+              responsibility, allowing for a single concrete <see cref="T:Kvasir.Reconstitution.Reconstitutor"/> to be synthesized per type.
+            </remarks>
+        </member>
+        <member name="P:Kvasir.Reconstitution.ReconstitutorFacade.Target">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Reconstitution.ReconstitutorFacade.#ctor(Kvasir.Reconstitution.IReconstitutor,System.Index,System.Int32)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Reconstitution.ReconstitutorFacade"/>.
+            </summary>
+            <param name="impl">
+              The implementation to which the new <see cref="T:Kvasir.Reconstitution.ReconstitutorFacade"/> is to delegate action.
+            </param>
+            <param name="startIdx">
+              The <c>0</c>-based index in the overall "row" of data values at which the ones relevant to this
+              <paramref name="impl"/> begin.
+            </param>
+            <param name="length">
+              The number of "row" data values that are relevant to <paramref name="impl"/>.
+            </param>
+            <pre>
+              <paramref name="length"/> <c>&gt; 0</c>
+            </pre>
+        </member>
+        <member name="M:Kvasir.Reconstitution.ReconstitutorFacade.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+            <inheritdoc/>
+        </member>
+        <member name="T:Kvasir.Reconstitution.SetPropertyMutationStep">
+            <summary>
+              An <see cref="T:Kvasir.Reconstitution.IMutationStep"/> that changes an existing CLR object by calling the setter on a writeable
+              instance property.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Reconstitution.SetPropertyMutationStep.ExpectedSubject">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Reconstitution.SetPropertyMutationStep.#ctor(System.Reflection.PropertyInfo,Kvasir.Reconstitution.IReconstitutor)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Reconstitution.SetPropertyMutationStep"/>.
+            </summary>
+            <param name="property">
+              The <see cref="T:System.Reflection.PropertyInfo"/> describing the property to which to write.
+            </param>
+            <param name="valueReconstitutor">
+              The <see cref="T:Kvasir.Reconstitution.IReconstitutor"/> to use to create the value to write to <paramref name="property"/>.
+            </param>
+            <pre>
+              <paramref name="property"/> is a writeable instance property
+                --and--
+              the <see cref="P:Kvasir.Reconstitution.IReconstitutor.Target">target type</see> of <paramref name="valueReconstitutor"/> is
+              compatible with the property type of <paramref name="property"/>.
+            </pre>
+        </member>
+        <member name="M:Kvasir.Reconstitution.SetPropertyMutationStep.Execute(System.Object,System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
             <inheritdoc/>
         </member>
         <member name="T:Kvasir.Schema.BasicField">

--- a/src/Kvasir/Reconstitution/ByConstructorCreator.cs
+++ b/src/Kvasir/Reconstitution/ByConstructorCreator.cs
@@ -1,0 +1,59 @@
+﻿using Ardalis.GuardClauses;
+using Cybele.Extensions;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace Kvasir.Reconstitution {
+    /// <summary>
+    ///   An <see cref="IObjectCreator"/> that produces a single, complex CLR object by invoking a constructor via
+    ///   reflection.
+    /// </summary>
+    public sealed class ByConstructorCreator : IObjectCreator {
+        /// <inheritdoc/>
+        public Type Target { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="ByConstructorCreator"/>.
+        /// </summary>
+        /// <param name="ctor">
+        ///   The <see cref="ConstructorInfo"/> describing the constructor to be invoked.
+        /// </param>
+        /// <param name="argReconstitutors">
+        ///   A list of <see cref="IReconstitutor">Reconstitutors</see> to be used to create the arguments to the
+        ///   reflection invocation of <paramref name="ctor"/>, in the order in which they are listed.
+        /// </param>
+        /// <pre>
+        ///   <paramref name="argReconstitutors"/> is not empty
+        ///     --and--
+        ///   The <see cref="IReconstitutor.Target">target type</see> of each element of
+        ///   <paramref name="argReconstitutors"/> is compatible with the corresponding argument to
+        ///   <paramref name="ctor"/>.
+        /// </pre>
+        internal ByConstructorCreator(ConstructorInfo ctor, IEnumerable<IReconstitutor> argReconstitutors) {
+            Guard.Against.Null(ctor, nameof(ctor));
+            Guard.Against.NullOrEmpty(argReconstitutors, nameof(argReconstitutors));
+            Debug.Assert(ctor.IsPublic);
+            Debug.Assert(argReconstitutors.All((i, r) => r.Target.IsInstanceOf(ctor.GetParameters()[i].ParameterType)));
+
+            Target = ctor.ReflectedType!;
+            ctor_ = ctor;
+            arguments_ = argReconstitutors;
+        }
+
+        /// <inheritdoc/>
+        public object? Execute(IReadOnlyList<DBValue> rawValues) {
+            Guard.Against.NullOrEmpty(rawValues, nameof(rawValues));
+
+            var args = arguments_.Select(r => r.ReconstituteFrom(rawValues));
+            return ctor_.Invoke(args.ToArray());
+        }
+
+
+        private readonly ConstructorInfo ctor_;
+        private readonly IEnumerable<IReconstitutor> arguments_;
+    }
+}

--- a/src/Kvasir/Reconstitution/EntityReconstitutionPlan.cs
+++ b/src/Kvasir/Reconstitution/EntityReconstitutionPlan.cs
@@ -1,0 +1,84 @@
+﻿using Ardalis.GuardClauses;
+using Cybele.Extensions;
+using Kvasir.Core;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Kvasir.Reconstitution {
+    /// <summary>
+    ///   A description of the way in which data for a particular Entity type is to be extracted from a back-end
+    ///   database, transformed, and reimagined as an Entity data object.
+    /// </summary>
+    public sealed class EntityReconstitutionPlan {
+        /// <summary>
+        ///   The <see cref="Type"/> of CLR object produced by this <see cref="EntityReconstitutionPlan"/>.
+        /// </summary>
+        public Type Target { get; }
+
+        /// <summary>
+        ///   Construct a new <see cref="EntityReconstitutionPlan"/>.
+        /// </summary>
+        /// <param name="reconstitutor">
+        ///   The <see cref="IReconstitutor"/> with which to produce the CLR object when the new
+        ///   <see cref="EntityReconstitutionPlan"/> is executed.
+        /// </param>
+        /// <param name="reverters">
+        ///   The ordered sequence of <see cref="DataConverter">data converters</see> that extrinsically transform the
+        ///   values extracted from the back-end database..
+        /// </param>
+        /// <pre>
+        ///   <paramref name="reverters"/> is not empty
+        ///     --and--
+        ///   each element of <paramref name="reverters"/> is a bidirectional <see cref="DataConverter"/>.
+        /// </pre>
+        internal EntityReconstitutionPlan(IReconstitutor reconstitutor, IEnumerable<DataConverter> reverters) {
+            Guard.Against.Null(reconstitutor, nameof(reconstitutor));
+            Guard.Against.Null(reverters, nameof(reverters));
+            Debug.Assert(!reverters.IsEmpty());
+            Debug.Assert(reverters.All(dc => dc.IsBidirectional));
+
+            Target = reconstitutor.Target;
+            reconstitutor_ = reconstitutor;
+            reverters_ = reverters;
+        }
+
+        /// <summary>
+        ///   Execute this <see cref="EntityReconstitutionPlan"/> to create a brand new CLR object from a "row" of
+        ///   datbase values.
+        /// </summary>
+        /// <param name="rawValues">
+        ///   The database values from which to reconstitute a CLR object.
+        /// </param>
+        /// <pre>
+        ///   <paramref name="rawValues"/> is not empty.
+        /// </pre>
+        /// <returns>
+        ///   A CLR object of type <see cref="Target"/> that, when run through the dedicated extractor for
+        ///   <see cref="Target"/>, produces <paramref name="rawValues"/>.
+        /// </returns>
+        public object ReconstituteFrom(IReadOnlyList<DBValue> rawValues) {
+            Guard.Against.Null(rawValues, nameof(rawValues));
+            Debug.Assert(!rawValues.IsEmpty());
+
+            List<DBValue> reversions = new List<DBValue>();
+            var reverterIter = reverters_.GetEnumerator();
+
+            foreach (var value in rawValues) {
+                reverterIter.MoveNext();
+
+                // The unwrap-and-rewrap paradigm here is a little annoying, but at least this way we can leverage
+                // the DBValue to ensure that identity conversions are perfectly valid.
+                reversions.Add(DBValue.Create(reverterIter.Current.Revert(value.Datum)));
+            }
+
+            return reconstitutor_.ReconstituteFrom(reversions)!;
+        }
+
+
+        private readonly IReconstitutor reconstitutor_;
+        private readonly IEnumerable<DataConverter> reverters_;
+    }
+}

--- a/src/Kvasir/Reconstitution/IMutationStep.cs
+++ b/src/Kvasir/Reconstitution/IMutationStep.cs
@@ -1,0 +1,47 @@
+﻿using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+
+namespace Kvasir.Reconstitution {
+    /// <summary>
+    ///   The interface that defines how an existing CLR object is modified based on a list of values extraced from a
+    ///   back-end relational database
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     The process of creating a CLR object from a "row" of database values is a two-step process. In the first
+    ///     step, the object is <i>created</i>; that is, some valid CLR object is brought into existence according to
+    ///     the APIs exposed by the target type. In the second step, that object is modified so that its state reflects
+    ///     the full slate of values in the "row." This two-step dance allows for the use of, for exaple, read-only
+    ///     properties in conjunction with constructors, which is a more natural object model for most users (as
+    ///     compared to requiring that all properties be writeable).
+    ///   </para>
+    ///   <para>
+    ///     The <see cref="IMutationStep"/> interface describes the shape of the second step in the object-building
+    ///     process only. The guarantee of the interface is that the provided subject, modified in place, will be in a
+    ///     state that fully reflects the provided database state.
+    ///   </para>
+    /// </remarks>
+    /// <seealso cref="IObjectCreator"/>
+    /// <seealso cref="Reconstitutor"/>
+    public interface IMutationStep {
+        /// <summary>
+        ///   The <see cref="Type"/> of object on which this <see cref="IMutationStep"/> is expected to operate.
+        /// </summary>
+        Type ExpectedSubject { get; }
+
+        /// <summary>
+        ///   Execute this <see cref="IMutationStep"/> to modify an existing CLR object in-place.
+        /// </summary>
+        /// <param name="subject">
+        ///   The non-<see langword="null"/> object to mutate.
+        /// </param>
+        /// <param name="rawValues">
+        ///   The raw database values with which to perform the mutation.
+        /// </param>
+        /// <pre>
+        ///   <paramref name="subject"/> is an instance of <see cref="ExpectedSubject"/>.
+        /// </pre>
+        void Execute(object subject, IReadOnlyList<DBValue> rawValues);
+    }
+}

--- a/src/Kvasir/Reconstitution/IObjectCreator.cs
+++ b/src/Kvasir/Reconstitution/IObjectCreator.cs
@@ -1,0 +1,50 @@
+﻿using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+
+namespace Kvasir.Reconstitution {
+    /// <summary>
+    ///   The interface that defines how a CLR object is created from a list of values extraced from a back-end
+    ///   relational database
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     The process of creating a CLR object from a "row" of database values is a two-step process. In the first
+    ///     step, the object is <i>created</i>; that is, some valid CLR object is brought into existence according to
+    ///     the APIs exposed by the target type. In the second step, that object is modified so that its state reflects
+    ///     the full slate of values in the "row." This two-step dance allows for the use of, for exaple, read-only
+    ///     properties in conjunction with constructors, which is a more natural object model for most users (as
+    ///     compared to requiring that all properties be writeable).
+    ///   </para>
+    ///   <para>
+    ///     The <see cref="IObjectCreator"/> interface describes the shape of the first step in the object-building
+    ///     process only. The guarantee of the interface is that a produced object is valid according to the domain
+    ///     object being created, though it is not necessarily fully reflective of the database state.
+    ///   </para>
+    /// </remarks>
+    /// <seealso cref="IMutationStep"/>
+    /// <seealso cref="Reconstitutor"/>
+    public interface IObjectCreator {
+        /// <summary>
+        ///   The <see cref="Type"/> of CLR object created by this <see cref="IObjectCreator"/>.
+        /// </summary>
+        Type Target { get; }
+
+        /// <summary>
+        ///   Execute this <see cref="IObjectCreator"/> to create a brand new CLR object.
+        /// </summary>
+        /// <param name="rawValues">
+        ///   The raw database values from which to perform the reconstitution.
+        /// </param>
+        /// <pre>
+        ///   <paramref name="rawValues"/> constitutes a collection of values that were produced by an extraction run
+        ///   over an instance of <see cref="Target"/>, with relevant values aligned to position <c>0</c>.
+        /// </pre>
+        /// <returns>
+        ///   An object of type <see cref="Target"/> created from <paramref name="rawValues"/> according to the rules
+        ///   of this <see cref="IObjectCreator"/>. If the relevant slots of <paramref name="rawValues"/> correspond to
+        ///   a <see langword="null"/> object, <see langword="null"/> is returned.
+        /// </returns>
+        object? Execute(IReadOnlyList<DBValue> rawValues);
+    }
+}

--- a/src/Kvasir/Reconstitution/IReconstitutor.cs
+++ b/src/Kvasir/Reconstitution/IReconstitutor.cs
@@ -1,0 +1,32 @@
+﻿using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+
+namespace Kvasir.Reconstitution {
+    /// <summary>
+    ///   The interface that defines the mechanism by which a "row" of database values is converted into an equivalent
+    ///   CLR object.
+    /// </summary>
+    public interface IReconstitutor {
+        /// <summary>
+        ///   The <see cref="Type"/> of object produced by this <see cref="Reconstitutor"/>.
+        /// </summary>
+        Type Target { get; }
+
+        /// <summary>
+        ///   Execute this <see cref="IReconstitutor"/> to create a brand new CLR object from a "row" of datbase
+        ///   values.
+        /// </summary>
+        /// <param name="rawValues">
+        ///   The database values from which to reconstitute a CLR object.
+        /// </param>
+        /// <pre>
+        ///   <paramref name="rawValues"/> is not empty.
+        /// </pre>
+        /// <returns>
+        ///   A CLR object of type <see cref="Target"/> that, when run through the dedicated extractor for
+        ///   <see cref="Target"/>, produces <paramref name="rawValues"/>.
+        /// </returns>
+        object? ReconstituteFrom(IReadOnlyList<DBValue> rawValues);
+    }
+}

--- a/src/Kvasir/Reconstitution/PrimitiveCreator.cs
+++ b/src/Kvasir/Reconstitution/PrimitiveCreator.cs
@@ -1,0 +1,60 @@
+﻿using Ardalis.GuardClauses;
+using Kvasir.Core;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Kvasir.Reconstitution {
+    /// <summary>
+    ///   An <see cref="IObjectCreator"/> that produces a single, primitive value.
+    /// </summary>
+    public sealed class PrimitiveCreator : IObjectCreator {
+        /// <inheritdoc/>
+        public Type Target { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="PrimitiveCreator"/>.
+        /// </summary>
+        /// <param name="index">
+        ///   The index in the to-be-provided array of database values at which the target primitive value resides.
+        /// </param>
+        /// <param name="reverter">
+        ///   A <see cref="DataConverter"/> defining how to undo the transform performed on the primitive value. If no
+        ///   transformation was applied on storage, an <see cref="DataConverter.Identity{T}">identity conversion</see>
+        ///   should be provided.
+        /// </param>
+        /// <pre>
+        ///   <paramref name="reverter"/> supports bidirectional conversion
+        ///     --and--
+        ///   The <see cref="DataConverter.ResultType"/> of <paramref name="reverter"/> is a data type supported by the
+        ///   Framework.
+        /// </pre>
+        internal PrimitiveCreator(Index index, DataConverter reverter) {
+            Guard.Against.Null(reverter, nameof(reverter));
+            Debug.Assert(reverter.IsBidirectional);
+            Debug.Assert(DBType.IsSupported(reverter.SourceType));
+
+            Target = reverter.SourceType;
+            index_ = index;
+            reverter_ = reverter;
+        }
+
+        /// <inheritdoc/>
+        public object? Execute(IReadOnlyList<DBValue> values) {
+            Guard.Against.NullOrEmpty(values, nameof(values));
+
+            // DataConverters operate on raw values, of which DBNull is not one. If we pass DBNull to the revert
+            // method (or, for that matter, the convert method) we'll get an error because DBNull is not an instance of
+            // the expected type.
+            if (values[index_] == DBValue.NULL) {
+                return reverter_.Revert(null);
+            }
+            return reverter_.Revert(values[index_].Datum);
+        }
+
+
+        private readonly Index index_;
+        private readonly DataConverter reverter_;
+    }
+}

--- a/src/Kvasir/Reconstitution/Reconstitutor.cs
+++ b/src/Kvasir/Reconstitution/Reconstitutor.cs
@@ -1,0 +1,67 @@
+﻿using Ardalis.GuardClauses;
+using Cybele.Extensions;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Kvasir.Reconstitution {
+    /// <summary>
+    ///   The standard form of <see cref="IReconstitutor"/>, which presumes that the provided data will consist exactly
+    ///   of the expected values (i.e. aligned to index <c>0</c>, with nothing extraneous).
+    /// </summary>
+    public sealed class Reconstitutor : IReconstitutor {
+        /// <inheritdoc/>
+        public Type Target { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="Reconstitutor"/>.
+        /// </summary>
+        /// <param name="creator">
+        ///   The <see cref="IObjectCreator"/> with which to create the CLR object shell.
+        /// </param>
+        /// <param name="mutators">
+        ///   A list of zero or more <see cref="IMutationStep">IMutationSteps</see> to be applied to the object created
+        ///   by <paramref name="creator"/>.
+        /// </param>
+        /// <pre>
+        ///   The <see cref="IMutationStep.ExpectedSubject">expected subject type</see> of each element of
+        ///   <paramref name="mutators"/> is the same as the <see cref="IObjectCreator.Target">target type</see> of
+        ///   <paramref name="creator"/>.
+        /// </pre>
+        internal Reconstitutor(IObjectCreator creator, IEnumerable<IMutationStep> mutators) {
+            Guard.Against.Null(creator, nameof(creator));
+            Guard.Against.Null(mutators, nameof(mutators));
+            Debug.Assert(mutators.All(m => creator.Target.IsInstanceOf(m.ExpectedSubject)));
+
+            Target = creator.Target;
+            creator_ = creator;
+            mutators_ = mutators;
+        }
+
+        /// <inheritdoc/>
+        public object? ReconstituteFrom(IReadOnlyList<DBValue> rawValues) {
+            Guard.Against.NullOrEmpty(rawValues, nameof(rawValues));
+
+            // Mutators cannot operate on null objects, because there would be no target on which to call the property
+            // setter. If the object creator produces a null value, then, that's the end of the reconstitution
+            // pipeline.
+            var obj = creator_.Execute(rawValues);
+            if (obj is null) {
+                return obj;
+            }
+
+            // If the object creator produces a non-null value, it gets passed to each mutator in order. Technically
+            // the order is irrelevant, though. If the list of mutators is empty, then this is effectively a no-op.
+            foreach (var mutator in mutators_) {
+                mutator.Execute(obj, rawValues);
+            }
+            return obj;
+        }
+
+
+        private readonly IObjectCreator creator_;
+        private readonly IEnumerable<IMutationStep> mutators_;
+    }
+}

--- a/src/Kvasir/Reconstitution/ReconstitutorFacade.cs
+++ b/src/Kvasir/Reconstitution/ReconstitutorFacade.cs
@@ -1,0 +1,63 @@
+﻿using Ardalis.GuardClauses;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kvasir.Reconstitution {
+    /// <summary>
+    ///   An <see cref="IReconstitutor"/> that provides a view over a "row" of data to another
+    ///   <see cref="IReconstitutor"/> that is concerned with only a specific subset of values.
+    /// </summary>
+    /// <remarks>
+    ///   Fundamentally, the process for reconstituting an object of type <c>T</c> is independent of the manner in
+    ///   which <c>T</c> an instance of <c>T</c> is stored in the back-end database. Specifically, it is independent of
+    ///   the Table, the position in the "row," and the names of the back-end Fields. To mirror this independence in
+    ///   the Reconstitution Layer requires a mechanism by which individual owning entities can indicate that an
+    ///   instance of <c>T</c> is stored at varying offsets. The <see cref="ReconstitutorFacade"/> fulfills this
+    ///   responsibility, allowing for a single concrete <see cref="Reconstitutor"/> to be synthesized per type.
+    /// </remarks>
+    public sealed class ReconstitutorFacade : IReconstitutor {
+        /// <inheritdoc/>
+        public Type Target { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="ReconstitutorFacade"/>.
+        /// </summary>
+        /// <param name="impl">
+        ///   The implementation to which the new <see cref="ReconstitutorFacade"/> is to delegate action.
+        /// </param>
+        /// <param name="startIdx">
+        ///   The <c>0</c>-based index in the overall "row" of data values at which the ones relevant to this
+        ///   <paramref name="impl"/> begin.
+        /// </param>
+        /// <param name="length">
+        ///   The number of "row" data values that are relevant to <paramref name="impl"/>.
+        /// </param>
+        /// <pre>
+        ///   <paramref name="length"/> <c>&gt; 0</c>
+        /// </pre>
+        public ReconstitutorFacade(IReconstitutor impl, Index startIdx, int length) {
+            Guard.Against.Null(impl, nameof(impl));
+            Guard.Against.NegativeOrZero(length, nameof(length));
+
+            Target = impl.Target;
+            impl_ = impl;
+            start_ = startIdx;
+            length_ = length;
+        }
+
+        /// <inheritdoc/>
+        public object? ReconstituteFrom(IReadOnlyList<DBValue> rawValues) {
+            Guard.Against.NullOrEmpty(rawValues, nameof(rawValues));
+
+            var view = rawValues.Skip(start_.Value).Take(length_).ToList();
+            return impl_.ReconstituteFrom(view);
+        }
+
+
+        private readonly IReconstitutor impl_;
+        private readonly Index start_;
+        private readonly int length_;
+    }
+}

--- a/src/Kvasir/Reconstitution/SetPropertyMutationStep.cs
+++ b/src/Kvasir/Reconstitution/SetPropertyMutationStep.cs
@@ -1,0 +1,59 @@
+﻿using Ardalis.GuardClauses;
+using Cybele.Extensions;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Kvasir.Reconstitution {
+    /// <summary>
+    ///   An <see cref="IMutationStep"/> that changes an existing CLR object by calling the setter on a writeable
+    ///   instance property.
+    /// </summary>
+    public class SetPropertyMutationStep : IMutationStep {
+        /// <inheritdoc/>
+        public Type ExpectedSubject { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="SetPropertyMutationStep"/>.
+        /// </summary>
+        /// <param name="property">
+        ///   The <see cref="PropertyInfo"/> describing the property to which to write.
+        /// </param>
+        /// <param name="valueReconstitutor">
+        ///   The <see cref="IReconstitutor"/> to use to create the value to write to <paramref name="property"/>.
+        /// </param>
+        /// <pre>
+        ///   <paramref name="property"/> is a writeable instance property
+        ///     --and--
+        ///   the <see cref="IReconstitutor.Target">target type</see> of <paramref name="valueReconstitutor"/> is
+        ///   compatible with the property type of <paramref name="property"/>.
+        /// </pre>
+        internal SetPropertyMutationStep(PropertyInfo property, IReconstitutor valueReconstitutor) {
+            Guard.Against.Null(property, nameof(property));
+            Guard.Against.Null(valueReconstitutor, nameof(valueReconstitutor));
+            Debug.Assert(property.CanWrite);
+            Debug.Assert(!property.GetSetMethod()!.IsStatic);
+            Debug.Assert(valueReconstitutor.Target.IsInstanceOf(property.PropertyType));
+
+            ExpectedSubject = property.ReflectedType!;
+            property_ = property;
+            argument_ = valueReconstitutor;
+        }
+
+        /// <inheritdoc/>
+        public void Execute(object subject, IReadOnlyList<DBValue> rawValues) {
+            Guard.Against.Null(subject, nameof(subject));
+            Guard.Against.NullOrEmpty(rawValues, nameof(rawValues));
+            Debug.Assert(subject.GetType().IsInstanceOf(ExpectedSubject));
+
+            var arg = argument_.ReconstituteFrom(rawValues);
+            property_.SetValue(subject, arg);
+        }
+
+
+        private readonly PropertyInfo property_;
+        private readonly IReconstitutor argument_;
+    }
+}

--- a/test/UnitTests/Cybele/Extensions/Type.cs
+++ b/test/UnitTests/Cybele/Extensions/Type.cs
@@ -148,5 +148,17 @@ namespace UT.Cybele.Extensions {
             delegateResult.Should().BeTrue();
             interfaceResult.Should().BeFalse();
         }
+
+        [TestMethod] public void NonNullableIsInstanceOfNullable() {
+            // Arrange
+            var parent = typeof(char?);
+            var child = typeof(char);
+
+            // Act
+            var result = child.IsInstanceOf(parent);
+
+            // Assert
+            result.Should().BeTrue();
+        }
     }
 }

--- a/test/UnitTests/Kvasir/Reconstitution/EntityReconstitutionPlan.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/EntityReconstitutionPlan.cs
@@ -1,0 +1,58 @@
+﻿using Atropos.Moq;
+using FluentAssertions;
+using Kvasir.Core;
+using Kvasir.Reconstitution;
+using Kvasir.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UT.Kvasir.Reconstitution {
+    [TestClass, TestCategory("EntityReconstitutionPlan")]
+    public class EntityReconstitutionPlanTests {
+        [TestMethod] public void Construction() {
+            // Arrange
+            var mockReconstitutor = new Mock<IReconstitutor>();
+            mockReconstitutor.Setup(r => r.Target).Returns(typeof(string));
+            mockReconstitutor.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns("");
+            var reverter = DataConverter.Identity<int>();
+
+            // Act
+            var reverters = new DataConverter[] { reverter };
+            var plan = new EntityReconstitutionPlan(mockReconstitutor.Object, reverters);
+
+            // Assert
+            plan.Target.Should().Be(typeof(string));
+        }
+
+        [TestMethod]
+        public void Execute() {
+            // Arrange
+            var year = DBValue.Create(2011);
+            var month = DBValue.Create(11);
+            var day = DBValue.Create(30);
+            var values = new DBValue[] { year, month, day };
+
+            var offsetCnv = DataConverter.Create<int, int>(i => i - 1, i => i + 1);
+            var reverters = Enumerable.Repeat(offsetCnv, 3);
+
+            var reconstitutor = new Mock<IReconstitutor>();
+            reconstitutor.Setup(r => r.Target).Returns(typeof(DateTime));
+            reconstitutor.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(new DateTime());
+
+            var plan = new EntityReconstitutionPlan(reconstitutor.Object, reverters);
+
+            // Act
+            _ = plan.ReconstituteFrom(values);
+
+            // Assert
+            var expYear = DBValue.Create(2012);
+            var expMonth = DBValue.Create(12);
+            var expDay = DBValue.Create(31);
+            var expValues = new DBValue[] { expYear, expMonth, expDay };
+            reconstitutor.Verify(r => r.ReconstituteFrom(Arg.IsSameSequence<IReadOnlyList<DBValue>>(expValues)));
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Reconstitution/Mutators.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/Mutators.cs
@@ -1,0 +1,92 @@
+﻿using FluentAssertions;
+using Kvasir.Reconstitution;
+using Kvasir.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Collections.Generic;
+
+namespace UT.Kvasir.Reconstitution {
+    [TestClass, TestCategory("SetPropertyMutationStep")]
+    public class SetPropertyMutationTests {
+        [TestMethod] public void Construct() {
+            // Arrange
+            var prop = typeof(PODClass).GetProperty(nameof(PODClass.String))!;
+            var mockArgRecon = new Mock<IReconstitutor>();
+            mockArgRecon.Setup(r => r.Target).Returns(typeof(string));
+
+            // Act
+            var mutator = new SetPropertyMutationStep(prop, mockArgRecon.Object);
+
+            // Assert
+            mutator.ExpectedSubject.Should().Be(typeof(PODClass));
+        }
+
+        [TestMethod] public void ExecuteOnClass() {
+            // Arrange
+            var prop = typeof(PODClass).GetProperty(nameof(PODClass.String))!;
+            var arg = "Santa Clara";
+            var mockArgRecon = new Mock<IReconstitutor>();
+            mockArgRecon.Setup(r => r.Target).Returns(typeof(string));
+            mockArgRecon.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(arg);
+            var data = new DBValue[] { DBValue.NULL, DBValue.Create(0), DBValue.Create('@') };
+            var mutator = new SetPropertyMutationStep(prop, mockArgRecon.Object);
+            object source = new PODClass();
+
+            // Act
+            ((PODClass)source).String.Should().BeNull();
+            mutator.Execute(source, data);
+
+            // Assert
+            ((PODClass)source).String.Should().Be(arg);
+        }
+
+        [TestMethod] public void ExecuteOnStruct() {
+            // Arrange
+            var prop = typeof(PODStruct).GetProperty(nameof(PODStruct.String))!;
+            var arg = "Valparaiso";
+            var mockArgRecon = new Mock<IReconstitutor>();
+            mockArgRecon.Setup(r => r.Target).Returns(typeof(string));
+            mockArgRecon.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(arg);
+            var data = new DBValue[] { DBValue.NULL, DBValue.Create(0), DBValue.Create('@') };
+            var mutator = new SetPropertyMutationStep(prop, mockArgRecon.Object);
+            object source = new PODStruct();
+
+            // Act
+            ((PODStruct)source).String.Should().BeNull();
+            mutator.Execute(source, data);
+
+            // Assert
+            ((PODStruct)source).String.Should().Be(arg);
+        }
+
+        [TestMethod] public void ExecuteWithNullValue() {
+            // Arrange
+            var prop = typeof(PODClass).GetProperty(nameof(PODClass.Character))!;
+            var mockArgRecon = new Mock<IReconstitutor>();
+            mockArgRecon.Setup(r => r.Target).Returns(typeof(char));
+            mockArgRecon.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(null);
+            var data = new DBValue[] { DBValue.NULL, DBValue.Create(0), DBValue.Create('@') };
+            var mutator = new SetPropertyMutationStep(prop, mockArgRecon.Object);
+            var source = new PODClass() { Character = '.' };
+
+            // Act
+            source.Character.Should().NotBeNull();
+            mutator.Execute(source, data);
+
+            // Assert
+            source.Character.Should().BeNull();
+        }
+    }
+
+
+    internal class PODClass {
+        public int? Integer { get; set; }
+        public char? Character { get; set; }
+        public string? String { get; set; }
+    }
+    internal struct PODStruct {
+        public int? Integer { get; set; }
+        public char? Character { get; set; }
+        public string? String { get; set; }
+    }
+}

--- a/test/UnitTests/Kvasir/Reconstitution/ObjectCreators.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/ObjectCreators.cs
@@ -1,0 +1,171 @@
+﻿using FluentAssertions;
+using Kvasir.Core;
+using Kvasir.Reconstitution;
+using Kvasir.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+
+namespace UT.Kvasir.Reconstitution {
+    [TestClass, TestCategory("PrimitiveCreator")]
+    public class PrimitiveCreatorTests {
+        [TestMethod] public void ConstructNoReversion() {
+            // Arrange
+            var idx = new Index(3);
+            var reverter = DataConverter.Identity<int>();
+
+            // Act
+            var creator = new PrimitiveCreator(idx, reverter);
+
+            // Assert
+            creator.Target.Should().Be(typeof(int));
+        }
+
+        [TestMethod] public void ConstructWithReversion() {
+            // Arrange
+            var idx = new Index(491);
+            var reverter = DataConverter.Create<char, int>(c => c, i => (char)i);
+
+            // Act
+            var creator = new PrimitiveCreator(idx, reverter);
+
+            // Assert
+            creator.Target.Should().Be(typeof(char));
+        }
+
+        [TestMethod] public void ProduceNonNullNoReversion() {
+            // Arrange
+            var idx = new Index(1);
+            var reverter = DataConverter.Identity<string>();
+            var data = new DBValue[] { DBValue.Create(7), DBValue.Create("Jefferson City") };
+            var creator = new PrimitiveCreator(idx, reverter);
+
+            // Act
+            var value = creator.Execute(data);
+
+            // Assert
+            value.Should().Be(data[idx].Datum);
+        }
+
+        [TestMethod] public void ProduceNonNullWithReversion() {
+            // Arrange
+            var idx = new Index(0);
+            var reverter = DataConverter.Create<int, string>(i => i.ToString(), s => int.Parse(s));
+            var data = new DBValue[] { DBValue.Create("7"), DBValue.NULL, DBValue.Create(7) };
+            var creator = new PrimitiveCreator(idx, reverter);
+
+            // Act
+            var value = creator.Execute(data);
+
+            // Assert
+            value.Should().Be(7);
+        }
+
+        [TestMethod] public void ProduceNullNoReversion() {
+            // Arrange
+            var idx = new Index(1);
+            var reverter = DataConverter.Identity<ushort>();
+            var data = new DBValue[] { DBValue.Create('&'), DBValue.NULL, DBValue.Create(-4L) };
+            var creator = new PrimitiveCreator(idx, reverter);
+
+            // Act
+            var value = creator.Execute(data);
+
+            // Assert
+            value.Should().BeNull();
+        }
+
+        [TestMethod] public void ProduceNullWithReversion() {
+            // Arrange
+            var idx = new Index(1);
+            var reverter = DataConverter.Create<DateTime, int>(d => d.Year, i => new DateTime(i, 1, 1));
+            var data = new DBValue[] { DBValue.Create("Bloomington"), DBValue.NULL };
+            var creator = new PrimitiveCreator(idx, reverter);
+
+            // Act
+            var value = creator.Execute(data);
+
+            // Assert
+            value.Should().BeNull();
+        }
+    }
+
+    [TestClass, TestCategory("ByConstructorCreator")]
+    public class ByConstructorCreatorTests {
+        [TestMethod] public void Construct() {
+            // Arrange
+            var ctor = typeof(string).GetConstructor(new Type[] { typeof(char), typeof(int) })!;
+            var mockArgRecon = new Mock<IReconstitutor>();
+            mockArgRecon.SetupSequence(r => r.Target).Returns(typeof(char)).Returns(typeof(int));
+
+            // Act
+            var creator = new ByConstructorCreator(ctor, new IReconstitutor[] { mockArgRecon.Object });
+
+            // Assert
+            creator.Target.Should().Be(typeof(string));
+        }
+
+        [TestMethod] public void ProduceFromSingleArgument() {
+            // Arrange
+            var ctor = typeof(TestCategoryAttribute).GetConstructor(new Type[] { typeof(string) })!;
+            var arg = "Fort Lauderdale";
+            var mockArgRecon = new Mock<IReconstitutor>();
+            mockArgRecon.Setup(r => r.Target).Returns(typeof(string));
+            mockArgRecon.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(arg);
+            var data = new DBValue[] { DBValue.NULL, DBValue.Create(35L) };
+            var creator = new ByConstructorCreator(ctor, new IReconstitutor[] { mockArgRecon.Object });
+
+            // Act
+            var value = creator.Execute(data);
+
+            // Assert
+            var expected = new TestCategoryAttribute(arg);
+            value.Should().Equals(expected);
+        }
+
+        [TestMethod] public void ProduceFromMultipleArguments() {
+            // Arrange
+            var ctor = typeof(System.Range).GetConstructor(new Type[] { typeof(Index), typeof(Index) })!;
+            var arg0 = new Index(95);
+            var arg1 = new Index(2074);
+            var mockArgRecon0 = new Mock<IReconstitutor>();
+            mockArgRecon0.Setup(r => r.Target).Returns(typeof(Index));
+            mockArgRecon0.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(arg0);
+            var mockArgRecon1 = new Mock<IReconstitutor>();
+            mockArgRecon1.Setup(r => r.Target).Returns(typeof(Index));
+            mockArgRecon1.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(arg1);
+            var recons = new IReconstitutor[] { mockArgRecon0.Object, mockArgRecon1.Object };
+            var data = new DBValue[] { DBValue.Create('|'), DBValue.Create('>'), DBValue.Create("Eugene") };
+            var creator = new ByConstructorCreator(ctor, recons);
+
+            // Act
+            var value = creator.Execute(data);
+
+            // Assert
+            var expected = new System.Range(arg0, arg1);
+            value.Should().Equals(expected);
+        }
+
+        [TestMethod] public void ProduceFromAllNulls() {
+            // Arrange
+            var ctor = typeof(ArgumentException).GetConstructor(new Type[] { typeof(string), typeof(Exception) })!;
+            var mockArgRecon0 = new Mock<IReconstitutor>();
+            mockArgRecon0.Setup(r => r.Target).Returns(typeof(string));
+            mockArgRecon0.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(null);
+            var mockArgRecon1 = new Mock<IReconstitutor>();
+            mockArgRecon1.Setup(r => r.Target).Returns(typeof(Exception));
+            mockArgRecon1.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(null);
+            var recons = new IReconstitutor[] { mockArgRecon0.Object, mockArgRecon1.Object };
+            var data = new DBValue[] { DBValue.Create('%') };
+            var creator = new ByConstructorCreator(ctor, recons);
+
+            // Act
+            var value = creator.Execute(data);
+
+            // Assert
+            var expected = new ArgumentException(null, (Exception?)null);
+            value.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Reconstitution/Reconstitutors.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/Reconstitutors.cs
@@ -1,0 +1,105 @@
+﻿using Atropos.Moq;
+using FluentAssertions;
+using Kvasir.Reconstitution;
+using Kvasir.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+
+namespace UT.Kvasir.Reconstitution {
+    [TestClass, TestCategory("Reconstitutor")]
+    public class ReconstitutorTests {
+        [TestMethod] public void Construct() {
+            // Arrange
+            var mockCreator = new Mock<IObjectCreator>();
+            mockCreator.Setup(c => c.Target).Returns(typeof(Exception));
+            var mutators = new IMutationStep[] {};
+
+            // Act
+            var reconstitutor = new Reconstitutor(mockCreator.Object, mutators);
+
+            // Assert
+            reconstitutor.Target.Should().Be(typeof(Exception));
+        }
+
+        [TestMethod] public void ExecuteProducesNonNull() {
+            // Arrange
+            var mockCreator = new Mock<IObjectCreator>();
+            mockCreator.Setup(c => c.Target).Returns(typeof(Exception));
+            mockCreator.Setup(c => c.Execute(It.IsAny<IReadOnlyList<DBValue>>())).Returns(new Exception());
+            var mockMutator0 = new Mock<IMutationStep>();
+            mockMutator0.Setup(m => m.ExpectedSubject).Returns(typeof(Exception));
+            mockMutator0.Setup(m => m.Execute(It.IsAny<object>(), It.IsAny<IReadOnlyList<DBValue>>()));
+            var mockMutator1 = new Mock<IMutationStep>();
+            mockMutator1.Setup(m => m.ExpectedSubject).Returns(typeof(Exception));
+            mockMutator1.Setup(m => m.Execute(It.IsAny<object>(), It.IsAny<IReadOnlyList<DBValue>>()));
+            var mutators = new IMutationStep[] { mockMutator0.Object, mockMutator1.Object };
+            var reconstitutor = new Reconstitutor(mockCreator.Object, mutators);
+            var data = new DBValue[] { DBValue.Create(7), DBValue.Create('='), DBValue.NULL };
+
+            // Act
+            var _ = reconstitutor.ReconstituteFrom(data);
+
+            // Assert
+            mockCreator.Verify(c => c.Execute(data));
+            mockMutator0.Verify(c => c.Execute(It.IsAny<Exception>(), data));
+            mockMutator1.Verify(c => c.Execute(It.IsAny<Exception>(), data));
+        }
+
+        [TestMethod] public void ExecuteProducesNull() {
+            // Arrange
+            var mockCreator = new Mock<IObjectCreator>();
+            mockCreator.Setup(c => c.Target).Returns(typeof(Exception));
+            mockCreator.Setup(c => c.Execute(It.IsAny<IReadOnlyList<DBValue>>())).Returns(null);
+            var mockMutator0 = new Mock<IMutationStep>();
+            mockMutator0.Setup(m => m.ExpectedSubject).Returns(typeof(Exception));
+            var mockMutator1 = new Mock<IMutationStep>();
+            mockMutator1.Setup(m => m.ExpectedSubject).Returns(typeof(Exception));
+            var mutators = new IMutationStep[] { mockMutator0.Object, mockMutator1.Object };
+            var reconstitutor = new Reconstitutor(mockCreator.Object, mutators);
+            var data = new DBValue[] { DBValue.Create(7), DBValue.Create('='), DBValue.NULL };
+
+            // Act
+            var _ = reconstitutor.ReconstituteFrom(data);
+
+            // Assert
+            mockCreator.Verify(c => c.Execute(data));
+        }
+    }
+
+    [TestClass, TestCategory("ReconstitutorFacade")]
+    public class ReconstitutorFacadeTests {
+        [TestMethod] public void Construct() {
+            // Arrange
+            var start = new Index(3);
+            var length = 2;
+            var mockRecon = new Mock<IReconstitutor>();
+            mockRecon.Setup(r => r.Target).Returns(typeof(Activator));
+
+            // Act
+            var reconstitutor = new ReconstitutorFacade(mockRecon.Object, start, length);
+
+            // Assert
+            reconstitutor.Target.Should().Be(typeof(Activator));
+        }
+
+        [TestMethod] public void Execute() {
+            // Arrange
+            var start = new Index(1);
+            var length = 2;
+            var mockRecon = new Mock<IReconstitutor>();
+            mockRecon.Setup(r => r.Target).Returns(typeof(Lazy<string>));
+            mockRecon.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(null);
+            var reconstitutor = new ReconstitutorFacade(mockRecon.Object, start, length);
+            var data = new DBValue[] { DBValue.Create(1), DBValue.Create(2), DBValue.Create(3), DBValue.Create(4) };
+
+            // Act
+            var _ = reconstitutor.ReconstituteFrom(data);
+
+            // Assert
+            var view = data[1..3];
+            mockRecon.Verify(r => r.ReconstituteFrom(Arg.IsSameSequence<IReadOnlyList<DBValue>>(view)));
+        }
+    }
+}

--- a/test/UnitTests/_TestCities.txt
+++ b/test/UnitTests/_TestCities.txt
@@ -18,6 +18,7 @@ Baton Rouge
 Biloxi
 Birmingham
 Bismarck
+Bloomington
 Boise
 Boston
 Buffalo
@@ -38,8 +39,10 @@ Des Moines
 Detroit
 Dover
 El Paso
+Eugene
 Fairbanks
 Flagstaff
+Fort Lauderdale
 Fort Wayne
 Fresno
 Galveston
@@ -56,6 +59,7 @@ Indianapolis
 Ithaca
 Jackson
 Jacksonville
+Jefferson City
 Jersey City
 Juneau
 Kansas City
@@ -102,6 +106,7 @@ San Antonio
 San Diego
 San Francisco
 San Jose
+Santa Clara
 Santa Fe
 Savannah
 Seattle
@@ -119,6 +124,7 @@ Topeka
 Trenton
 Tucson
 Tulsa
+Valparaiso
 Virginia Beach
 Waco
 Walla Walla


### PR DESCRIPTION
This commit implements the Reconstitution Layer, which is a complement to the Extraction Layer implemented in the
previous commit. This layer is responsible for modeling the process by which a row of data from the database is turned
back into a CLR object through two phases: creation (e.g. calling a constructor) and mutation (e.g. setting property
values). As with the Extraction Layer, the current tools available in the Reconstitution Layer are intentionally limited
but specifically designed to be forward compatible with other mechanics, such as factory functions and arbitrary method
invocations.