### PR TITLE
Dependency Upgrades (8/8/2021)

### DIFF
--- a/src/Atropos/Atropos.csproj
+++ b/src/Atropos/Atropos.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="3.1.0" />
-    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="3.2.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/Cybele/Cybele.csproj
+++ b/src/Cybele/Cybele.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="3.0.1" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="3.2.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/Kvasir/Kvasir.csproj
+++ b/src/Kvasir/Kvasir.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="3.0.1" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="3.2.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>
 

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.16.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This commit updates all third-party dependencies in Kvasir and friends. Specifically, the following upgrades were made:

     * Adalis.GuardClauses upgraded to v3.2.0
     * Moq upgrades to v4.16.1

Upgrades to unit testing packages were made also.