### PR TITLE
Nullability Check Extension Method

### DIFF
--- a/src/Cybele/Extensions/Nullability.cs
+++ b/src/Cybele/Extensions/Nullability.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cybele.Extensions {
+    /// An indication of the nullability of an aspect of a program.
+    public enum Nullability : ushort {
+        /// <see langword="null"/> is a valid value for the aspect in question.
+        Nullable,
+
+        /// <see langword="null"/> is an invalid value for the aspect in question.
+        NonNullable,
+
+        /// <see langword="null"/> may or may not be a valid value for the aspect in question; this generally applies
+        /// only to generic types, with the ambiguity being resolved by the selection of a concrete type.
+        Ambiguous
+    }
+
+    /// <summary>
+    ///   A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that provide insight to the
+    ///   nullabilitiy of various aspects of a program.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     All types in C# can be separated into one of two categories: value types (primitives, enums, and structs)
+    ///     and reference types (classes, interfaces, delegates, and dynamic types). Prior to C# 8.0, one of the
+    ///     distinctions between these two types was that <see langword="null"/> was a valid value only for the former.
+    ///     However, C# 8.0 introduced the notion of nullable and non-nullable reference types, meaning that the
+    ///     nullability of a particular aspect of a program depends not only on the aspect's static type but also on
+    ///     any user-supplied annotations <i>and</i> on the nullability context in which the aspect is defined.
+    ///   </para>
+    ///   <para>
+    ///     The <c>GetNullability</c> family of methods can operate on properties, events, function parameters,
+    ///     function return types, and member variables. There is limited support for open generics (see below) and
+    ///     full support for closed generics. Specifically, the following types are identified as nullable:
+    ///         <list type="bullet">
+    ///             <item><description>
+    ///               Instantiations of the <see cref="Nullable{T}"/> generic wrapper.
+    ///             </description></item>
+    ///             <item><description>
+    ///               Reference types defined in a nullable-disabled context; this includes code from before C# 8.0.
+    ///             </description></item>
+    ///             <item><description>
+    ///               Nullable-annotated reference types (e.g. <c>string?</c>); these can only be defined in a
+    ///               nullable-enabled context in code from C# 8.0 or later.
+    ///             </description></item>
+    ///             <item><description>
+    ///               Open generic types that, through a combination of annotations and constraints, can be analyzed as
+    ///               one of the above.
+    ///             </description></item>
+    ///         </list>
+    ///   </para>
+    ///   <para>
+    ///     Some uses of closed generics can be ambiguous as to the imparted nullability; these scenarios generally
+    ///     arise when the generic is unconstrained or constrained in such a way so as to allow both nullable and
+    ///     non-nullable types as <c>T</c>. Unfortunately, the reflection APIs offered by the C# standard library do
+    ///     not provide complete access to all forms of constraint, leading to an inability to properly identify these
+    ///     ambiguities. Specificall, the following scenarios should produce <see cref="Nullability.Ambiguous"/> but
+    ///     currently do not:
+    ///         <list type="bullet">
+    ///             <item><description>
+    ///               <c>T [unconstrained]</c> resolves as either nullable or non-nullable, depending on its context
+    ///             </description></item>
+    ///             <item><description>
+    ///               <c>T? [unconstrained]</c> resolves as nullable.
+    ///             </description></item>
+    ///             <item><description>
+    ///               <c>T [where T : class?]</c> resolves as non-nullable.
+    ///             </description></item>
+    ///             <item><description>
+    ///               <c>T? [where T : notnull]</c> resolves as nullable.
+    ///             </description></item>
+    ///         </list>
+    ///   </para>
+    ///   <para>
+    ///     A complete description of how the nullable context of a type is embedded in compiler metadata for C# 8.0+
+    ///     can be found on a <a href="https://tinyurl.com/jsm-roslyn-nullable-metadata">writeup</a> on the Roslyn
+    ///     GitHub page.
+    ///   </para>
+    /// </remarks>
+    public static class NullabilityExtensions {
+        /// <summary>
+        ///   Determines if a particular property of a class or struct is nullable.
+        /// </summary>
+        /// <param name="self">
+        ///   The <see cref="PropertyInfo"/> on which the extension method is invoked.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Nullability"/> indicator reflective of the traits of <paramref name="self"/>.
+        /// </returns>
+        public static Nullability GetNullability(this PropertyInfo self) {
+            return GetNullability(self.PropertyType, self.DeclaringType!, self.GetCustomAttributes());
+        }
+
+        /// <summary>
+        ///   Determines if a particular field (e.g. member variable) of a class or struct is nullable.
+        /// </summary>
+        /// <param name="self">
+        ///   The <see cref="FieldInfo"/> on which the extension method is invoked.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Nullability"/> indicator reflective of the traits of <paramref name="self"/>.
+        /// </returns>
+        public static Nullability GetNullability(this FieldInfo self) {
+            return GetNullability(self.FieldType, self.DeclaringType!, self.GetCustomAttributes());
+        }
+
+        /// <summary>
+        ///   Determines if a particular parameter or return value of a method is nullable.
+        /// </summary>
+        /// <param name="self">
+        ///   The <see cref="ParamArrayAttribute"/> on which the extension method is invoked.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Nullability"/> indicator reflective of the traits of <paramref name="self"/>.
+        /// </returns>
+        public static Nullability GetNullability(this ParameterInfo self) {
+            return GetNullability(self.ParameterType, self.Member, self.GetCustomAttributes());
+        }
+
+        /// <summary>
+        ///   Determines if a particular event of a class or struct is nullable.
+        /// </summary>
+        /// <param name="self">
+        ///   The <see cref="EventInfo"/> on which the extension method is invoked.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Nullability"/> indicator reflective of the traits of <paramref name="self"/>.
+        /// </returns>
+        public static Nullability GetNullability(this EventInfo self) {
+            return GetNullability(self.EventHandlerType!, self.DeclaringType!, self.GetCustomAttributes());
+        }
+
+        /// <summary>
+        ///   Determines if a program aspect with a given static <see cref="Type"/> defined in a particular context
+        ///   with (or without) certain attributes is nullable.
+        /// </summary>
+        /// <param name="type">
+        ///   The <see cref="Type"/> of the aspect being evaluated.
+        /// </param>
+        /// <param name="context">
+        ///   The context of the aspect being evaluated. For most aspects, this should be the <see cref="Type"/> in
+        ///   whih the aspect is being declared. For method parameters and return types, this should be the method
+        ///   itself.
+        /// </param>
+        /// <param name="attributes">
+        ///   The collection of attributes applied to the aspect.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Nullability"/> indicator reflective of the traits of an aspect with static
+        ///   <see cref="Type"/> <paramref name="type"/> defined in <paramref name="context"/> with
+        ///   <paramref name="attributes"/>.
+        /// </returns>
+        private static Nullability GetNullability(Type type, MemberInfo? context, IEnumerable<Attribute> attributes) {
+            // These values are defined by Roslyn
+            byte OBLIVIOUS = 0;
+            byte NOT_ANNOTATED = 1;
+            byte ANNOTATED = 2;
+
+            // If the type in question is a value type (primitive, enum, struct, etc.) or a generic type on which a
+            // struct or enum constraint is applied, then we can determine the nullability of the tpe without doing
+            // heavy reflection
+            if (type.IsValueType) {
+                if (Nullable.GetUnderlyingType(type) is null) {
+                    return Nullability.NonNullable;
+                }
+                return Nullability.Nullable;
+            }
+
+            // We now know that we are dealing with a reference type (class, interface, delegate, etc.), a generic
+            // type on which a class or notnull constraint is applied, or an unconstrained generic type. To determine
+            // the type's nullability, we have to perform heavy reflection according to the Roslyn docs.
+            var nullableAttribute = attributes.FirstOrDefault(a => a.GetType().FullName == NULLABLE_ATTR_NAME);
+            if (nullableAttribute is not null) {
+                var flags = nullableAttribute.GetType().GetField("NullableFlags")!.GetValue(nullableAttribute)!;
+                var asBytes = (byte[])flags;
+                Debug.Assert(asBytes[0] == OBLIVIOUS || asBytes[0] == NOT_ANNOTATED || asBytes[0] == ANNOTATED);
+
+                // The first byte in the compiler-generated flags describes the nullability of the type itself;
+                // additional bytes describe the nullability of generic parameters (e.g. for Tuple<string, string?> the
+                // bytes would be { 1, 1, 2 }).
+                return asBytes[0] == ANNOTATED ? Nullability.Nullable : Nullability.NonNullable;
+            }
+
+            // If there's no [NullableAttribute] applied directly to the type, we have to look at the surrounding
+            // contexts, traversing ancestrally until a [NullableContextAttribute] is encountered or the contexts are
+            // exhausted
+            for (MemberInfo? current = context; current is not null; current = current.DeclaringType) {
+                var attrs = current.GetCustomAttributes();
+                var contextAttribute = attrs.FirstOrDefault(a => a.GetType().FullName == NULLABLE_CONTEXT_ATTR_NAME);
+
+                if (contextAttribute is not null) {
+                    var flag = (byte)contextAttribute.GetType().GetField("Flag")!.GetValue(contextAttribute)!;
+                    Debug.Assert(flag == OBLIVIOUS || flag == NOT_ANNOTATED || flag == ANNOTATED);
+
+                    // A flag value of OBLIVIOUS indicates that the nullable context is disabled, akin to pre-C#8.0
+                    // code. Because we are dealing with a reference type, this obliviousness imparts nullability.
+                    if (flag != NOT_ANNOTATED) {
+                        return Nullability.Nullable;
+                    }
+                    return Nullability.NonNullable;
+                }
+            }
+
+            // There was no [NullableContextAttribute] anywhere in the context hierarchy, so we have the equivalent
+            // of an OBLIVIOUS flag. As above, this imparts nullability.
+            return Nullability.Nullable;
+        }
+
+
+        // The attributes that are relevant to determining nullability cannot be directly used in code: the enclosing
+        // namespace is not even made available. As such, we have to hard code the fully qualified names of the
+        // attributes rather than accessing them through reflection APIs.
+        private static readonly string NULLABLE_ATTRS_NS = "System.Runtime.CompilerServices";
+        private static readonly string NULLABLE_CONTEXT_ATTR_NAME = $"{NULLABLE_ATTRS_NS}.NullableContextAttribute";
+        private static readonly string NULLABLE_ATTR_NAME = $"{NULLABLE_ATTRS_NS}.NullableAttribute";
+    }
+}

