### PR TITLE
StickyList

### DIFF
--- a/src/Cybele/Collections/StickyList.cs
+++ b/src/Cybele/Collections/StickyList.cs
@@ -1,0 +1,425 @@
+﻿using Ardalis.GuardClauses;
+using Cybele.Extensions;
+using Optional;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Cybele.Collections {
+    /// <summary>
+    ///   An indexable collection in which certain elements are "stuck" in specific slots while others may move from
+    ///   slot to slot.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     Elements in a <see cref="StickyList{T}"/> come in two flavors: sticky and non-sticky. A sticky element is
+    ///     inserted with a specific index and will not move from that slot. A non-sticky element is added to the
+    ///     collection in the first available slot, being appended on the end if there are no gaps; that element may
+    ///     move to a new slot if a gap arises later. Because of this, the order of elements within the collection is
+    ///     volatile and should not be relied on; only the positions of sticky elements is guaranteed.
+    ///   </para>
+    ///   <para>
+    ///     The nature of sticky elements means that performing operations on a <see cref="StickyList{T}"/> may lead to
+    ///     "gaps." For example, inserting a sticky element at index <c>3</c> into an empty list will produce a gap in
+    ///     slots <c>0</c>, <c>1</c>, and <c>2</c>. Attempting to access an element at this index for any reason will
+    ///     result in an exception, much like attempting to read beyond the end of the list. However, the
+    ///     <see cref="StickyList{T}"/> will do what it can to minimize gaps by rearranging non-sticky elements when
+    ///     gaps arise; if the gaps cannot be fully eliminated, they will be pushed as far to the back of the list as
+    ///     possible. On iteration, gaps are ignored.
+    ///   </para>
+    /// </remarks>
+    /// <typeparam name="T">
+    ///   The type of element to be stored in the StickyList.
+    /// </typeparam>
+    public sealed class StickyList<T> : IReadOnlyList<T>, IList<T> {
+        /// <summary>
+        ///   Gets or sets the element at the specified index in the <see cref="StickyList{T}"/>.
+        /// </summary>
+        /// <param name="index">
+        ///   [GET] The <c>0</c>-based index of the element to return.
+        ///   [SET] The <c>0</c>-based index at which to insert the new element.
+        /// </param>
+        /// <returns>
+        ///   [GET] The element at index <paramref name="index"/>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   [GET] if <paramref name="index"/> is negative or if there is no element at the specified position,
+        ///     including if it is larger than <see cref="LargestIndex"/>.
+        ///   [SET] if <paramref name="index"/> is negative
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   [SET] if a sticky element is already in the StickyList at position <paramref name="index"/>.
+        /// </exception>
+        public T this[int index] {
+            get {
+                return elements_[index].ValueOr(
+                    () => throw new ArgumentOutOfRangeException(nameof(index), "Requested index is a gap")
+                ).item;
+            }
+            set {
+                Insert(index, value);
+            }
+        }
+
+        /// <summary>
+        ///   The number of elements contained in the <see cref="StickyList{T}"/>. This count ignores gaps, and
+        ///   therefore may be less than <see cref="LargestIndex"/>.
+        /// </summary>
+        public int Count { get; private set; }
+
+        /// <summary>
+        ///   The largest <c>0</c>-based index that is <see cref="IsOccupied(int)">occupied</see> by an element in the
+        ///   <see cref="StickyList{T}"/>. If the list is empty, this property returns <c>-1</c>.
+        /// </summary>
+        public int LargestIndex => elements_.Count - 1;
+
+        /// <summary>
+        ///   Whether or not there are any gaps in the <see cref="StickyList{T}"/>.
+        /// </summary>
+        public bool HasGaps => (Count != elements_.Count);
+
+        /// <inheritdoc/>
+        bool ICollection<T>.IsReadOnly => false;
+
+        /// <summary>
+        ///   Constructs a new, empty <see cref="StickyList{T}"/> that uses the default <see cref="IEqualityComparer"/>
+        ///   for <typeparamref name="T"/> for comparison purposes.
+        /// </summary>
+        public StickyList()
+            : this(Enumerable.Empty<T>()) {}
+
+        /// <summary>
+        ///   Constructs a new <see cref="StickyList{T}"/> that uses the default <see cref="IEqualityComparer"/> for
+        ///   <typeparamref name="T"/> for comparison purposes and is populated with the non-sticky contents of another
+        ///   enumerable.
+        /// </summary>
+        /// <param name="enumerable">
+        ///   The enumerable from which to populate the initial state of the new StickyList. All elemenets will be
+        ///   initialized as non-sticky.
+        /// </param>
+        public StickyList(IEnumerable<T> enumerable)
+            : this(enumerable, EqualityComparer<T>.Default) {}
+
+        /// <summary>
+        ///   Constructs a new, empty <see cref="StickyList{T}"/> that uses a custom <see cref="IEqualityComparer"/>
+        ///   for comparison purposes.
+        /// </summary>
+        /// <param name="comparer">
+        ///   The <see cref="IEqualityComparer{T}"/> that the new StickyList should use for comparisons.
+        /// </param>
+        public StickyList(IEqualityComparer<T> comparer)
+            : this(Enumerable.Empty<T>(), comparer) {}
+
+        /// <summary>
+        ///   Constructs a new <see cref="StickyList{T}"/> that uses a custom <see cref="IEqualityComparer{T}"/> for
+        ///   comparison purposes and is populated with the non-sticky contents of another enumerable.
+        /// </summary>
+        /// <param name="enumerable">
+        ///   The enumerable from which to populate the initial state of the new StickyList. All elemenets will be
+        ///   initialized as non-sticky.
+        /// </param>
+        /// <param name="comparer">
+        ///   The <see cref="IEqualityComparer{T}"/> that the new StickyList should use for comparisons.
+        /// </param>
+        public StickyList(IEnumerable<T> enumerable, IEqualityComparer<T> comparer) {
+            Guard.Against.Null(enumerable, nameof(enumerable));
+            Guard.Against.Null(comparer, nameof(comparer));
+
+            elements_ = enumerable.Select(i => Option.Some((i, false))).ToList();
+            comparer_ = comparer;
+
+            Count = elements_.Count;
+            EnsureInvariant();
+        }
+
+        /// <summary>
+        ///   Checks if a particular index in the <see cref="StickyList{T}"/> is occupied by an element.
+        /// </summary>
+        /// <param name="index">
+        ///   The <c>0</c>-based index at which to check.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the StickyList contains an element at position <paramref name="index"/>;
+        ///   otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is negative or not less than <see cref="LargestIndex"/>.
+        /// </exception>
+        public bool IsOccupied(int index) {
+            return elements_[index].HasValue;
+        }
+
+        /// <summary>
+        ///   Checks if an element at a particular index in the <see cref="StickyList{T}"/> is "sticky."
+        /// </summary>
+        /// <param name="index">
+        ///   The <c>0</c>-based index at which to check.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the element at position <paramref name="index"/> is "sticky"; otherwise,
+        ///   <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is negative or if there is no element at the specified position, including if
+        ///   it is larger than <see cref="LargestIndex"/>.
+        /// </exception>
+        public bool IsSticky(int index) {
+            return elements_[index].Match(some: elt => elt.isSticky, none: () => false);
+        }
+
+        /// <summary>
+        ///   Checks if an elemment exists in the <see cref="StickyList{T}"/>.
+        /// </summary>
+        /// <param name="element">
+        ///   The probe element.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the StickyList contains an element that compares equal to
+        ///   <paramref name="element"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool Contains(T element) {
+            return this.Any(entry => comparer_.Equals(entry, element));
+        }
+
+        /// <summary>
+        ///   Determines the <c>0</c>-based index of an element in the <see cref="StickyList{T}"/>.
+        /// </summary>
+        /// <param name="element">
+        ///   The probe element.
+        /// </param>
+        /// <returns>
+        ///   The <c>0</c>-based index of the first element in the StickList that compares equal to
+        ///   <paramref name="element"/>, if suh an element exists; otherwise, <c>-1</c>.
+        /// </returns>
+        public int IndexOf(T element) {
+            for (var idx = 0; idx < elements_.Count; ++idx) {
+                if (elements_[idx].HasValue && comparer_.Equals(elements_[idx].Unwrap().item, element)) {
+                    return idx;
+                }
+            }
+            return -1;
+        }
+
+        /// <summary>
+        ///   Adds a new non-sticky element into the <see cref="StickyList{T}"/>. If there are no gaps, the element
+        ///   will be appended onto the end of the collection. If there are any gaps, the element will be placed into
+        ///   the unoccupied slot with the smallest index.
+        /// </summary>
+        /// <param name="element">
+        ///   The new element to add.
+        /// </param>
+        public void Add(T element) {
+            ++Count;
+            var entry = Option.Some((element, false));
+
+            for (int i = 0; i < elements_.Count; ++i) {
+                if (!elements_[i].HasValue) {
+                    elements_[i] = entry;
+                    return;
+                }
+            }
+            elements_.Add(entry);
+
+            EnsureInvariant();
+        }
+
+        /// <summary>
+        ///   Adds a new sticky element into the <see cref="StickyList{T}"/> at a specified position. If that position
+        ///   is occupied by a non-sticky element, it will be displaced and <see cref="Add(T)">added back</see>. If
+        ///   that position is beyond the current endpoint of the collection, a new gap will be created.
+        /// </summary>
+        /// <param name="index">
+        ///   The <c>0</c>-based index at which to add the new element.
+        /// </param>
+        /// <param name="element">
+        ///   The new element to add.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is negative.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   if a sticky element already occupies position <paramref name="index"/>.
+        /// </exception>
+        public void Insert(int index, T element) {
+            var entry = Option.Some((element, true));
+
+            // Scenario 1: The target index is beyond the current end of the collection
+            if (index >= elements_.Count) {
+                var difference = index - elements_.Count + 1;
+                elements_.AddRange(Enumerable.Repeat(Option.None<(T, bool)>(), difference));
+                elements_[index] = entry;
+                ++Count;
+                EnsureInvariant();
+                return;
+            }
+
+            // Scenario 2: The target index is empty
+            if (!elements_[index].HasValue) {
+                elements_[index] = entry;
+                ++Count;
+                EnsureInvariant();
+                return;
+            }
+
+            // Scenario 3: The target index is occupied by a non-sticky entry
+            if (elements_[index].Exists(entry => !entry.isSticky)) {
+                Add(elements_[index].Unwrap().item);
+                elements_[index] = entry;
+                EnsureInvariant();
+                return;
+            }
+
+            // Scenario 4: The target index is occupied by a sticky entry
+            throw new InvalidOperationException($"Cannot insert new entry into StickList at index {index}: a sticky " +
+                "entry already occupies that position");
+        }
+
+        /// <summary>
+        ///   Removes the first element in the <see cref="StickyList{T}"/> that compares equal to a probe. If the
+        ///   removal creates a gap, non-sticky elements will be rearranged so as to push the gap toward the end.
+        ///   Elements will not be rearranged otherwise.
+        /// </summary>
+        /// <param name="element">
+        ///   The probe element.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if an element was removed; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool Remove(T element) {
+            var idx = IndexOf(element);
+            if (idx == -1) {
+                return false;
+            }
+
+            RemoveAt(idx);
+            EnsureInvariant();
+            return true;
+        }
+
+        /// <summary>
+        ///   Removes the element at a specified index from the <see cref="StickyList{T}"/>. If the removal creates a
+        ///   gap, non-sticky elements will be rearranged so as to push the gap toward the end. Elements will not be
+        ///   rearranged otherwise.
+        /// </summary>
+        /// <param name="index">
+        ///   The <c>0</c>-based index of the element to remove.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is negative or if there is no element at the specified position, including if
+        ///   it is larger than <see cref="LargestIndex"/>.
+        /// </exception>
+        public void RemoveAt(int index) {
+            if (!elements_[index].HasValue) {
+                throw new ArgumentOutOfRangeException(nameof(index), "Requested removal index is a gap");
+            }
+
+            elements_[index] = Option.None<(T, bool)>();
+            for (int i = elements_.Count - 1; i > index; --i) {
+                if (elements_[i].HasValue) {
+                    var (item, isSticky) = elements_[i].Unwrap();
+                    if (!isSticky) {
+                        elements_[index] = Option.Some((item, false));
+                        elements_[i] = Option.None<(T, bool)>();
+                        break;
+                    }
+                }
+            }
+
+            while (!elements_.IsEmpty() && !elements_[^1].HasValue) {
+                elements_.RemoveAt(elements_.Count - 1);
+            }
+
+            --Count;
+            EnsureInvariant();
+        }
+
+        /// <summary>
+        ///   Removes all elements from the <see cref="StickyList{T}"/>.
+        /// </summary>
+        public void Clear() {
+            elements_.Clear();
+            Count = 0;
+            EnsureInvariant();
+        }
+
+        /// <summary>
+        ///   Produces an enumerator that iterates over the elements of the <see cref="StickyList{T}"/>, skipping any
+        ///   gaps.
+        /// </summary>
+        /// <remarks>
+        ///   Because the StickyList's enumerator skips gaps, the sequence of items (and, by extension, the sequence
+        ///   produced by using LINQ to convert a StickyList to an Array or standard List) may not line up with indices
+        ///   as reported by other aspects of the API.
+        /// </remarks>
+        /// <returns>
+        ///   An enumerator over the elements of the StickyList in order, with all gaps skipped.
+        /// </returns>
+        public IEnumerator<T> GetEnumerator() {
+            foreach (var entry in elements_) {
+                if (entry.HasValue) {
+                    yield return entry.Unwrap().item;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Checks that the <see cref="StickyList{T}"/> invariant is maintained. Specifically, there should be no
+        ///   non-sticky elements present after the first gap; and, the Count should always reflect the number of
+        ///   non-empty entries in the collection.
+        /// </summary>
+        /// <remarks>
+        ///   Violation of a class invariant is always due to programmer error. User input should be sanitized and
+        ///   checked to ensure that its use does not violate invariants, with appropriate (documented) exceptions
+        ///   raised if necessary.
+        /// </remarks>
+        /// <exception cref="ApplicationException">
+        ///   if the current state of the StickList violates the class's invariant.
+        /// </exception>
+        [Conditional("DEBUG"), ExcludeFromCodeCoverage]
+        private void EnsureInvariant() {
+            bool encounteredGap = false;
+            int expectedCount = 0;
+
+            for (int i = 0; i < elements_.Count; ++i) {
+                if (!elements_[i].HasValue) {
+                    encounteredGap = true;
+                    continue;
+                }
+
+                ++expectedCount;
+                if (encounteredGap && !elements_[i].Unwrap().isSticky) {
+                    throw new ApplicationException($"Item at index {i} is non-sticky, but appears after a gap");
+                }
+            }
+
+            if (!elements_.IsEmpty() && !elements_[^1].HasValue) {
+                throw new ApplicationException($"There cannot be a gap at the end of the StickyList");
+            }
+            if (expectedCount != Count) {
+                throw new ApplicationException($"Actual count of {Count} does not match expected {expectedCount}");
+            }
+            if (encounteredGap != HasGaps) {
+                throw new ApplicationException($"HasGaps property is reporting incorrect result of {HasGaps}");
+            }
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        void ICollection<T>.CopyTo(T[] array, int arrayIndex) {
+            foreach (var item in this) {
+                array[arrayIndex++] = item;
+            }
+        }
+
+
+        private readonly List<Option<(T item, bool isSticky)>> elements_;
+        private readonly IEqualityComparer<T> comparer_;
+    }
+}

--- a/src/Cybele/Cybele.csproj
+++ b/src/Cybele/Cybele.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="3.0.1" />
+    <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Cybele/Extensions/Option.cs
+++ b/src/Cybele/Extensions/Option.cs
@@ -1,0 +1,32 @@
+﻿using Optional;
+using System;
+
+namespace Cybele.Extensions {
+    /// <summary>
+    ///   A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
+    ///   of the <see cref="Option{T}"/> class.
+    /// </summary>
+    public static class OptionExtensions {
+        /// <summary>
+        ///   Unwraps an <see cref="Option{T}"/>, exposing the wrapped value.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   [deduced] The type of value wrapped in the option.
+        /// </typeparam>
+        /// <param name="self">
+        ///   The option on which the extension method is invoked.
+        /// </param>
+        /// <returns>
+        ///   The value wrapped by <paramref name="self"/>.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   if <paramref name="self"/> is a <c>NONE</c> instance (i.e. an empty option).
+        /// </exception>
+        public static T Unwrap<T>(this Option<T> self) {
+            return self.Match(
+                some: t => t,
+                none: () => throw new InvalidOperationException("Cannot unwrap an empty option")
+            );
+        }
+    }
+}

--- a/src/Cybele/Intellisense.xml
+++ b/src/Cybele/Intellisense.xml
@@ -4,6 +4,263 @@
         <name>Cybele</name>
     </assembly>
     <members>
+        <member name="T:Cybele.Collections.StickyList`1">
+            <summary>
+              An indexable collection in which certain elements are "stuck" in specific slots while others may move from
+              slot to slot.
+            </summary>
+            <remarks>
+              <para>
+                Elements in a <see cref="T:Cybele.Collections.StickyList`1"/> come in two flavors: sticky and non-sticky. A sticky element is
+                inserted with a specific index and will not move from that slot. A non-sticky element is added to the
+                collection in the first available slot, being appended on the end if there are no gaps; that element may
+                move to a new slot if a gap arises later. Because of this, the order of elements within the collection is
+                volatile and should not be relied on; only the positions of sticky elements is guaranteed.
+              </para>
+              <para>
+                The nature of sticky elements means that performing operations on a <see cref="T:Cybele.Collections.StickyList`1"/> may lead to
+                "gaps." For example, inserting a sticky element at index <c>3</c> into an empty list will produce a gap in
+                slots <c>0</c>, <c>1</c>, and <c>2</c>. Attempting to access an element at this index for any reason will
+                result in an exception, much like attempting to read beyond the end of the list. However, the
+                <see cref="T:Cybele.Collections.StickyList`1"/> will do what it can to minimize gaps by rearranging non-sticky elements when
+                gaps arise; if the gaps cannot be fully eliminated, they will be pushed as far to the back of the list as
+                possible. On iteration, gaps are ignored.
+              </para>
+            </remarks>
+            <typeparam name="T">
+              The type of element to be stored in the StickyList.
+            </typeparam>
+        </member>
+        <member name="P:Cybele.Collections.StickyList`1.Item(System.Int32)">
+            <summary>
+              Gets or sets the element at the specified index in the <see cref="T:Cybele.Collections.StickyList`1"/>.
+            </summary>
+            <param name="index">
+              [GET] The <c>0</c>-based index of the element to return.
+              [SET] The <c>0</c>-based index at which to insert the new element.
+            </param>
+            <returns>
+              [GET] The element at index <paramref name="index"/>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              [GET] if <paramref name="index"/> is negative or if there is no element at the specified position,
+                including if it is larger than <see cref="P:Cybele.Collections.StickyList`1.LargestIndex"/>.
+              [SET] if <paramref name="index"/> is negative
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+              [SET] if a sticky element is already in the StickyList at position <paramref name="index"/>.
+            </exception>
+        </member>
+        <member name="P:Cybele.Collections.StickyList`1.Count">
+            <summary>
+              The number of elements contained in the <see cref="T:Cybele.Collections.StickyList`1"/>. This count ignores gaps, and
+              therefore may be less than <see cref="P:Cybele.Collections.StickyList`1.LargestIndex"/>.
+            </summary>
+        </member>
+        <member name="P:Cybele.Collections.StickyList`1.LargestIndex">
+            <summary>
+              The largest <c>0</c>-based index that is <see cref="M:Cybele.Collections.StickyList`1.IsOccupied(System.Int32)">occupied</see> by an element in the
+              <see cref="T:Cybele.Collections.StickyList`1"/>. If the list is empty, this property returns <c>-1</c>.
+            </summary>
+        </member>
+        <member name="P:Cybele.Collections.StickyList`1.HasGaps">
+            <summary>
+              Whether or not there are any gaps in the <see cref="T:Cybele.Collections.StickyList`1"/>.
+            </summary>
+        </member>
+        <member name="P:Cybele.Collections.StickyList`1.System#Collections#Generic#ICollection{T}#IsReadOnly">
+            <inheritdoc/>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.#ctor">
+            <summary>
+              Constructs a new, empty <see cref="T:Cybele.Collections.StickyList`1"/> that uses the default <see cref="T:System.Collections.IEqualityComparer"/>
+              for <typeparamref name="T"/> for comparison purposes.
+            </summary>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.#ctor(System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+              Constructs a new <see cref="T:Cybele.Collections.StickyList`1"/> that uses the default <see cref="T:System.Collections.IEqualityComparer"/> for
+              <typeparamref name="T"/> for comparison purposes and is populated with the non-sticky contents of another
+              enumerable.
+            </summary>
+            <param name="enumerable">
+              The enumerable from which to populate the initial state of the new StickyList. All elemenets will be
+              initialized as non-sticky.
+            </param>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.#ctor(System.Collections.Generic.IEqualityComparer{`0})">
+            <summary>
+              Constructs a new, empty <see cref="T:Cybele.Collections.StickyList`1"/> that uses a custom <see cref="T:System.Collections.IEqualityComparer"/>
+              for comparison purposes.
+            </summary>
+            <param name="comparer">
+              The <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> that the new StickyList should use for comparisons.
+            </param>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.#ctor(System.Collections.Generic.IEnumerable{`0},System.Collections.Generic.IEqualityComparer{`0})">
+            <summary>
+              Constructs a new <see cref="T:Cybele.Collections.StickyList`1"/> that uses a custom <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> for
+              comparison purposes and is populated with the non-sticky contents of another enumerable.
+            </summary>
+            <param name="enumerable">
+              The enumerable from which to populate the initial state of the new StickyList. All elemenets will be
+              initialized as non-sticky.
+            </param>
+            <param name="comparer">
+              The <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> that the new StickyList should use for comparisons.
+            </param>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.IsOccupied(System.Int32)">
+            <summary>
+              Checks if a particular index in the <see cref="T:Cybele.Collections.StickyList`1"/> is occupied by an element.
+            </summary>
+            <param name="index">
+              The <c>0</c>-based index at which to check.
+            </param>
+            <returns>
+              <see langword="true"/> if the StickyList contains an element at position <paramref name="index"/>;
+              otherwise, <see langword="false"/>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is negative or not less than <see cref="P:Cybele.Collections.StickyList`1.LargestIndex"/>.
+            </exception>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.IsSticky(System.Int32)">
+            <summary>
+              Checks if an element at a particular index in the <see cref="T:Cybele.Collections.StickyList`1"/> is "sticky."
+            </summary>
+            <param name="index">
+              The <c>0</c>-based index at which to check.
+            </param>
+            <returns>
+              <see langword="true"/> if the element at position <paramref name="index"/> is "sticky"; otherwise,
+              <see langword="false"/>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is negative or if there is no element at the specified position, including if
+              it is larger than <see cref="P:Cybele.Collections.StickyList`1.LargestIndex"/>.
+            </exception>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.Contains(`0)">
+            <summary>
+              Checks if an elemment exists in the <see cref="T:Cybele.Collections.StickyList`1"/>.
+            </summary>
+            <param name="element">
+              The probe element.
+            </param>
+            <returns>
+              <see langword="true"/> if the StickyList contains an element that compares equal to
+              <paramref name="element"/>; otherwise, <see langword="false"/>.
+            </returns>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.IndexOf(`0)">
+            <summary>
+              Determines the <c>0</c>-based index of an element in the <see cref="T:Cybele.Collections.StickyList`1"/>.
+            </summary>
+            <param name="element">
+              The probe element.
+            </param>
+            <returns>
+              The <c>0</c>-based index of the first element in the StickList that compares equal to
+              <paramref name="element"/>, if suh an element exists; otherwise, <c>-1</c>.
+            </returns>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.Add(`0)">
+            <summary>
+              Adds a new non-sticky element into the <see cref="T:Cybele.Collections.StickyList`1"/>. If there are no gaps, the element
+              will be appended onto the end of the collection. If there are any gaps, the element will be placed into
+              the unoccupied slot with the smallest index.
+            </summary>
+            <param name="element">
+              The new element to add.
+            </param>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.Insert(System.Int32,`0)">
+            <summary>
+              Adds a new sticky element into the <see cref="T:Cybele.Collections.StickyList`1"/> at a specified position. If that position
+              is occupied by a non-sticky element, it will be displaced and <see cref="M:Cybele.Collections.StickyList`1.Add(`0)">added back</see>. If
+              that position is beyond the current endpoint of the collection, a new gap will be created.
+            </summary>
+            <param name="index">
+              The <c>0</c>-based index at which to add the new element.
+            </param>
+            <param name="element">
+              The new element to add.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is negative.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+              if a sticky element already occupies position <paramref name="index"/>.
+            </exception>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.Remove(`0)">
+            <summary>
+              Removes the first element in the <see cref="T:Cybele.Collections.StickyList`1"/> that compares equal to a probe. If the
+              removal creates a gap, non-sticky elements will be rearranged so as to push the gap toward the end.
+              Elements will not be rearranged otherwise.
+            </summary>
+            <param name="element">
+              The probe element.
+            </param>
+            <returns>
+              <see langword="true"/> if an element was removed; otherwise, <see langword="false"/>.
+            </returns>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.RemoveAt(System.Int32)">
+            <summary>
+              Removes the element at a specified index from the <see cref="T:Cybele.Collections.StickyList`1"/>. If the removal creates a
+              gap, non-sticky elements will be rearranged so as to push the gap toward the end. Elements will not be
+              rearranged otherwise.
+            </summary>
+            <param name="index">
+              The <c>0</c>-based index of the element to remove.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is negative or if there is no element at the specified position, including if
+              it is larger than <see cref="P:Cybele.Collections.StickyList`1.LargestIndex"/>.
+            </exception>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.Clear">
+            <summary>
+              Removes all elements from the <see cref="T:Cybele.Collections.StickyList`1"/>.
+            </summary>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.GetEnumerator">
+            <summary>
+              Produces an enumerator that iterates over the elements of the <see cref="T:Cybele.Collections.StickyList`1"/>, skipping any
+              gaps.
+            </summary>
+            <remarks>
+              Because the StickyList's enumerator skips gaps, the sequence of items (and, by extension, the sequence
+              produced by using LINQ to convert a StickyList to an Array or standard List) may not line up with indices
+              as reported by other aspects of the API.
+            </remarks>
+            <returns>
+              An enumerator over the elements of the StickyList in order, with all gaps skipped.
+            </returns>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.EnsureInvariant">
+            <summary>
+              Checks that the <see cref="T:Cybele.Collections.StickyList`1"/> invariant is maintained. Specifically, there should be no
+              non-sticky elements present after the first gap; and, the Count should always reflect the number of
+              non-empty entries in the collection.
+            </summary>
+            <remarks>
+              Violation of a class invariant is always due to programmer error. User input should be sanitized and
+              checked to ensure that its use does not violate invariants, with appropriate (documented) exceptions
+              raised if necessary.
+            </remarks>
+            <exception cref="T:System.ApplicationException">
+              if the current state of the StickList violates the class's invariant.
+            </exception>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.System#Collections#IEnumerable#GetEnumerator">
+            <inheritdoc/>
+        </member>
+        <member name="M:Cybele.Collections.StickyList`1.System#Collections#Generic#ICollection{T}#CopyTo(`0[],System.Int32)">
+            <inheritdoc/>
+        </member>
         <member name="T:Cybele.Core.ConceptString`1">
             <summary>
               A strongly typed piece of text for representing specific domain concepts.
@@ -719,6 +976,29 @@
               <see cref="T:System.Type"/> <paramref name="type"/> defined in <paramref name="context"/> with
               <paramref name="attributes"/>.
             </returns>
+        </member>
+        <member name="T:Cybele.Extensions.OptionExtensions">
+            <summary>
+              A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
+              of the <see cref="T:Optional.Option`1"/> class.
+            </summary>
+        </member>
+        <member name="M:Cybele.Extensions.OptionExtensions.Unwrap``1(Optional.Option{``0})">
+            <summary>
+              Unwraps an <see cref="T:Optional.Option`1"/>, exposing the wrapped value.
+            </summary>
+            <typeparam name="T">
+              [deduced] The type of value wrapped in the option.
+            </typeparam>
+            <param name="self">
+              The option on which the extension method is invoked.
+            </param>
+            <returns>
+              The value wrapped by <paramref name="self"/>.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+              if <paramref name="self"/> is a <c>NONE</c> instance (i.e. an empty option).
+            </exception>
         </member>
     </members>
 </doc>

--- a/test/UnitTests/Cybele/Collections/StickyListTests.cs
+++ b/test/UnitTests/Cybele/Collections/StickyListTests.cs
@@ -1,0 +1,523 @@
+﻿using Cybele.Collections;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace UT.Cybele.Collections {
+    [TestClass, TestCategory("StickyList")]
+    public sealed class StickyListTests {
+        [TestMethod] public void Empty() {
+            // Arrange
+
+            // Act
+            var list = new StickyList<float>();
+
+            // Assert
+            list.Should().BeEmpty();
+            list.LargestIndex.Should().Be(-1);
+            (list as ICollection<float>).IsReadOnly.Should().BeFalse();
+        }
+
+        [TestMethod] public void ConstructFromEnumerable() {
+            // Arrange
+            var contents = new string[] { "Las Cruces", "St. Augustine", "Asheville", "Scranton", "Wilmington" };
+
+            // Act
+            var defaultList = new StickyList<string>(contents);
+            var customList = new StickyList<string>(contents, StringComparer.OrdinalIgnoreCase);
+
+            // Assert
+            defaultList.Should().HaveCount(contents.Length);
+            customList.Should().HaveCount(contents.Length);
+            for (var i = 0; i < contents.Length; ++i) {
+                defaultList[i].Should().Be(contents[i]);
+                defaultList.IsOccupied(i).Should().BeTrue();
+                defaultList.IsSticky(i).Should().BeFalse();
+
+                customList[i].Should().Be(contents[i]);
+                customList.IsOccupied(i).Should().BeTrue();
+                customList.IsSticky(i).Should().BeFalse();
+            }
+            defaultList.HasGaps.Should().BeFalse();
+            customList.HasGaps.Should().BeFalse();
+        }
+
+        [TestMethod] public void AddNonSticky() {
+            // Arrange
+            var list = new StickyList<int>();
+            var elt0 = 49;
+            var elt1 = 316722;
+            var elt2 = -9281;
+
+            // Act
+            list.Add(elt0);
+            list.Add(elt1);
+            list.Add(elt2);
+
+            // Assert
+            list.Should().HaveCount(3);
+            list[0].Should().Be(elt0);
+            list[1].Should().Be(elt1);
+            list[2].Should().Be(elt2);
+            for (int i = 0; i <= 2; ++i) {
+                list.IsOccupied(i).Should().BeTrue();
+                list.IsSticky(i).Should().BeFalse();
+            }
+            list.HasGaps.Should().BeFalse();
+        }
+
+        [TestMethod] public void AddNonStickyToFillGaps() {
+            // Arrange
+            var list = new StickyList<double>();
+            list.Insert(3, 525.600);
+            list.Insert(0, -12.44414);
+            list.HasGaps.Should().BeTrue();
+
+            // Act
+            list.Add(72.07099);
+            list.Add(-23.1);
+            list.Add(691827.00128);
+
+            // Assert
+            list.HasGaps.Should().BeFalse();
+            list.Should().HaveCount(5);
+            list.LargestIndex.Should().Be(list.Count - 1);
+        }
+
+        [TestMethod] public void InsertSticky() {
+            // Arrange
+            var list = new StickyList<char>();
+            var elt2 = ('x', 2);
+            var elt5 = ('y', 5);
+            var elt119 = ('z', 119);
+
+            // Act
+            list.Insert(elt2.Item2, elt2.Item1);
+            list.Insert(elt5.Item2, elt5.Item1);
+            list.Insert(elt119.Item2, elt119.Item1);
+
+            // Assert
+            list.Should().HaveCount(3);
+            list[elt2.Item2].Should().Be(elt2.Item1);
+            list[elt5.Item2].Should().Be(elt5.Item1);
+            list[elt119.Item2].Should().Be(elt119.Item1);
+            for (int i = 0; i <= elt119.Item2; ++i) {
+                list.IsOccupied(i).Should().Be(i == elt2.Item2 || i == elt5.Item2 || i == elt119.Item2);
+                list.IsSticky(i).Should().Be(i == elt2.Item2 || i == elt5.Item2 || i == elt119.Item2);
+            }
+            list.HasGaps.Should().BeTrue();
+        }
+
+        [TestMethod] public void InsertStickyDisplaceNonStickyToEnd() {
+            // Arrange
+            var list = new StickyList<string>();
+            list.Add("Harrisburg");
+            list.Add("Scottsdale");
+            list.Add("Bentonville");
+
+            // Act
+            list.HasGaps.Should().BeFalse();
+            list.IsSticky(1).Should().BeFalse();
+            list.Insert(1, "Fort Worth");
+
+            // Assert
+            list.Should().HaveCount(4);
+            list.HasGaps.Should().BeFalse();
+            list.IsSticky(1).Should().BeTrue();
+            list.IsSticky(3).Should().BeFalse();
+        }
+
+        [TestMethod] public void InsertStickyDisplaceNonStickToGap() {
+            // Arrange
+            var list = new StickyList<string>();
+            list.Add("Bakersfield");
+            list[2] = "Lincoln";
+
+            // Act
+            list.HasGaps.Should().BeTrue();
+            list.IsSticky(0).Should().BeFalse();
+            list.IsOccupied(1).Should().BeFalse();
+            list.Insert(0, "Santa Ana");
+
+            // Assert
+            list.Should().HaveCount(3);
+            list.HasGaps.Should().BeFalse();
+            list.IsSticky(0).Should().BeTrue();
+            list.IsOccupied(1).Should().BeTrue();
+            list.IsSticky(1).Should().BeFalse();
+        }
+
+        [TestMethod] public void InsertNegativeIndex() {
+            // Arrange
+            var list = new StickyList<int>();
+
+            // Act
+            Action insert = () => list.Insert(-5, 111111);
+            Action set = () => list[-192] = 812;
+
+            // Assert
+            insert.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+            set.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void InsertAlreadyStickiedIndex() {
+            // Arrange
+            var list = new StickyList<string>();
+            var idx = 7;
+            list.Insert(idx, "Cheyenne");
+
+            // Act
+            Action act = () => list.Insert(idx, "Newark");
+
+            // Assert
+            act.Should().ThrowExactly<InvalidOperationException>().WithMessage($"*{idx}*");
+        }
+
+        [TestMethod] public void RemoveFromEnd() {
+            // Arrange
+            var list = new StickyList<DateTime>();
+            list.Add(new DateTime(1984, 7, 12));
+            list.Insert(8, new DateTime(2021, 7, 23));
+            list.Add(new DateTime(1988, 9, 17));
+            list.Insert(4, new DateTime(2000, 9, 15));
+            list.Insert(5, new DateTime(2004, 8, 13));
+            list.Add(new DateTime(1992, 7, 25));
+            list.Add(new DateTime(1996, 7, 19));
+            list.Insert(7, new DateTime(2016, 8, 5));
+            list.Add(new DateTime(2012, 7, 25));
+
+            // Act
+            list.RemoveAt(list.Count - 1);
+            list.Remove(new DateTime(2016, 8, 5));
+
+            // Assert
+            list.Contains(new DateTime(2016, 8, 5)).Should().BeFalse();
+            list.Contains(new DateTime(2021, 7, 23)).Should().BeFalse();
+            list.HasGaps.Should().BeFalse();
+        }
+
+        [TestMethod] public void RemoveCreateGaps() {
+            // Arrange
+            var list = new StickyList<char>();
+            list.Add('*');
+            list.Insert(3, '+');
+            list.Add('0');
+            list.Add('\'');
+            list.Add('?');
+            list.Add('%');
+
+            // Act
+            list.IsSticky(3).Should().BeTrue();
+            list.HasGaps.Should().BeFalse();
+            list.RemoveAt(3);
+            list.Remove('?');
+
+            // Assert
+            list.IsSticky(3).Should().BeFalse();
+            list.HasGaps.Should().BeFalse();
+            list.LargestIndex.Should().Be(list.Count - 1);
+        }
+
+        [TestMethod] public void RemoveOnlyOneIfDuplicates() {
+            // Arrange
+            var list = new StickyList<string>();
+            list.Insert(2, "Boulder");
+            list.Insert(0, "Boulder");
+            list.Insert(1, "Knoxville");
+            list.Add("Davenport");
+
+            // Act
+            list.Contains("Boulder").Should().BeTrue();
+            list.Remove("Boulder");
+
+            // Assert
+            list.Contains("Boulder").Should().BeTrue();
+            list.HasGaps.Should().BeFalse();
+        }
+
+        [TestMethod] public void RemoveUntilEmpty() {
+            // Arrange
+            var list = new StickyList<string>();
+            list.Insert(18, "Wisconsin Dells");
+            list.Insert(137, "Coeur d'Alene");
+            list.Insert(81, "Durham");
+            list.Insert(2896, "Aurora");
+
+            // Act
+            list.Remove("Wisconsin Dells");
+            list.RemoveAt(137);
+            list.RemoveAt(81);
+            list.Remove("Aurora");
+
+            // Assert
+            list.Should().BeEmpty();
+            list.Should().HaveCount(0);
+            list.LargestIndex.Should().Be(-1);
+        }
+
+        [TestMethod] public void RemoveMissingElement() {
+            // Arrange
+            var list = new StickyList<int>();
+            list[8] = 192;
+            list[2] = 192;
+            list[17] = 192;
+
+            // Act
+            var result = list.Remove(2);
+
+            // Asert
+            result.Should().BeFalse();
+        }
+
+        [TestMethod] public void RemoveAtIndexOutOfBounds() {
+            // Arrange
+            var list = new StickyList<string>();
+            list.Insert(44, "Lawrence");
+            list.Add("Bridgeport");
+            list.Add("Pomona");
+
+            // Act
+            Action removeNegative = () => list.RemoveAt(-681);
+            Action removeTooLarge = () => list.RemoveAt(list.LargestIndex + 1);
+
+            // Assert
+            removeNegative.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+            removeTooLarge.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void RemoveAtGapIndex() {
+            // Arrange
+            var list = new StickyList<string>();
+            list.Insert(21, "Stillwater");
+
+            // Act
+            Action remove = () => list.RemoveAt(13);
+
+            // Assert
+            remove.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void Clear() {
+            // Arrange
+            var list = new StickyList<char>();
+            list.Add('&');
+            list.Insert(4, '%');
+            list.Add('E');
+            list.Add('=');
+            list.Insert(2, '/');
+
+            // Act
+            list.Should().NotBeEmpty();
+            list.Clear();
+
+            // Assert
+            list.Should().BeEmpty();
+        }
+
+        [TestMethod] public void Iteration() {
+            // Arrange
+            var list = new StickyList<char>() { '-', '+', '-', '+', '-', '+', '-', '+', '-', '+' };
+
+            // Act
+            var strongIter = list.GetEnumerator();
+            var weakIter = (list as IEnumerable).GetEnumerator();
+
+            // Assert
+            while (strongIter.MoveNext()) {
+                weakIter.MoveNext().Should().BeTrue();
+                weakIter.Current.Should().Be(strongIter.Current);
+            }
+            weakIter.MoveNext().Should().BeFalse();
+        }
+
+        [TestMethod] public void GetItemOutOfBounds() {
+            // Arrange
+            var list = new StickyList<int>();
+            list.Add(35);
+            list.Add(-1);
+            list.Add(0);
+
+            // Act
+            Func<int> actPos = () => list[25];
+            Func<int> actNeg = () => list[-3];
+
+            // Assert
+            actPos.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+            actNeg.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void GetItemAtGap() {
+            // Arrange
+            var list = new StickyList<int>();
+            list.Insert(4, 405);
+            var gapIdx = 3;
+
+            // Act
+            list.IsOccupied(gapIdx).Should().BeFalse();
+            Func<int> act = () => list[gapIdx];
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithMessage("*gap*");
+        }
+
+        [TestMethod] public void IndexOfExistingItem() {
+            // Arrange
+            var list = new StickyList<char>();
+            list.Add('7');
+            list.Add('u');
+            list.Add('_');
+            list.Add('í');
+
+            // Act
+            var idx0 = list.IndexOf('7');        // the order of these is guarnated because no removals have occurred
+            var idx1 = list.IndexOf('u');
+            var idx2 = list.IndexOf('_');
+            var idx3 = list.IndexOf('í');
+
+            // Assert
+            idx0.Should().Be(0);
+            idx1.Should().Be(1);
+            idx2.Should().Be(2);
+            idx3.Should().Be(3);
+        }
+
+        [TestMethod] public void IndexOfExistingItemCustomComparer() {
+            // Arrange
+            var list = new StickyList<string>(StringComparer.OrdinalIgnoreCase);
+            list.Add("Lubbock");
+            list.Add("Kalamazoo");
+            list.Add("Mobile");
+
+            // Act
+            var idx0 = list.IndexOf("LuBbOCK");  // the order of these is guaranteed because no removals have ocurred
+            var idx1 = list.IndexOf("kalamazoo");
+            var idx2 = list.IndexOf("MOBILE");
+
+            // Assert
+            idx0.Should().Be(0);
+            idx1.Should().Be(1);
+            idx2.Should().Be(2);
+        }
+
+        [TestMethod] public void IndexOfMissingItem() {
+            // Arrange
+            var list = new StickyList<double>();
+            list.Add(double.MinValue);
+            list.Add(double.MaxValue);
+            list.Add(double.Epsilon);
+
+            // Act
+            var idx0 = list.IndexOf(38);
+            var idx1 = list.IndexOf(-2.8);
+
+            // Assert
+            idx0.Should().Be(-1);
+            idx1.Should().Be(-1);
+        }
+
+        [TestMethod] public void ContainsExistingItem() {
+            // Arrange
+            var list = new StickyList<string>();
+            list.Add("South Bend");
+            list.Insert(0, "Pasadena");
+            list.Insert(4, "Fargo");
+
+            // Act
+            var contains0 = list.Contains(list[0]);
+            var contains1 = list.Contains(list[1]);
+            var contains4 = list.Contains(list[4]);
+
+            // Assert
+            contains0.Should().BeTrue();
+            contains1.Should().BeTrue();
+            contains4.Should().BeTrue();
+        }
+
+        [TestMethod] public void ContainsExistingItemCustomComparer() {
+            // Arrange
+            var list = new StickyList<string>(StringComparer.OrdinalIgnoreCase);
+            list.Insert(8, "Pierre");
+            list.Add("Billings");
+
+            // Act
+            var contains0 = list.Contains(list[0].ToUpper());
+            var contains8 = list.Contains(list[8].ToLower());
+
+            // Assert
+            contains0.Should().BeTrue();
+            contains8.Should().BeTrue();
+        }
+
+        [TestMethod] public void ContainsMissingItem() {
+            // Arrange
+            var list = new StickyList<string>();
+            list.Insert(5, "Arlington");
+            list.Insert(21, "Tuscaloosa");
+            list.Add("Duluth");
+            list.Insert(0, "Joliet");
+
+            // Act
+            var missing0 = list.Contains("Santa Cruz");
+            var missing1 = list.Contains("Murfreesboro");
+
+            // Assert
+            missing0.Should().BeFalse();
+            missing1.Should().BeFalse();
+        }
+
+        [TestMethod] public void QuerySlotsPastTheEnd() {
+            // Arrange
+            var list = new StickyList<int>();
+            list.Add(2);
+            list.Add(-110);
+            list.Add(int.MaxValue);
+            list.Add(int.MinValue);
+            list.Add(0);
+
+            // Act & Assert
+            for (var i = list.Count; i < list.Count + 100; ++i) {
+                Func<bool> isOccupied = () => list.IsOccupied(i);
+                Func<bool> isSticky = () => list.IsSticky(i);
+
+                isOccupied.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+                isSticky.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+            }
+        }
+
+        [TestMethod] public void QueryNegativeIndex() {
+            // Arrange
+            var list = new StickyList<DateTime>();
+
+            // Act
+            Func<bool> actOccupied = () => list.IsOccupied(-44);
+            Func<bool> actSticky = () => list.IsSticky(-1);
+
+            // Assert
+            actOccupied.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+            actSticky.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void CopyToArray() {
+            // Arrange
+            var list = new StickyList<char>();
+            list.Add('h');
+            list.Add('~');
+            list.Insert(37, '(');
+            list.Insert(44, ')');
+            list.Add(',');
+
+            // Act
+            char[] array = new char[10];
+            (list as ICollection<char>).CopyTo(array, 3);
+
+            // Assert
+            array[3].Should().Be('h');
+            array[4].Should().Be('~');
+            array[5].Should().Be(',');
+            array[6].Should().Be('(');
+            array[7].Should().Be(')');
+        }
+    }
+}

--- a/test/UnitTests/Cybele/Extensions/Option.cs
+++ b/test/UnitTests/Cybele/Extensions/Option.cs
@@ -1,0 +1,33 @@
+﻿using Cybele.Extensions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Optional;
+using System;
+
+namespace UT.Cybele.Extensions {
+    [TestClass, TestCategory("Option: Unwrap")]
+    public sealed class Option_Unwrap : ExtensionTests {
+        [TestMethod] public void UnwrapSome() {
+            // Arrange
+            var expected = 389;
+            var some = Option.Some(expected);
+
+            // Act
+            var actual = some.Unwrap();
+
+            // Assert
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod] public void UnwrapNone() {
+            // Arrange
+            var none = Option.None<DateTime>();
+
+            // Act
+            Func<DateTime> act = () => none.Unwrap();
+
+            // Assert
+            act.Should().ThrowExactly<InvalidOperationException>().WithMessage("*empty*");
+        }
+    }
+}

--- a/test/UnitTests/_TestCities.txt
+++ b/test/UnitTests/_TestCities.txt
@@ -1,5 +1,4 @@
-﻿# This document lists the U.S. cities that have been used as elements of various IEnumerables in unit tests across all
-# projects.
+﻿# This document lists the U.S. cities that have been used in unit tests across all projects.
 
 Akron
 Albany
@@ -9,47 +8,63 @@ Anaheim
 Anchorage
 Ann Arbor
 Annapolis
+Arlington
+Asheville
 Atlanta
 Atlantic City
 Augusta
+Aurora
 Austin
+Bakersfield
 Baltimore
 Baton Rouge
+Bentonville
+Billings
 Biloxi
 Birmingham
 Bismarck
 Bloomington
 Boise
 Boston
+Boulder
+Bridgeport
 Buffalo
 Canton
 Carson City
 Charleston
 Charlotte
 Chattanooga
+Cheyenne
 Chicago
 Cincinnati
 Cleveland
+Coeur d'Alene
 Colorado Springs
 Corpus Christi
 Dallas
+Davenport
 Dayton
 Denver
 Des Moines
 Detroit
 Dover
+Duluth
+Durham
 El Paso
 Eugene
 Fairbanks
+Fargo
 Flagstaff
 Fort Lauderdale
 Fort Wayne
+Fort Worth
 Fresno
 Galveston
 Glendale
 Grand Rapids
 Green Bay
 Greensboro
+Harrisburg
 Hartford
 Helena
 Hialeah
@@ -61,17 +76,24 @@ Jackson
 Jacksonville
 Jefferson City
 Jersey City
+Joliet
 Juneau
+Kalamazoo
 Kansas City
+Knoxville
 Lansing
 Laramie
 Laredo
+Las Cruces
 Las Vegas
+Lawrence
 Lexington
+Lincoln
 Little Rock
 Long Beach
 Los Angeles
 Louisville
+Lubbock
 Madison
 Manchester
 Memphis
@@ -79,13 +101,16 @@ Mesa
 Miami
 Milwaukee
 Minneapolis
+Mobile
 Montgomery
 Montpelier
+Murfreesboro
 Myrtle Beach
 Nashville
 New Haven
 New Orleans
 New York City
+Newark
 Norfolk
 North Las Vegas
 Oakland
@@ -93,11 +118,14 @@ Oconomowoc
 Oklahoma City
 Omaha
 Orlando
+Pasadena
 Peoria
 Philadelphia
 Phoenix
+Pierre
 Pittsburgh
 Plano
+Pomona
 Portland
 Raleigh
 Reno
@@ -106,16 +134,23 @@ San Antonio
 San Diego
 San Francisco
 San Jose
+Santa Ana
 Santa Clara
+Santa Cruz
 Santa Fe
 Savannah
+Scottsdale
+Scranton
 Seattle
 Shreveport
 Sioux City
+South Bend
 Spokane
 Springfield
+St. Augustine
 St. Louis
 St. Paul
+Stillwater
 Tacoma
 Tallahassee
 Tampa
@@ -124,11 +159,14 @@ Topeka
 Trenton
 Tucson
 Tulsa
+Tuscaloosa
 Valparaiso
 Virginia Beach
 Waco
 Walla Walla
 Washington, D.C.
 Wichita
+Wilmington
 Winston-Salem
+Wisconsin Dells
 Ypsilanti


### PR DESCRIPTION
A StickyList is a list-like data structure in which each element has a 'stickiness' that defines whether or not its
position in the list is fixed. A non-sticky element can occupy any available slot, whereas a sticky element must ocupy
the slot at which it was inserted/added. This can lead to gaps in the list, which are filled by non-sticky elements
whenever possible (such as on addition, or when a gap arises due to a removal).

The StickyList will be used for ordering columns during Translation, as some Fields will be pinned to specificy column
indices while others will be flexible. That being said, the StickyList itself is intended to be general-purpose: for
example, it throws exceptions on invalid or noncomformant input and exposes certain query APIs that may not be useful
for the specific Translation use case.