--- a/src/Cybele/Intellisense.xml
+++ b/src/Cybele/Intellisense.xml
@@ -577,5 +577,148 @@
               otherwise, <see langword="false"/>.
             </returns>
         </member>
+        <member name="T:Cybele.Extensions.Nullability">
+            An indication of the nullability of an aspect of a program.
+        </member>
+        <member name="F:Cybele.Extensions.Nullability.Nullable">
+            <see langword="null"/> is a valid value for the aspect in question.
+        </member>
+        <member name="F:Cybele.Extensions.Nullability.NonNullable">
+            <see langword="null"/> is an invalid value for the aspect in question.
+        </member>
+        <member name="F:Cybele.Extensions.Nullability.Ambiguous">
+            <see langword="null"/> may or may not be a valid value for the aspect in question; this generally applies
+            only to generic types, with the ambiguity being resolved by the selection of a concrete type.
+        </member>
+        <member name="T:Cybele.Extensions.NullabilityExtensions">
+            <summary>
+              A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that provide insight to the
+              nullabilitiy of various aspects of a program.
+            </summary>
+            <remarks>
+              <para>
+                All types in C# can be separated into one of two categories: value types (primitives, enums, and structs)
+                and reference types (classes, interfaces, delegates, and dynamic types). Prior to C# 8.0, one of the
+                distinctions between these two types was that <see langword="null"/> was a valid value only for the former.
+                However, C# 8.0 introduced the notion of nullable and non-nullable reference types, meaning that the
+                nullability of a particular aspect of a program depends not only on the aspect's static type but also on
+                any user-supplied annotations <i>and</i> on the nullability context in which the aspect is defined.
+              </para>
+              <para>
+                The <c>GetNullability</c> family of methods can operate on properties, events, function parameters,
+                function return types, and member variables. There is limited support for open generics (see below) and
+                full support for closed generics. Specifically, the following types are identified as nullable:
+                    <list type="bullet">
+                        <item><description>
+                          Instantiations of the <see cref="T:System.Nullable`1"/> generic wrapper.
+                        </description></item>
+                        <item><description>
+                          Reference types defined in a nullable-disabled context; this includes code from before C# 8.0.
+                        </description></item>
+                        <item><description>
+                          Nullable-annotated reference types (e.g. <c>string?</c>); these can only be defined in a
+                          nullable-enabled context in code from C# 8.0 or later.
+                        </description></item>
+                        <item><description>
+                          Open generic types that, through a combination of annotations and constraints, can be analyzed as
+                          one of the above.
+                        </description></item>
+                    </list>
+              </para>
+              <para>
+                Some uses of closed generics can be ambiguous as to the imparted nullability; these scenarios generally
+                arise when the generic is unconstrained or constrained in such a way so as to allow both nullable and
+                non-nullable types as <c>T</c>. Unfortunately, the reflection APIs offered by the C# standard library do
+                not provide complete access to all forms of constraint, leading to an inability to properly identify these
+                ambiguities. Specificall, the following scenarios should produce <see cref="F:Cybele.Extensions.Nullability.Ambiguous"/> but
+                currently do not:
+                    <list type="bullet">
+                        <item><description>
+                          <c>T [unconstrained]</c> resolves as either nullable or non-nullable, depending on its context
+                        </description></item>
+                        <item><description>
+                          <c>T? [unconstrained]</c> resolves as nullable.
+                        </description></item>
+                        <item><description>
+                          <c>T [where T : class?]</c> resolves as non-nullable.
+                        </description></item>
+                        <item><description>
+                          <c>T? [where T : notnull]</c> resolves as nullable.
+                        </description></item>
+                    </list>
+              </para>
+              <para>
+                A complete description of how the nullable context of a type is embedded in compiler metadata for C# 8.0+
+                can be found on a <a href="https://tinyurl.com/jsm-roslyn-nullable-metadata">writeup</a> on the Roslyn
+                GitHub page.
+              </para>
+            </remarks>
+        </member>
+        <member name="M:Cybele.Extensions.NullabilityExtensions.GetNullability(System.Reflection.PropertyInfo)">
+            <summary>
+              Determines if a particular property of a class or struct is nullable.
+            </summary>
+            <param name="self">
+              The <see cref="T:System.Reflection.PropertyInfo"/> on which the extension method is invoked.
+            </param>
+            <returns>
+              A <see cref="T:Cybele.Extensions.Nullability"/> indicator reflective of the traits of <paramref name="self"/>.
+            </returns>
+        </member>
+        <member name="M:Cybele.Extensions.NullabilityExtensions.GetNullability(System.Reflection.FieldInfo)">
+            <summary>
+              Determines if a particular field (e.g. member variable) of a class or struct is nullable.
+            </summary>
+            <param name="self">
+              The <see cref="T:System.Reflection.FieldInfo"/> on which the extension method is invoked.
+            </param>
+            <returns>
+              A <see cref="T:Cybele.Extensions.Nullability"/> indicator reflective of the traits of <paramref name="self"/>.
+            </returns>
+        </member>
+        <member name="M:Cybele.Extensions.NullabilityExtensions.GetNullability(System.Reflection.ParameterInfo)">
+            <summary>
+              Determines if a particular parameter or return value of a method is nullable.
+            </summary>
+            <param name="self">
+              The <see cref="T:System.ParamArrayAttribute"/> on which the extension method is invoked.
+            </param>
+            <returns>
+              A <see cref="T:Cybele.Extensions.Nullability"/> indicator reflective of the traits of <paramref name="self"/>.
+            </returns>
+        </member>
+        <member name="M:Cybele.Extensions.NullabilityExtensions.GetNullability(System.Reflection.EventInfo)">
+            <summary>
+              Determines if a particular event of a class or struct is nullable.
+            </summary>
+            <param name="self">
+              The <see cref="T:System.Reflection.EventInfo"/> on which the extension method is invoked.
+            </param>
+            <returns>
+              A <see cref="T:Cybele.Extensions.Nullability"/> indicator reflective of the traits of <paramref name="self"/>.
+            </returns>
+        </member>
+        <member name="M:Cybele.Extensions.NullabilityExtensions.GetNullability(System.Type,System.Reflection.MemberInfo,System.Collections.Generic.IEnumerable{System.Attribute})">
+            <summary>
+              Determines if a program aspect with a given static <see cref="T:System.Type"/> defined in a particular context
+              with (or without) certain attributes is nullable.
+            </summary>
+            <param name="type">
+              The <see cref="T:System.Type"/> of the aspect being evaluated.
+            </param>
+            <param name="context">
+              The context of the aspect being evaluated. For most aspects, this should be the <see cref="T:System.Type"/> in
+              whih the aspect is being declared. For method parameters and return types, this should be the method
+              itself.
+            </param>
+            <param name="attributes">
+              The collection of attributes applied to the aspect.
+            </param>
+            <returns>
+              A <see cref="T:Cybele.Extensions.Nullability"/> indicator reflective of the traits of an aspect with static
+              <see cref="T:System.Type"/> <paramref name="type"/> defined in <paramref name="context"/> with
+              <paramref name="attributes"/>.
+            </returns>
+        </member>
     </members>
 </doc>

--- a/test/UnitTests/Cybele/Extensions/Nullability.cs
+++ b/test/UnitTests/Cybele/Extensions/Nullability.cs
@@ -1,0 +1,1218 @@
+﻿using Cybele.Extensions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UT.Cybele.Extensions {
+    [TestClass, TestCategory("Nullability: Enabled Context")]
+    public sealed class Nullability_EnabledContext {
+        [TestMethod] public void NonNullableReferenceProperty() {
+            // Arrange
+            var prop = typeof(NullableEnabled).GetProperty(nameof(NullableEnabled.NonNullableRefProp))!;
+
+            // Act
+            var nullability = prop. GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableReferenceProperty() {
+            // Arrange
+            var prop = typeof(NullableEnabled).GetProperty(nameof(NullableEnabled.NullableRefProp))!;
+
+            // Act
+            var nullability = prop. GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullablePrimitiveProperty() {
+            // Arrange
+            var prop = typeof(NullableEnabled).GetProperty(nameof(NullableEnabled.NonNullablePrimitiveProp))!;
+
+            // Act
+            var nullability = prop. GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullablePrimitiveProperty() {
+            // Arrange
+            var prop = typeof(NullableEnabled).GetProperty(nameof(NullableEnabled.NullablePrimitiveProp))!;
+
+            // Act
+            var nullability = prop. GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableEnumProperty() {
+            // Arrange
+            var prop = typeof(NullableEnabled).GetProperty(nameof(NullableEnabled.NonNullableEnumProp))!;
+
+            // Act
+            var nullability = prop. GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableEnumProperty() {
+            // Arrange
+            var prop = typeof(NullableEnabled).GetProperty(nameof(NullableEnabled.NullableEnumProp))!;
+
+            // Act
+            var nullability = prop. GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableDelegateProperty() {
+            // Arrange
+            var prop = typeof(NullableEnabled).GetProperty(nameof(NullableEnabled.NonNullableDelegateProp))!;
+
+            // Act
+            var nullability = prop. GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableDelegateProperty() {
+            // Arrange
+            var prop = typeof(NullableEnabled).GetProperty(nameof(NullableEnabled.NullableDeleateProp))!;
+
+            // Act
+            var nullability = prop. GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableDynamicProperty() {
+            // Arrange
+            var prop = typeof(NullableEnabled).GetProperty(nameof(NullableEnabled.NonNullableDynamicProp))!;
+
+            // Act
+            var nullability = prop.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableDynamicProperty() {
+            // Arrange
+            var prop = typeof(NullableEnabled).GetProperty(nameof(NullableEnabled.NullableDynamicProp))!;
+
+            // Act
+            var nullability = prop.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableReferenceField() {
+            // Arrange
+            var field = typeof(NullableEnabled).GetField(nameof(NullableEnabled.NonNullableRefVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableReferenceField() {
+            // Arrange
+            var field = typeof(NullableEnabled).GetField(nameof(NullableEnabled.NullableRefVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullablePrimitiveField() {
+            // Arrange
+            var field = typeof(NullableEnabled).GetField(nameof(NullableEnabled.NonNullablePrimitiveVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullablePrimitiveField() {
+            // Arrange
+            var field = typeof(NullableEnabled).GetField(nameof(NullableEnabled.NullablePrimitiveVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableEnumField() {
+            // Arrange
+            var field = typeof(NullableEnabled).GetField(nameof(NullableEnabled.NonNullableEnumVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableEnumField() {
+            // Arrange
+            var field = typeof(NullableEnabled).GetField(nameof(NullableEnabled.NullableEnumVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableDelegateField() {
+            // Arrange
+            var field = typeof(NullableEnabled).GetField(nameof(NullableEnabled.NonNullableDelegateVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableDelegateField() {
+            // Arrange
+            var field = typeof(NullableEnabled).GetField(nameof(NullableEnabled.NullableDelegateVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableDynamicField() {
+            // Arrange
+            var field = typeof(NullableEnabled).GetField(nameof(NullableEnabled.NonNullableDynamicVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableDynamicField() {
+            // Arrange
+            var field = typeof(NullableEnabled).GetField(nameof(NullableEnabled.NullableDynamicVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableEvent() {
+            // Arrange
+            var evnt = typeof(NullableEnabled).GetEvent(nameof(NullableEnabled.NonNullableEvent))!;
+
+            // Act
+            var nullability = evnt.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableEvent() {
+            // Arrange
+            var evnt = typeof(NullableEnabled).GetEvent(nameof(NullableEnabled.NullableEvent))!;
+
+            // Act
+            var nullability = evnt.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableReferenceParameter() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetConstructors()[0].GetParameters()[0]!;
+            param.Name.Should().Be("NonNullableRefParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableReferenceParameter() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetConstructors()[0].GetParameters()[1]!;
+            param.Name.Should().Be("NullableRefParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullablePrimitiveParameter() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetConstructors()[0].GetParameters()[2]!;
+            param.Name.Should().Be("NonNullablePrimitiveParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullablePrimitiveParameter() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetConstructors()[0].GetParameters()[3]!;
+            param.Name.Should().Be("NullablePrimitiveParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableEnumParameter() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetConstructors()[0].GetParameters()[4]!;
+            param.Name.Should().Be("NonNullableEnumParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableEnumParameter() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetConstructors()[0].GetParameters()[5]!;
+            param.Name.Should().Be("NullableEnumParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableDelegateParameter() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetConstructors()[0].GetParameters()[6]!;
+            param.Name.Should().Be("NonNullableDelegateParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableDelegateParameter() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetConstructors()[0].GetParameters()[7]!;
+            param.Name.Should().Be("NullableDelegateParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableDynamicParameter() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetConstructors()[0].GetParameters()[8]!;
+            param.Name.Should().Be("NonNullableDynamicParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableDynamicParameter() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetConstructors()[0].GetParameters()[9]!;
+            param.Name.Should().Be("NullableDynamicParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableReferenceReturn() {
+            // Arrange
+            var retval = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NonNullableRefReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableReferenceReturn() {
+            // Arrange
+            var retval = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NullableRefReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullablePrimitiveReturn() {
+            // Arrange
+            var retval = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NonNullablePrimitiveReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullablePrimitiveReturn() {
+            // Arrange
+            var retval = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NullablePrimitiveReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableEnumReturn() {
+            // Arrange
+            var retval = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NonNullableEnumReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableEnumReturn() {
+            // Arrange
+            var retval = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NullableEnumReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableDelegateReturn() {
+            // Arrange
+            var retval = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NonNullableDelegateReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableDelegateReturn() {
+            // Arrange
+            var retval = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NullableDelegateReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableDynamicReturn() {
+            // Arrange
+            var retval = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NonNullableDynamicReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableDynamicReturn() {
+            // Arrange
+            var retval = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NullableDynamicReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void UnrestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.UnrestrictedGeneric))!;
+            var ambiguousArg = method.GetParameters()[0]!;
+            var ambiguousArg2 = method.GetParameters()[1]!;
+            var retval = method.ReturnParameter;
+
+            // Act
+            var nullability0 = ambiguousArg.GetNullability();
+            var nullability1 = ambiguousArg2.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.NonNullable);              // limitation in reflection capabilities
+            nullability1.Should().Be(Nullability.Nullable);                 // limitation in reflection capabilities
+            returnNullability.Should().Be(Nullability.NonNullable);         // limitation in reflection capabilities
+        }
+
+        [TestMethod] public void NonNullableClassRestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NonNullableClassRestrictedGeneric))!;
+            var nonNullableArg = method.GetParameters()[0]!;
+            var nullableArg = method.GetParameters()[1]!;
+            var retval = method.ReturnParameter;
+
+            var x = ReferenceEquals(nonNullableArg.ParameterType, nullableArg.ParameterType);
+
+            // Act
+            var nullability0 = nonNullableArg.GetNullability();
+            var nullability1 = nullableArg.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.NonNullable);
+            nullability1.Should().Be(Nullability.Nullable);
+            returnNullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableClassRestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NullableClassRestrictedGeneric))!;
+            var ambiguousArg = method.GetParameters()[0]!;
+            var nullableArg = method.GetParameters()[1]!;
+            var retval = method.ReturnParameter;
+
+            // Act
+            var nullability0 = ambiguousArg.GetNullability();
+            var nullability1 = nullableArg.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.NonNullable);              // limitation in reflection capabilities
+            nullability1.Should().Be(Nullability.Nullable);
+            returnNullability.Should().Be(Nullability.NonNullable);         // limitation in reflection capabilities
+        }
+
+        [TestMethod] public void StructRestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.StructRestrictedGeneric))!;
+            var nonNullableArg = method.GetParameters()[0]!;
+            var nullableArg = method.GetParameters()[1]!;
+            var retval = method.ReturnParameter;
+
+            // Act
+            var nullability0 = nonNullableArg.GetNullability();
+            var nullability1 = nullableArg.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.NonNullable);
+            nullability1.Should().Be(Nullability.Nullable);
+            returnNullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void EnumRestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.EnumRestrictedGeneric))!;
+            var nonNullableArg = method.GetParameters()[0]!;
+            var nonNullableArg2 = method.GetParameters()[1]!;
+            var retval = method.ReturnParameter;
+
+            // Act
+            var nullability0 = nonNullableArg.GetNullability();
+            var nullability1 = nonNullableArg2.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.NonNullable);
+            nullability1.Should().Be(Nullability.NonNullable);
+            returnNullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NotNullRestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NotNullRestrictedGeneric))!;
+            var nonNullableArg = method.GetParameters()[0]!;
+            var ambiguousArg = method.GetParameters()[1]!;
+            var retval = method.ReturnParameter;
+
+            // Act
+            var nullability0 = nonNullableArg.GetNullability();
+            var nullability1 = ambiguousArg.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.NonNullable);
+            nullability1.Should().Be(Nullability.Nullable);                 // limitation in reflection capabilities
+            returnNullability.Should().Be(Nullability.NonNullable);
+        }
+    }
+
+    [TestClass, TestCategory("Nullability: Disabled Context")]
+    public sealed class Nullability_DisabledContext {
+        [TestMethod] public void ReferenceProperty() {
+            // Arrange
+            var prop = typeof(NullableDisabled).GetProperty(nameof(NullableDisabled.RefProp))!;
+
+            // Act
+            var nullability = prop.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullablePrimitiveProperty() {
+            // Arrange
+            var prop = typeof(NullableDisabled).GetProperty(nameof(NullableDisabled.NonNullablePrimitiveProp))!;
+
+            // Act
+            var nullability = prop.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullablePrimitiveProperty() {
+            // Arrange
+            var prop = typeof(NullableDisabled).GetProperty(nameof(NullableDisabled.NullablePrimitiveProp))!;
+
+            // Act
+            var nullability = prop.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableEnumProperty() {
+            // Arrange
+            var prop = typeof(NullableDisabled).GetProperty(nameof(NullableDisabled.NonNullableEnumProp))!;
+
+            // Act
+            var nullability = prop.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableEnumProperty() {
+            // Arrange
+            var prop = typeof(NullableDisabled).GetProperty(nameof(NullableDisabled.NullableEnumProp))!;
+
+            // Act
+            var nullability = prop.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void DelegateProperty() {
+            // Arrange
+            var prop = typeof(NullableDisabled).GetProperty(nameof(NullableDisabled.DelegateProp))!;
+
+            // Act
+            var nullability = prop.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void DynamicProperty() {
+            // Arrange
+            var prop = typeof(NullableDisabled).GetProperty(nameof(NullableDisabled.DynamicProp))!;
+
+            // Act
+            var nullability = prop.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void ReferenceField() {
+            // Arrange
+            var field = typeof(NullableDisabled).GetField(nameof(NullableDisabled.RefVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullablePrimitiveField() {
+            // Arrange
+            var field = typeof(NullableDisabled).GetField(nameof(NullableDisabled.NonNullablePrimitiveVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullablePrimitiveField() {
+            // Arrange
+            var field = typeof(NullableDisabled).GetField(nameof(NullableDisabled.NullablePrimitiveVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableEnumField() {
+            // Arrange
+            var field = typeof(NullableDisabled).GetField(nameof(NullableDisabled.NonNullableEnumVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableEnumField() {
+            // Arrange
+            var field = typeof(NullableDisabled).GetField(nameof(NullableDisabled.NullableEnumVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void DelegateField() {
+            // Arrange
+            var field = typeof(NullableDisabled).GetField(nameof(NullableDisabled.DelegateVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void DynamicField() {
+            // Arrange
+            var field = typeof(NullableDisabled).GetField(nameof(NullableDisabled.DynamicVar))!;
+
+            // Act
+            var nullability = field.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void Event() {
+            // Arrange
+            var evnt = typeof(NullableDisabled).GetEvent(nameof(NullableDisabled.Event))!;
+
+            // Act
+            var nullability = evnt.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void ReferenceParameter() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetConstructors()[0].GetParameters()[0]!;
+            param.Name.Should().Be("RefParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullablePrimitiveParameter() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetConstructors()[0].GetParameters()[1]!;
+            param.Name.Should().Be("NonNullablePrimitiveParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullablePrimitiveParameter() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetConstructors()[0].GetParameters()[2]!;
+            param.Name.Should().Be("NullablePrimitiveParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableEnumParameter() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetConstructors()[0].GetParameters()[3]!;
+            param.Name.Should().Be("NonNullableEnumParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableEnumParameter() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetConstructors()[0].GetParameters()[4]!;
+            param.Name.Should().Be("NullableEnumParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void DelegateParameter() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetConstructors()[0].GetParameters()[5]!;
+            param.Name.Should().Be("DelegateParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void DynamicParameter() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetConstructors()[0].GetParameters()[6]!;
+            param.Name.Should().Be("DynamicParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void ReferenceReturn() {
+            // Arrange
+            var retval = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.RefReturn))!.ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullablePrimitiveReturn() {
+            // Arrange
+            var retval = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NonNullablePrimitiveReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullablePrimitiveReturn() {
+            // Arrange
+            var retval = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NullablePrimitiveReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NonNullableEnumReturn() {
+            // Arrange
+            var retval = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NonNullableEnumReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NullableEnumReturn() {
+            // Arrange
+            var retval = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NullableEnumReturn))!
+                .ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void DelegateReturn() {
+            // Arrange
+            var retval = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.DelegateReturn))!.ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void DynamicReturn() {
+            // Arrange
+            var retval = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.DynamicReturn))!.ReturnParameter;
+
+            // Act
+            var nullability = retval.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void UnrestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.UnrestrictedGeneric))!;
+            var ambiguousArg = method.GetParameters()[0]!;
+            var retval = method.ReturnParameter;
+
+            // Act
+            var nullability0 = ambiguousArg.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.Nullable);                 // limitation in reflection capabilities
+            returnNullability.Should().Be(Nullability.Nullable);            // limitation in reflection capabilities
+        }
+
+        [TestMethod] public void ClassRestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.ClassRestrictedGeneric))!;
+            var nullableArg = method.GetParameters()[0]!;
+            var retval = method.ReturnParameter;
+
+            // Act
+            var nullability0 = nullableArg.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.Nullable);
+            returnNullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void StructRestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.StructRestrictedGeneric))!;
+            var nonNullableArg = method.GetParameters()[0]!;
+            var nullableArg = method.GetParameters()[1]!;
+            var retval = method.ReturnParameter;
+
+            // Act
+            var nullability0 = nonNullableArg.GetNullability();
+            var nullability1 = nullableArg.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.NonNullable);
+            nullability1.Should().Be(Nullability.Nullable);
+            returnNullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void EnumRestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.EnumRestrictedGeneric))!;
+            var nonNullableArg = method.GetParameters()[0]!;
+            var retval = method.ReturnParameter;
+
+            // Act
+            var nullability0 = nonNullableArg.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.NonNullable);
+            returnNullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NotNullRestrictedGeneric() {
+            // Arrange
+            var method = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NotNullRestrictedGeneric))!;
+            var ambiguousArg = method.GetParameters()[0]!;
+            var retval = method.ReturnParameter;
+
+            // Act
+            var nullability0 = ambiguousArg.GetNullability();
+            var returnNullability = retval.GetNullability();
+
+            // Assert
+            nullability0.Should().Be(Nullability.Nullable);                 // limitation in reflection capabilities
+            returnNullability.Should().Be(Nullability.Nullable);            // limitation in reflection capabilities
+        }
+    }
+
+    [TestClass, TestCategory("Nullability: Nested Context")]
+    public sealed class Nullability_NestedContext {
+        [TestMethod] public void NestedEnabledNonNullableRef() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NestedMethod))!.GetParameters()[0]!;
+            param.Name.Should().Be("NonNullableRefParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NestedEnabledNullableRef() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NestedMethod))!.GetParameters()[1]!;
+            param.Name.Should().Be("NullableRefParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NestedEnabledNonNullablePrimitive() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NestedMethod))!.GetParameters()[2]!;
+            param.Name.Should().Be("NonNullablePrimitiveParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NestedEnabledNullablePrimitive() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NestedMethod))!.GetParameters()[3]!;
+            param.Name.Should().Be("NullablePrimitiveParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NestedEnabledNonNullableEnum() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NestedMethod))!.GetParameters()[4]!;
+            param.Name.Should().Be("NonNullableEnumParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NestedEnabledNullableEnum() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NestedMethod))!.GetParameters()[5]!;
+            param.Name.Should().Be("NullableEnumParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NestedEnabledNonNullableDelegate() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NestedMethod))!.GetParameters()[6]!;
+            param.Name.Should().Be("NonNullableDelegateParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NestedEnabledNullableDelegate() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NestedMethod))!.GetParameters()[7]!;
+            param.Name.Should().Be("NullableDelegateParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NestedEnabledNonNullableDynamic() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NestedMethod))!.GetParameters()[8]!;
+            param.Name.Should().Be("NonNullableDynamicParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NestedEnabledNullableDynamic() {
+            // Arrange
+            var param = typeof(NullableDisabled).GetMethod(nameof(NullableDisabled.NestedMethod))!.GetParameters()[9]!;
+            param.Name.Should().Be("NullableDynamicParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NestedDisabledReference() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NestedMethod))!.GetParameters()[0]!;
+            param.Name.Should().Be("RefParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NestedDisabledNonNullablePrimitive() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NestedMethod))!.GetParameters()[1]!;
+            param.Name.Should().Be("NonNullablePrimitiveParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NestedDisabledNullablePrimitive() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NestedMethod))!.GetParameters()[2]!;
+            param.Name.Should().Be("NullablePrimitiveParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NestedDisabledNonNullableEnum() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NestedMethod))!.GetParameters()[3]!;
+            param.Name.Should().Be("NonNullableEnumParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.NonNullable);
+        }
+
+        [TestMethod] public void NestedDisabledNullableEnum() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NestedMethod))!.GetParameters()[4]!;
+            param.Name.Should().Be("NullableEnumParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NestedDisabledDelegate() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NestedMethod))!.GetParameters()[5]!;
+            param.Name.Should().Be("DelegateParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+
+        [TestMethod] public void NestedDisabledDynamic() {
+            // Arrange
+            var param = typeof(NullableEnabled).GetMethod(nameof(NullableEnabled.NestedMethod))!.GetParameters()[6]!;
+            param.Name.Should().Be("DynamicParam");
+
+            // Act
+            var nullability = param.GetNullability();
+
+            // Assert
+            nullability.Should().Be(Nullability.Nullable);
+        }
+    }
+}

--- a/test/UnitTests/Cybele/Extensions/_TestClass.cs
+++ b/test/UnitTests/Cybele/Extensions/_TestClass.cs
@@ -131,4 +131,123 @@ namespace UT.Cybele.Extensions {
 
         protected static readonly Random rand = new Random(02291996);
     }
+
+    #nullable enable
+    public sealed class NullableEnabled {
+        // Properties
+        public string NonNullableRefProp => "";
+        public string? NullableRefProp => null;
+        public int NonNullablePrimitiveProp => 0;
+        public int? NullablePrimitiveProp => null;
+        public LoaderOptimization NonNullableEnumProp => 0;
+        public LoaderOptimization? NullableEnumProp => null;
+        public Action NonNullableDelegateProp => () => {};
+        public Action? NullableDeleateProp => null;
+        public dynamic NonNullableDynamicProp => 0;
+        public dynamic? NullableDynamicProp => null;
+
+        // Member Variables
+        public string NonNullableRefVar = "";
+        public string? NullableRefVar = null;
+        public int NonNullablePrimitiveVar = 0;
+        public int? NullablePrimitiveVar = null;
+        public LoaderOptimization NonNullableEnumVar = 0;
+        public LoaderOptimization? NullableEnumVar = null;
+        public Action NonNullableDelegateVar = () => {};
+        public Action? NullableDelegateVar = null;
+        public dynamic NonNullableDynamicVar = 0;
+        public dynamic? NullableDynamicVar = null;
+
+        // Events
+        public event EventHandler NonNullableEvent = new EventHandler((_, _) => {});
+        public event EventHandler? NullableEvent = null;
+
+        // Constructor (to evaluate non-generic parameters)
+        public NullableEnabled(string NonNullableRefParam, string? NullableRefParam, int NonNullablePrimitiveParam,
+            int? NullablePrimitiveParam, LoaderOptimization NonNullableEnumParam,
+            LoaderOptimization? NullableEnumParam, Action NonNullableDelegateParam, Action? NullableDelegateParam,
+            dynamic NonNullableDynamicParam, dynamic? NullableDynamicParam
+        ) {}
+
+        // Member Functions (to evaluate return values)
+        public string NonNullableRefReturn() { throw new NotImplementedException(); }
+        public string? NullableRefReturn() { throw new NotImplementedException(); }
+        public int NonNullablePrimitiveReturn() { throw new NotImplementedException(); }
+        public int? NullablePrimitiveReturn() { throw new NotImplementedException(); }
+        public LoaderOptimization NonNullableEnumReturn() { throw new NotImplementedException(); }
+        public LoaderOptimization? NullableEnumReturn() { throw new NotImplementedException(); }
+        public Action NonNullableDelegateReturn() { throw new NotImplementedException(); }
+        public Action? NullableDelegateReturn() { throw new NotImplementedException(); }
+        public dynamic NonNullableDynamicReturn() { throw new NotImplementedException(); }
+        public dynamic? NullableDynamicReturn() { throw new NotImplementedException(); }
+
+        // Member Functions (to evaluate generics)
+        public T UnrestrictedGeneric<T>(T ambiguous, T? alsoAmbiguous) { return default!; }
+        public T NonNullableClassRestrictedGeneric<T>(T nonNullable, T? nullable) where T : class { return default!; }
+        public T NullableClassRestrictedGeneric<T>(T ambiguous, T? nullable) where T : class? { return default!; }
+        public T StructRestrictedGeneric<T>(T nonNullable, T? nullable) where T : struct { return default!; }
+        public T EnumRestrictedGeneric<T>(T nonNullable, T? alsoNonNullable) where T : Enum { return default!; }
+        public T NotNullRestrictedGeneric<T>(T nonNullable, T? ambiguous) where T : notnull { return default!; }
+
+        #nullable disable
+        public void NestedMethod(string RefParam, int NonNullablePrimitiveParam, int? NullablePrimitiveParam,
+            LoaderOptimization NonNullableEnumParam, LoaderOptimization? NullableEnumParam, Action DelegateParam,
+            dynamic DynamicParam) {}
+        #nullable restore
+    }
+    #nullable restore
+
+    #nullable disable
+    public sealed class NullableDisabled {
+        // Properties
+        public string RefProp => null;
+        public int NonNullablePrimitiveProp => 0;
+        public int? NullablePrimitiveProp => null;
+        public LoaderOptimization NonNullableEnumProp => 0;
+        public LoaderOptimization? NullableEnumProp => null;
+        public Action DelegateProp => null;
+        public dynamic DynamicProp => null;
+
+        // Member Variables
+        public string RefVar = null;
+        public int NonNullablePrimitiveVar = 0;
+        public int? NullablePrimitiveVar = null;
+        public LoaderOptimization NonNullableEnumVar = 0;
+        public LoaderOptimization? NullableEnumVar = null;
+        public Action DelegateVar = null;
+        public dynamic DynamicVar = null;
+
+        // Events
+        public event EventHandler Event = null;
+
+        // Constructor (to evaluate non-generic parameters)
+        public NullableDisabled(string RefParam, int NonNullablePrimitiveParam, int? NullablePrimitiveParam,
+            LoaderOptimization NonNullableEnumParam, LoaderOptimization? NullableEnumParam, Action DelegateParam,
+            dynamic DynamicParam
+        ) {}
+
+        // Member Functions (to evaluate return values)
+        public string RefReturn() { throw new NotImplementedException(); }
+        public int NonNullablePrimitiveReturn() { throw new NotImplementedException(); }
+        public int? NullablePrimitiveReturn() { throw new NotImplementedException(); }
+        public LoaderOptimization NonNullableEnumReturn() { throw new NotImplementedException(); }
+        public LoaderOptimization? NullableEnumReturn() { throw new NotImplementedException(); }
+        public Action DelegateReturn() { throw new NotImplementedException(); }
+        public dynamic DynamicReturn() { throw new NotImplementedException(); }
+
+        // Member Functions (to evaluate generics)
+        public T UnrestrictedGeneric<T>(T ambiguous) { return default!; }
+        public T ClassRestrictedGeneric<T>(T nullable) where T : class { return default!; }
+        public T StructRestrictedGeneric<T>(T nonNullable, T? nullable) where T : struct { return default!; }
+        public T EnumRestrictedGeneric<T>(T nonNullable) where T : Enum { return default!; }
+        public T NotNullRestrictedGeneric<T>(T ambiguous) where T : notnull { return default!; }
+
+        #nullable enable
+        public void NestedMethod(string NonNullableRefParam, string? NullableRefParam, int NonNullablePrimitiveParam,
+            int? NullablePrimitiveParam, LoaderOptimization NonNullableEnumParam,
+            LoaderOptimization? NullableEnumParam, Action NonNullableDelegateParam, Action? NullableDelegateParam,
+            dynamic NonNullableDynamicParam, dynamic? NullableDynamicParam) {}
+        #nullable restore
+    }
+    #nullable restore
 }


### PR DESCRIPTION
This commit adds a family of extension methods for determining the nullability of properties, member variables (fields),
events, funciton parameters, and function return types. These methods attempt to resolve the nullability without using
reflection, but will fall back to interrogating the Roslyn-specified compiler metadata if necessary. The functions work
fine for closed generics but may report an inaccurate non-Ambiguous result for certain open generics (these are all
documented in-source).