### PR TITLE
RelationList<T>

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -1610,6 +1610,939 @@
         <member name="M:Kvasir.Reconstitution.SetPropertyMutationStep.Execute(System.Object,System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
             <inheritdoc/>
         </member>
+        <member name="T:Kvasir.Relations.IRelation">
+            <summary>
+              The internal framework interface denoting a custom collection type that serves as a one-to-many relation.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Relations.IRelation.ConnectionType">
+            <summary>
+              The type of the Relation connection (the "many" in the one-to-many).
+            </summary>
+        </member>
+        <member name="M:Kvasir.Relations.IRelation.Canonicalize">
+            <summary>
+              Updates the internal state tracking to reflect the Relation being fully synchronized with the back-end
+              relational database.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Relations.IRelation.GetEnumerator">
+            <summary>
+              Produces an enumerator that iterates over the connections that are tracked by this Relation, including
+              those that have been deleted fro it.
+            </summary>
+            <remarks>
+              The order in which connections are exposed by this method is only softly defined. Any connections that
+              have been <see cref="F:Kvasir.Relations.Status.Deleted">deleted</see> since the last
+              <see cref="M:Kvasir.Relations.IRelation.Canonicalize">canonicalization</see> will be exposed first, followed by all
+              <see cref="F:Kvasir.Relations.Status.New">new</see> and <see cref="F:Kvasir.Relations.Status.Saved">saved</see> ones (which may be interspersed
+              together). Within the two groupings, the relative order of connections is undefined. No connection will
+              more than once, and implementations are encouraged to ensure that repeated enuerations of the same
+              Relation without intervening changes produce the same sequence of items.
+            </remarks>
+            <returns>
+              An enumerator that iterates over the connections that are tracked by this Relation.
+            </returns>
+        </member>
+        <member name="T:Kvasir.Relations.RelationList`1">
+            <summary>
+                An unordered collection that tracks the state of its elements for interaction with a back-end database.
+            </summary>
+            <remarks>
+              <para>
+                A <see cref="T:Kvasir.Relations.RelationList`1"/> implements the same interfaces as and behaves identically to a standard
+                <see cref="T:System.Collections.Generic.List`1"/> collection. Operations that mutate the collection are used to track changes that can
+                then be reflected in a back-end database, while view- or read-only operations have no additional side
+                effects. Converting a <see cref="T:Kvasir.Relations.RelationList`1"/> into another collection type, such as through a member
+                API (e.g. <see cref="M:Kvasir.Relations.RelationList`1.CopyTo(`0[])"/>) or LINQ, drops the change tracking capabilities.
+              </para>
+              <para>
+                Every item in a <see cref="T:Kvasir.Relations.RelationList`1"/> is in one of three state: <c>NEW</c>, <c>SAVED</c>, and
+                <c>DELETED</c>. Each state corresponds to the action or actions that should be taken with respect to that
+                item to synchronize the back-end database table corresponding to the relation. An item enters the
+                <c>NEW</c> state when it is first added; when the collection is canonicalized, each <c>NEW</c> items
+                transitions to the <c>SAVED</c> state, indicating that it does not need to be written to the database on
+                the next write. When a <c>SAVED</c> item is removed from the collection, it transitions to the
+                <c>DELETED</c> stat; <c>NEW</c> items do no transition to <c>DELETED</c>. Note that if a <c>SAVED</c> item
+                is deleted and then re-added, it will be re-added in the <c>SAVED</c> state.
+              </para>
+              <para>
+                Items used in a <see cref="T:Kvasir.Relations.RelationList`1"/> should be immutable: structs, <see cref="T:System.String"/>, etc. This
+                is because read access is <i>not</i> tracked: when using mutable elements, it is possible for the user to
+                access an ite (e.g. through <c>[]</c>) and mutate that element without the collection knowing, preventing
+                that change from being reflected in the back-end database. This also means that actions that convert the
+                collection into another form will <i>copy</i> the elements, ensuring that the tracking data remains
+                up-to-date.
+              </para>
+              <para>
+                A <see cref="T:Kvasir.Relations.RelationList`1"/> technically permits duplicate elements, though it is strongly advised that
+                users treat the collection as more of an unordered set, as the back-end relational database table will
+                not permit duplicates. For example, it is possile for the collection to expose a single item in multiple
+                seemingly incompatible states (e.g. <c>SAVED</c> and <c>DELETED</c>). Though different search APIs enable
+                the use of custom comparators, the internal comparison logic always uses the default comparison.
+              </para>
+            </remarks>
+            <typeparam name="T">
+              The type of element to be stored in the collection.
+            </typeparam>
+        </member>
+        <member name="P:Kvasir.Relations.RelationList`1.Capacity">
+            <summary>
+              Gets or sets the total number of elements the internal data structure can hold without resizing.
+            </summary>
+            <value>
+              The number of elements that the <see cref="T:Kvasir.Relations.RelationList`1"/> can contain before resizing is required.
+            </value>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <see cref="P:Kvasir.Relations.RelationList`1.Capacity"/> is set to a value that is less than <see cref="P:Kvasir.Relations.RelationList`1.Count"/>.
+            </exception>
+            <exception cref="T:System.OutOfMemoryException">
+              if there is not enough memory available on the system.
+            </exception>
+        </member>
+        <member name="P:Kvasir.Relations.RelationList`1.Count">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Relations.RelationList`1.Item(System.Int32)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.#ctor">
+            <summary>
+              Initializes a new instance of the <see cref="T:Kvasir.Relations.RelationList`1"/> class that is empty and has the default
+              initial capacity.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.#ctor(System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+              Initializes a new instance of the <see cref="T:Kvasir.Relations.RelationList`1"/> class that contains elements copied from
+              the specified collection and has sufficient capacity to accommodate the number of elements copied.
+            </summary>
+            <param name="collection">
+              The element whose names are copied to the new list.
+            </param>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.#ctor(System.Int32)">
+            <summary>
+              Initializes a new instance of the <see cref="T:Kvasir.Relations.RelationList`1"/> class that is empty and has the specified
+              initial capacity.
+            </summary>
+            <param name="capacity">
+              The number of elements that the new list can initially store.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="capacity"/> is less than 0.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Add(`0)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.AddRange(System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+              Adds the elements of the specified collection to the end of the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+            <param name="collection">
+              The collection whose elements should be added to the end of the <see cref="T:Kvasir.Relations.RelationList`1"/>. The
+              collection itself cannot be <see langword="null"/>, but it can contain elements that are
+              <see langword="null"/>, if type <typeparamref name="T"/> is a reference type.
+            </param>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.AsReadOnly">
+            <summary>
+              Returns a read-only <see cref="T:System.Collections.ObjectModel.ReadOnlyCollection`1"/> wrapper for the current collection.
+            </summary>
+            <returns>
+              An object that acts as a read-only wrapper around the current <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.BinarySearch(`0)">
+            <summary>
+              Searches the entire sorted <see cref="T:Kvasir.Relations.RelationList`1"/> for an element using the default comparer and
+              returns the zero-based index of the element.
+            </summary>
+            <param name="item">
+              The object to locate. The value can be <see langword="null"/> for reference types.
+            </param>
+            <returns>
+              The zero-based index of <paramref name="item"/> in the sorted <see cref="T:Kvasir.Relations.RelationList`1"/>, if
+              <paramref name="item"/> is found; otherwise, a negative number that is the bitwise complement of the
+              index of the new element that is larger than <paramref name="item"/> or, if there is no larger element,
+              the bitwise complement of <see cref="P:Kvasir.Relations.RelationList`1.Count"/>.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+              if the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find an implementation of the
+              <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/> interfae for type
+              <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.BinarySearch(`0,System.Collections.Generic.Comparer{`0})">
+            <summary>
+              Searches the entire sorted <see cref="T:Kvasir.Relations.RelationList`1"/> for an element using the specified comparer and
+              returns the zero-based index of the element.
+            </summary>
+            <param name="item">
+              The object to locate. The value can be <see langword="null"/> for reference types.
+            </param>
+            <param name="comparer">
+              The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements; or, <see langword="null"/>
+              to use the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <returns>
+              The zero-based index of <paramref name="item"/> in the sorted <see cref="T:Kvasir.Relations.RelationList`1"/>, if
+              <paramref name="item"/> is found; otherwise, a negative number that is the bitwise complement of the
+              index of the next element that is larger than <paramref name="item"/> or, if there is no larger element,
+              the bitwise complement of <see cref="P:Kvasir.Relations.RelationList`1.Count"/>.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+              if <paramref name="comparer"/> is <see langword="null"/>, and the default comparer
+              <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find an implementation of the <see cref="T:System.IComparable`1"/>
+              generic interface or the <see cref="T:System.IComparable"/> interface for the type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.BinarySearch(System.Int32,System.Int32,`0,System.Collections.Generic.Comparer{`0})">
+            <summary>
+              Searches a range of elements in the sorted <see cref="T:Kvasir.Relations.RelationList`1"/> for an element using the
+              specified comparer and returns the zero-based index of the elemment.
+            </summary>
+            <param name="index">
+              The zero-based starting index of the range to search.
+            </param>
+            <param name="count">
+              The length of the range to search.
+            </param>
+            <param name="item">
+              The object to locate. The value can be <see langword="null"/> for reference types.
+            </param>
+            <param name="comparer">
+              The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or <see langword="null"/>
+              to use the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <returns>
+              The zero-based inex of <paramref name="item"/> in the sorted <see cref="T:Kvasir.Relations.RelationList`1"/>, if
+              <paramref name="item"/> is found; otherwise, a negative number that is the bitwise complement of the
+              index of the next element that is larger than <paramref name="item"/> or, if there is no larger element,
+              the bitwise complement of <see cref="P:Kvasir.Relations.RelationList`1.Count"/>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="item"/> is less than <c>0</c>
+                --or--
+              if <paramref name="count"/> is less than <c>0</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="index"/> and <paramref name="count"/> do not denote a valid range in the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+              <paramref name="comparer"/> is <see langword="null"/>, and the default comparer
+              <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find an implementation of the <see cref="T:System.IComparable`1"/>
+              generic interface or the <see cref="T:System.IComparable"/> interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Clear">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Contains(`0)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.ConvertAll``1(System.Converter{`0,``0})">
+            <summary>
+              Converts the elements in the current <see cref="T:Kvasir.Relations.RelationList`1"/> to another type, and returns a list
+              containing the converted elements.
+            </summary>
+            <typeparam name="TOutput">
+              The type of the elements of the target array.
+            </typeparam>
+            <param name="converter">
+              A <see cref="T:System.Converter`2"/> delegate that converts each element from one type to another
+              type.
+            </param>
+            <returns>
+              A <see cref="T:System.Collections.Generic.List`1"/> of the target type containing the converted elements from the current
+              <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.CopyTo(`0[])">
+            <summary>
+              Copies the entire <see cref="T:Kvasir.Relations.RelationList`1"/> to a compatible one-dimensional array, starting at the
+              beginning of the target array.
+            </summary>
+            <param name="array">
+              The one-dimensional <see cref="T:System.Array"/> that is the destination of the elements copied from the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>. The <see cref="T:System.Array"/> must have zero-based indexing.
+            </param>
+            <exception cref="T:System.ArgumentException">
+              if the number of elements in the source <see cref="T:Kvasir.Relations.RelationList`1"/> is greater than the number of
+              elements that the destination <paramref name="array"/> can contain.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.CopyTo(`0[],System.Int32)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.CopyTo(System.Int32,`0[],System.Int32,System.Int32)">
+            <summary>
+              Copies a range of elements from the <see cref="T:Kvasir.Relations.RelationList`1"/> to a compatible one-dimensional array,
+              starting at the specified index of the target array.
+            </summary>
+            <param name="index">
+              The zero-based index in the source <see cref="T:Kvasir.Relations.RelationList`1"/> at which copying begins.
+            </param>
+            <param name="array">
+              The one-dimensional <see cref="T:System.Array"/> that is the destination of the elements copied from the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>. The <see cref="T:System.Array"/> must have zero-based indexing.
+            </param>
+            <param name="arrayIndex">
+              The zero-based index in <paramref name="array"/> at which copying begins.
+            </param>
+            <param name="count">
+              The number of elements to copy.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is less than <c>0</c>
+                --or--
+              if <paramref name="arrayIndex"/> is less than <c>0</c>
+                --or--
+              if <paramref name="count"/> is less than <c>0</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="index"/> is equal to or greater than the <see cref="P:Kvasir.Relations.RelationList`1.Count"/> of the source
+              <see cref="T:Kvasir.Relations.RelationList`1"/>
+                --or--
+              if the number of elements from <paramref name="index"/> to the end of the source
+              <see cref="T:Kvasir.Relations.RelationList`1"/> is greater than the available space from <paramref name="arrayIndex"/> to
+              the end of the destination <paramref name="array"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Equals(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Exists(System.Predicate{`0})">
+            <summary>
+              Determines whether the <see cref="T:Kvasir.Relations.RelationList`1"/> contains elements that match the conditions defined
+              by the specified predicate.
+            </summary>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions of the elements to search for.
+            </param>
+            <returns>
+              <see langword="true"/> if the <see cref="T:Kvasir.Relations.RelationList`1"/> contains one or more elements that match the
+              conditions defined by the specified predicate; otherwise, <see langword="false"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Find(System.Predicate{`0})">
+            <summary>
+              Searches for an element that matches the conditions defined by the specified predicate, and returns the
+              first occurrence within the entire <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions of the element to search for.
+            </param>
+            <returns>
+              The first element that matches the condition defined by the specified predicate, if found; otherwise, the
+              default value for type <typeparamref name="T"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.FindAll(System.Predicate{`0})">
+            <summary>
+              Retrieves all the elements that match the conditions defined by the specified predicate.
+            </summary>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions of the elements to search for.
+            </param>
+            <returns>
+              A <see cref="T:System.Collections.Generic.List`1"/> containing all the elements that match the conditions defined by the specified
+              predicate, if found; otherwise, an empty <see cref="T:System.Collections.Generic.List`1"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.FindIndex(System.Predicate{`0})">
+            <summary>
+              Searches for an element that matches the conditions defined by the specified predicate, and returns the
+              zero-based index of the first occurrence within the entire <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions of the element to search for.
+            </param>
+            <returns>
+              The zero-based index of the first occurrence of an element that matches the conditions defined by
+              <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+            </returns> 
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.FindIndex(System.Int32,System.Predicate{`0})">
+            <summary>
+              Searches for an element that matches the conditions defined by the specified predicate, and returns the
+              zero-based index of the first occurrence within the range of elements in the
+              <see cref="T:Kvasir.Relations.RelationList`1"/> that extends from the specified index to the last element.
+            </summary>
+            <param name="startIndex">
+              The zero-based starting index of the search.
+            </param>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions of the element to search for.
+            </param>
+            <returns>
+              The zero-based index of the first occurrence of an element that matches the conditions defined by
+              <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+               if <paramref name="startIndex"/> is outside the range of valid indexes for the
+               <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.FindIndex(System.Int32,System.Int32,System.Predicate{`0})">
+            <summary>
+              Searches for an element that matches the conditions defined by the specified predicate, and returns the
+              zero-based index of the first occurrence within the range of elements in the
+              <see cref="T:Kvasir.Relations.RelationList`1"/> that starts at the specified index and contains the specified number of
+              elements.
+            </summary>
+            <param name="startIndex">
+               The zero-based starting index of the search.
+            </param>
+            <param name="count">
+              The number of elements in the section to search.
+            </param>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions of the elements to search for.
+            </param>
+            <returns>
+              The zero-based index of the first occurrence of an element that matches the conditions defined by
+              <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+               if <paramref name="startIndex"/> is outside the range of valid indexes for the
+               <see cref="T:Kvasir.Relations.RelationList`1"/>
+                 --or--
+               if <paramref name="count"/> is less than <c>0</c>
+                 --or--
+               if <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section in the
+               <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.FindLast(System.Predicate{`0})">
+            <summary>
+              Searches for an element that matches the conditions defined by the specified predicate, and returns the
+              last occurrence within the entire <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions of the element to search for.
+            </param>
+            <returns>
+              The last element that matches the conditions defined by the specified predicate, if found; otherwise, the
+              default value for type <typeparamref name="T"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.FindLastIndex(System.Predicate{`0})">
+            <summary>
+              Searches for an element that matches the conditions defined by the specified predicate, and returns the
+              zero-based index of the last occurrence within the entire <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions of the element to search for.
+            </param>
+            <returns>
+              The zero-based index of the last occurrence of an element that matches the conditions defined by
+              <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.FindLastIndex(System.Int32,System.Predicate{`0})">
+            <summary>
+              Searches for an element that matchs the conditions defined by the specified predicate, and returns the
+              zero-based index of the last occurrence within the range of elements in the <see cref="T:Kvasir.Relations.RelationList`1"/>
+              that extends from the first element to the specified index.
+            </summary>
+            <param name="startIndex">
+              The zero-based starting index of the backward search.
+            </param>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions of the element to search for.
+            </param>
+            <returns>
+              The zero-based index of the last occurrence of an element that matches the conditions defined by
+              <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="startIndex"/> is outside the range of valid indexes for the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.FindLastIndex(System.Int32,System.Int32,System.Predicate{`0})">
+            <summary>
+              Searches for an element that matches the conditions defined by the specified predicate, and returns the
+              zero-based index of the last occurrence within the range of elements in the <see cref="T:Kvasir.Relations.RelationList`1"/>
+              that contains the specified number of elements and ends at the specified index.
+            </summary>
+            <param name="startIndex">
+              The zero-based starting index of the backward search.
+            </param>
+            <param name="count">
+              The number of elements in the section to search.
+            </param>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions of the element to search for.
+            </param>
+            <returns>
+              The zero-based index of the last occurrence of an element that matches the conditions defined by
+              <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="startIndex"/> is outside the range of valid indexes for the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>
+                --or--
+              if <paramref name="count"/> is less than <c>0</c>
+                --or--
+              if <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section in the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.ForEach(System.Action{`0})">
+            <summary>
+              Performs the specified action on each element of the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+            <param name="action">
+              The <see cref="T:System.Action`1"/> delegate to perform on each element of the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </param>
+            <exception cref="T:System.InvalidOperationException">
+              if an element in the collection has been modified.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.GetEnumerator">
+            <summary>
+              Returns an enumerator that iterates through the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+            <returns>
+              A <see cref="T:System.Collections.Generic.List`1.Enumerator"/> for the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.GetHashCode">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.GetRange(System.Int32,System.Int32)">
+            <summary>
+              Creates a shallow copy of a range of elements in the source <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+            <param name="index">
+              The zero-based <see cref="T:Kvasir.Relations.RelationList`1"/> index at which the range stats.
+            </param>
+            <param name="count">
+              The number of elements in the range.
+            </param>
+            <returns>
+              A shallow copy of a range of elements in the source <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is less than <c>0</c>
+                --or--
+              if <paramref name="count"/> is less than <c>0</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements in the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.IndexOf(`0)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.IndexOf(`0,System.Int32)">
+            <summary>
+              Searches for the specified object and returns the zero-based index of the first occurrence within the
+              range of elements in the <see cref="T:Kvasir.Relations.RelationList`1"/> that extends from the specified index to the last
+              element.
+            </summary>
+            <param name="item">
+              The object to locate in the <see cref="T:Kvasir.Relations.RelationList`1"/>. The value can be <see langword="null"/> for
+              reference types.
+            </param>
+            <param name="index">
+              The zero-based starting index of the sarch. <c>0</c> (zero) is valid in an empty list.
+            </param>
+            <returns>
+              The zero-based index of the first occurrence of <paramref name="item"/> within the range of elements in
+              the <see cref="T:Kvasir.Relations.RelationList`1"/> that extends from <paramref name="index"/> to the last element, if
+              found; otherwise, <c>-1</c>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.IndexOf(`0,System.Int32,System.Int32)">
+            <summary>
+              Searches for the specified object and returns the zero-based index of the first occurrence within the
+              range of elements in the <see cref="T:Kvasir.Relations.RelationList`1"/> that starts at the specified index and contains
+              the specified number of elements.
+            </summary>
+            <param name="item">
+              The object to locate in the <see cref="T:Kvasir.Relations.RelationList`1"/>. The value can be <see langword="null"/> for
+              reference tpes.
+            </param>
+            <param name="index">
+              The zero-based starting index of the search. <c>0</c> (zero) is valid in an empty list.
+            </param>
+            <param name="count">
+              The number of elements in the section to search.
+            </param>
+            <returns>
+              The zero-based index of teh first occurrence of <paramref name="item"/> within the range of elements in
+              the <see cref="T:Kvasir.Relations.RelationList`1"/> that starts at <paramref name="index"/> and contains
+              <paramref name="count"/> number of elements, if found; otherwise, <c>-1</c>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is outside the range of valid indexes of the <see cref="T:Kvasir.Relations.RelationList`1"/>
+                --or--
+              if <paramref name="count"/> is less than <c>0</c>
+                --or--
+              if <paramref name="index"/> and <paramref name="count"/> do not specify a valid section in the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Insert(System.Int32,`0)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.InsertRange(System.Int32,System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+              Inserts the elements of a collection into the <see cref="T:Kvasir.Relations.RelationList`1"/> at the specified index.
+            </summary>
+            <param name="index">
+              The zero-based index at which the new elements sould be inserted.
+            </param>
+            <param name="collection">
+              The collection whose elements should be inserted into the <see cref="T:Kvasir.Relations.RelationList`1"/>. The collection
+              itself cannot be <see langword="null"/>, but it cacn contain elements that are <see langword="null"/> if
+              type <typeparamref name="T"/> is a reference type.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is less than <c>0</c>
+                --or--
+              if <paramref name="index"/> is greater than <see cref="P:Kvasir.Relations.RelationList`1.Count"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.LastIndexOf(`0)">
+            <summary>
+              Searchs for the specified object and returns the zero-based index of the last occurrence within the
+              entire <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+            <param name="item">
+              The object to locate in the <see cref="T:Kvasir.Relations.RelationList`1"/>. The value can be <see langword="null"/> for
+              reference types.
+            </param>
+            <returns>
+              The zero-based index of the last occurrence of <paramref name="item"/> within the entire
+              <see cref="T:Kvasir.Relations.RelationList`1"/>, if found; otherwise, <c>-1</c>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.LastIndexOf(`0,System.Int32)">
+            <summary>
+              Searches for the specified object and returns the zero-based index of the last occurrence within the
+              range of elements in the <see cref="T:Kvasir.Relations.RelationList`1"/> that extends from the first element to the
+              specified index.
+            </summary>
+            <param name="item">
+              The object to locate in the <see cref="T:Kvasir.Relations.RelationList`1"/>. The value can be <see langword="null"/> for
+              reference types.
+            </param>
+            <param name="index">
+              The zero-based starting index of the backward search.
+            </param>
+            <returns>
+              The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements in
+              the <see cref="T:Kvasir.Relations.RelationList`1"/> that extends from the first element to <paramref name="index"/>, if
+              found; otherwise, <c>-1</c>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.LastIndexOf(`0,System.Int32,System.Int32)">
+            <summary>
+              Searches for the specified object and returns the zero-based index of the last occurrence within the
+              range of elements in the <see cref="T:Kvasir.Relations.RelationList`1"/> that contains the specified number of elements and
+              ends at the specified index.
+            </summary>
+            <param name="item">
+              The object to locate in the <see cref="T:Kvasir.Relations.RelationList`1"/>. The value can be <see langword="null"/> for
+              reference types.
+            </param>
+            <param name="index">
+              The zero-based starting index of the backward search.
+            </param>
+            <param name="count">
+              The number of elements in the section to search.
+            </param>
+            <returns>
+              The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements in
+              the <see cref="T:Kvasir.Relations.RelationList`1"/> that contains <paramref name="count"/> number of elements and ends at
+              <paramref name="index"/>, if found; otherwise, <c>-1</c>.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:Kvasir.Relations.RelationList`1"/>
+                --or--
+              if <paramref name="count"/> is less than <c>0</c>
+                --or--
+              if <paramref name="index"/> and <paramref name="count"/> do not specify a valid section in the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Remove(`0)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.RemoveAll(System.Predicate{`0})">
+            <summary>
+              Removes all the elements that match the conditions defined by the specified predicate.
+            </summary>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that dfines the conditions of the elements to remove.
+            </param>
+            <returns>
+              The number of elements removed from the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.RemoveAt(System.Int32)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.RemoveRange(System.Int32,System.Int32)">
+            <summary>
+              Removes a range of elements from the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+            <param name="index">
+              The zero-based starting index of the range of elements to remove.
+            </param>
+            <param name="count">
+              The number of elements to remove.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is less than <c>0</c>
+                --or--
+              if <paramref name="count"/> is less than <c>0</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements in the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Reverse">
+            <summary>
+              Reverses the order of the elements in the entire <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Reverse(System.Int32,System.Int32)">
+            <summary>
+              Reverses the order of the elements in the specified range.
+            </summary>
+            <param name="index">
+              The zero-based staring index of the range to reverse.
+            </param>
+            <param name="count">
+              The number of elements in the range to reverse.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is less than <c>0</c>
+                --or--
+              if <paramref name="count"/> is less than <c>0</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements in the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Sort">
+            <summary>
+              Sorts the elements in the entire <see cref="T:Kvasir.Relations.RelationList`1"/> using the default comparer.
+            </summary>
+            <exception cref="T:System.InvalidOperationException">
+              if the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find an
+              implementation of the <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/>
+              interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Sort(System.Comparison{`0})">
+            <summary>
+              Sorts the elements in the entire <see cref="T:Kvasir.Relations.RelationList`1"/> using the specified
+              <see cref="T:System.Comparison`1"/>.
+            </summary>
+            <param name="comparison">
+              The <see cref="T:System.Comparison`1"/> to use when comparing elements.
+            </param>
+            <exception cref="T:System.ArgumentException">
+              The implementation of <paramref name="comparison"/> caused an error during the sort. For example,
+              <paramref name="comparison"/> might not return <c>0</c> when comparing an item with itself.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Sort(System.Collections.Generic.IComparer{`0})">
+            <summary>
+              Sorts the elements in the entire <see cref="T:Kvasir.Relations.RelationList`1"/> using the specified comparer.
+            </summary>
+            <param name="comparer">
+              The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or <see langword="null"/>
+              to use the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <exception cref="T:System.InvalidOperationException">
+              if <paramref name="comparer"/> is <see langword="null"/>, and the default comparer
+              <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find an implementation of the <see cref="T:System.IComparable`1"/>
+              generic interface or the <see cref="T:System.IComparable"/> interface for type <typeparamref name="T"/>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+              if the implementation of <paramref name="comparer"/> caused an error during the sort. For example,
+              <paramref name="comparer"/> might not return <c>0</c> when comparing an item with itself.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Sort(System.Int32,System.Int32,System.Collections.Generic.IComparer{`0})">
+            <summary>
+              Sorts the elements in a range of elements in the <see cref="T:Kvasir.Relations.RelationList`1"/> using the specified
+              comparer.
+            </summary>
+            <param name="index">
+              The zero-based starting index of the range to sort.
+            </param>
+            <param name="count">
+              The length of the range to sort.
+            </param>
+            <param name="comparer">
+              The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or <see langword="null"/>
+              to use the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+              if <paramref name="index"/> is less than <c>0</c>
+                --or--
+              if <paramref name="count"/> is less than <c>0</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="index"/> and <paramref name="count"/> do not specify a valid range in the
+              <see cref="T:Kvasir.Relations.RelationList`1"/>
+                --or--
+              if the implementation of <paramref name="comparer"/> caused an error during the sort. For example,
+              <paramref name="comparer"/> might not return <c>0</c> when comparing an item with itself.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+              if <paramref name="comparer"/> is <see langword="null"/>, and the default comparer
+              <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find an implementation of the <see cref="T:System.IComparable`1"/>
+              generic interface or the <see cref="T:System.IComparable"/> interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.ToArray">
+            <summary>
+              Copies the elements of the <see cref="T:Kvasir.Relations.RelationList`1"/> to a new array.
+            </summary>
+            <returns>
+              An array containing copies of the elements of the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.ToString">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.TrimExcess">
+            <summary>
+              Sets the capacity to the actual number of elements in the <see cref="T:Kvasir.Relations.RelationList`1"/>, if that number
+              is less than a threshold value.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.TrueForAll(System.Predicate{`0})">
+            <summary>
+              Determines whether every element in the <see cref="T:Kvasir.Relations.RelationList`1"/> matches the conditions defined by
+              the speified predicate.
+            </summary>
+            <param name="match">
+              The <see cref="T:System.Predicate`1"/> delegate that defines the conditions to check against the elements.
+            </param>
+            <returns>
+              <see langword="true"/> if every element in the <see cref="T:Kvasir.Relations.RelationList`1"/> matches the conditions
+              defined by the specified predicate; otherise, <see langword="false"/>. If the list contains no elements,
+              the return value is <see langword="true"/>.
+            </returns>
+        </member>
+        <member name="P:Kvasir.Relations.RelationList`1.Kvasir#Relations#IRelation#ConnectionType">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Relations.RelationList`1.System#Collections#IList#IsFixedSize">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Relations.RelationList`1.System#Collections#Generic#ICollection{T}#IsReadOnly">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Relations.RelationList`1.System#Collections#IList#IsReadOnly">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Relations.RelationList`1.System#Collections#ICollection#IsSynchronized">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Relations.RelationList`1.System#Collections#ICollection#SyncRoot">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Relations.RelationList`1.System#Collections#IList#Item(System.Int32)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.System#Collections#IList#Add(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Kvasir#Relations#IRelation#Canonicalize">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.System#Collections#IList#Contains(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.System#Collections#ICollection#CopyTo(System.Array,System.Int32)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.System#Collections#IEnumerable#GetEnumerator">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.System#Collections#Generic#IEnumerable{T}#GetEnumerator">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.Kvasir#Relations#IRelation#GetEnumerator">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.System#Collections#IList#IndexOf(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.System#Collections#IList#Insert(System.Int32,System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.System#Collections#IList#Remove(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.BookkeepAddition(`0)">
+            <summary>
+              Removes an item from the deletions of the current <see cref="T:Kvasir.Relations.RelationList`1"/> if it's there, and
+              determines the status of a to-be-added item.
+            </summary>
+            <remarks>
+              Note that this method does <i>NOT</i> add put the item into the collection. This method is viable for any
+              form of addition: insertions, overwrites, and appends. If the deletions contains multiple copies of the
+              item, only one instance is removed.
+            </remarks>
+            <param name="addition">
+              The item that is being added to the <see cref="T:Kvasir.Relations.RelationList`1"/>.
+            </param>
+            <returns>
+              The <see cref="T:Kvasir.Relations.Status"/> of the item being added: either <see cref="F:Kvasir.Relations.Status.New"/> if the item was not
+              deleted from the <see cref="T:Kvasir.Relations.RelationList`1"/> since the last canonicalization, or
+              <see cref="F:Kvasir.Relations.Status.Deleted"/> if the item is currently marked for deletion.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Relations.RelationList`1.BookkeepRemoval(System.Int32)">
+            <summary>
+              Updates the internal set of deletions with the item at a particular index if the item at that index is
+              currently in the <see cref="F:Kvasir.Relations.Status.Saved"/> state. Otherwise, this method has no impact.
+            </summary>
+            <param name="removalIndex">
+              The index of the item in the <see cref="T:Kvasir.Relations.RelationList`1"/> to be removed.
+            </param>
+        </member>
+        <member name="T:Kvasir.Relations.Status">
+            <summary>
+              An enumeration indicating the state of an entry in a relational collection relative to the back-end database.
+            </summary>
+        </member>
+        <member name="F:Kvasir.Relations.Status.New">
+            <summary>The relation connection has yet to be written to the back-end database.</summary>
+        </member>
+        <member name="F:Kvasir.Relations.Status.Saved">
+            <summary>The relation connection is already in the back-end database.</summary>
+        </member>
+        <member name="F:Kvasir.Relations.Status.Deleted">
+            <summary>The relation connection needs to be deleted from the back-end database.</summary>
+        </member>
+        <member name="F:Kvasir.Relations.Status.Modified">
+            <summary>The relation connection has been modified relative to the entry in the back-end datbase.</summary>
+            <remarks>This status is generally useful only for ordered collections, to indicate a reordering.</remarks>
+        </member>
         <member name="T:Kvasir.Schema.BasicField">
             <summary>
               A Field whose data type has no intrinsic constraints beyond those imposed by the back-end storage.

--- a/src/Kvasir/Relations/IRelation.cs
+++ b/src/Kvasir/Relations/IRelation.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kvasir.Relations {
+    /// <summary>
+    ///   The internal framework interface denoting a custom collection type that serves as a one-to-many relation.
+    /// </summary>
+    public interface IRelation {
+        /// <summary>
+        ///   The type of the Relation connection (the "many" in the one-to-many).
+        /// </summary>
+        internal Type ConnectionType { get; }
+
+        /// <summary>
+        ///   Updates the internal state tracking to reflect the Relation being fully synchronized with the back-end
+        ///   relational database.
+        /// </summary>
+        internal void Canonicalize();
+
+        /// <summary>
+        ///   Produces an enumerator that iterates over the connections that are tracked by this Relation, including
+        ///   those that have been deleted fro it.
+        /// </summary>
+        /// <remarks>
+        ///   The order in which connections are exposed by this method is only softly defined. Any connections that
+        ///   have been <see cref="Status.Deleted">deleted</see> since the last
+        ///   <see cref="Canonicalize">canonicalization</see> will be exposed first, followed by all
+        ///   <see cref="Status.New">new</see> and <see cref="Status.Saved">saved</see> ones (which may be interspersed
+        ///   together). Within the two groupings, the relative order of connections is undefined. No connection will
+        ///   more than once, and implementations are encouraged to ensure that repeated enuerations of the same
+        ///   Relation without intervening changes produce the same sequence of items.
+        /// </remarks>
+        /// <returns>
+        ///   An enumerator that iterates over the connections that are tracked by this Relation.
+        /// </returns>
+        internal IEnumerator<(object Item, Status Status)> GetEnumerator();
+    }
+}

--- a/src/Kvasir/Relations/RelationList.cs
+++ b/src/Kvasir/Relations/RelationList.cs
@@ -1,0 +1,1193 @@
+﻿using Ardalis.GuardClauses;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+
+namespace Kvasir.Relations {
+    /// <summary>
+    ///     An unordered collection that tracks the state of its elements for interaction with a back-end database.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     A <see cref="RelationList{T}"/> implements the same interfaces as and behaves identically to a standard
+    ///     <see cref="List{T}"/> collection. Operations that mutate the collection are used to track changes that can
+    ///     then be reflected in a back-end database, while view- or read-only operations have no additional side
+    ///     effects. Converting a <see cref="RelationList{T}"/> into another collection type, such as through a member
+    ///     API (e.g. <see cref="CopyTo(T[])"/>) or LINQ, drops the change tracking capabilities.
+    ///   </para>
+    ///   <para>
+    ///     Every item in a <see cref="RelationList{T}"/> is in one of three state: <c>NEW</c>, <c>SAVED</c>, and
+    ///     <c>DELETED</c>. Each state corresponds to the action or actions that should be taken with respect to that
+    ///     item to synchronize the back-end database table corresponding to the relation. An item enters the
+    ///     <c>NEW</c> state when it is first added; when the collection is canonicalized, each <c>NEW</c> items
+    ///     transitions to the <c>SAVED</c> state, indicating that it does not need to be written to the database on
+    ///     the next write. When a <c>SAVED</c> item is removed from the collection, it transitions to the
+    ///     <c>DELETED</c> stat; <c>NEW</c> items do no transition to <c>DELETED</c>. Note that if a <c>SAVED</c> item
+    ///     is deleted and then re-added, it will be re-added in the <c>SAVED</c> state.
+    ///   </para>
+    ///   <para>
+    ///     Items used in a <see cref="RelationList{T}"/> should be immutable: structs, <see cref="string"/>, etc. This
+    ///     is because read access is <i>not</i> tracked: when using mutable elements, it is possible for the user to
+    ///     access an ite (e.g. through <c>[]</c>) and mutate that element without the collection knowing, preventing
+    ///     that change from being reflected in the back-end database. This also means that actions that convert the
+    ///     collection into another form will <i>copy</i> the elements, ensuring that the tracking data remains
+    ///     up-to-date.
+    ///   </para>
+    ///   <para>
+    ///     A <see cref="RelationList{T}"/> technically permits duplicate elements, though it is strongly advised that
+    ///     users treat the collection as more of an unordered set, as the back-end relational database table will
+    ///     not permit duplicates. For example, it is possile for the collection to expose a single item in multiple
+    ///     seemingly incompatible states (e.g. <c>SAVED</c> and <c>DELETED</c>). Though different search APIs enable
+    ///     the use of custom comparators, the internal comparison logic always uses the default comparison.
+    ///   </para>
+    /// </remarks>
+    /// <typeparam name="T">
+    ///   The type of element to be stored in the collection.
+    /// </typeparam>
+    public sealed class RelationList<T> : ICollection<T>, IEnumerable, IEnumerable<T>, IList, IList<T>,
+        IReadOnlyCollection<T>, IReadOnlyList<T>, IRelation {
+
+        // *************************************** PROPERTIES ***************************************
+
+        /// <summary>
+        ///   Gets or sets the total number of elements the internal data structure can hold without resizing.
+        /// </summary>
+        /// <value>
+        ///   The number of elements that the <see cref="RelationList{T}"/> can contain before resizing is required.
+        /// </value>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <see cref="Capacity"/> is set to a value that is less than <see cref="Count"/>.
+        /// </exception>
+        /// <exception cref="OutOfMemoryException">
+        ///   if there is not enough memory available on the system.
+        /// </exception>
+        public int Capacity {
+            get {
+                return impl_.Capacity;
+            }
+            set {
+                impl_.Capacity = value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public int Count => impl_.Count;
+
+        /// <inheritdoc/>
+        public T this[int index] {
+            get {
+                return impl_[index];
+            }
+            set {
+                BookkeepRemoval(index);
+                statuses_[index] = BookkeepAddition(value);
+                impl_[index] = value;
+            }
+        }
+
+        // ************************************** CONSTRUCTORS **************************************
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="RelationList{T}"/> class that is empty and has the default
+        ///   initial capacity.
+        /// </summary>
+        public RelationList() {
+            impl_ = new List<T>();
+            statuses_ = new List<Status>();
+            deletions_ = new List<T>();
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="RelationList{T}"/> class that contains elements copied from
+        ///   the specified collection and has sufficient capacity to accommodate the number of elements copied.
+        /// </summary>
+        /// <param name="collection">
+        ///   The element whose names are copied to the new list.
+        /// </param>
+        public RelationList(IEnumerable<T> collection) {
+            impl_ = new List<T>(collection);
+            statuses_ = Enumerable.Repeat(Status.New, impl_.Count).ToList();
+            deletions_ = new List<T>();
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="RelationList{T}"/> class that is empty and has the specified
+        ///   initial capacity.
+        /// </summary>
+        /// <param name="capacity">
+        ///   The number of elements that the new list can initially store.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="capacity"/> is less than 0.
+        /// </exception>
+        public RelationList(int capacity) {
+            impl_ = new List<T>(capacity);
+            statuses_ = new List<Status>(capacity);
+            deletions_ = new List<T>();
+        }
+
+        // **************************************** METHODS *****************************************
+
+        /// <inheritdoc/>
+        public void Add(T item) {
+            statuses_.Add(BookkeepAddition(item));
+            impl_.Add(item);
+        }
+
+        /// <summary>
+        ///   Adds the elements of the specified collection to the end of the <see cref="RelationList{T}"/>.
+        /// </summary>
+        /// <param name="collection">
+        ///   The collection whose elements should be added to the end of the <see cref="RelationList{T}"/>. The
+        ///   collection itself cannot be <see langword="null"/>, but it can contain elements that are
+        ///   <see langword="null"/>, if type <typeparamref name="T"/> is a reference type.
+        /// </param>
+        public void AddRange(IEnumerable<T> collection) {
+            foreach (var item in collection) {
+                statuses_.Add(BookkeepAddition(item));
+                impl_.Add(item);
+            }
+        }
+
+        /// <summary>
+        ///   Returns a read-only <see cref="ReadOnlyCollection{T}"/> wrapper for the current collection.
+        /// </summary>
+        /// <returns>
+        ///   An object that acts as a read-only wrapper around the current <see cref="RelationList{T}"/>.
+        /// </returns>
+        [ExcludeFromCodeCoverage]
+        public ReadOnlyCollection<T> AsReadOnly() {
+            return impl_.AsReadOnly();
+        }
+
+        /// <summary>
+        ///   Searches the entire sorted <see cref="RelationList{T}"/> for an element using the default comparer and
+        ///   returns the zero-based index of the element.
+        /// </summary>
+        /// <param name="item">
+        ///   The object to locate. The value can be <see langword="null"/> for reference types.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of <paramref name="item"/> in the sorted <see cref="RelationList{T}"/>, if
+        ///   <paramref name="item"/> is found; otherwise, a negative number that is the bitwise complement of the
+        ///   index of the new element that is larger than <paramref name="item"/> or, if there is no larger element,
+        ///   the bitwise complement of <see cref="Count"/>.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   if the default comparer <see cref="Comparer{T}.Default"/> cannot find an implementation of the
+        ///   <see cref="IComparable{T}"/> generic interface or the <see cref="IComparable"/> interfae for type
+        ///   <typeparamref name="T"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int BinarySearch(T item) {
+            return impl_.BinarySearch(item);
+        }
+
+        /// <summary>
+        ///   Searches the entire sorted <see cref="RelationList{T}"/> for an element using the specified comparer and
+        ///   returns the zero-based index of the element.
+        /// </summary>
+        /// <param name="item">
+        ///   The object to locate. The value can be <see langword="null"/> for reference types.
+        /// </param>
+        /// <param name="comparer">
+        ///   The <see cref="IComparer{T}"/> implementation to use when comparing elements; or, <see langword="null"/>
+        ///   to use the default comparer <see cref="Comparer{T}.Default"/>.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of <paramref name="item"/> in the sorted <see cref="RelationList{T}"/>, if
+        ///   <paramref name="item"/> is found; otherwise, a negative number that is the bitwise complement of the
+        ///   index of the next element that is larger than <paramref name="item"/> or, if there is no larger element,
+        ///   the bitwise complement of <see cref="Count"/>.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   if <paramref name="comparer"/> is <see langword="null"/>, and the default comparer
+        ///   <see cref="Comparer{T}.Default"/> cannot find an implementation of the <see cref="IComparable{T}"/>
+        ///   generic interface or the <see cref="IComparable"/> interface for the type <typeparamref name="T"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int BinarySearch(T item, Comparer<T>? comparer) {
+            return impl_.BinarySearch(item, comparer);
+        }
+
+        /// <summary>
+        ///   Searches a range of elements in the sorted <see cref="RelationList{T}"/> for an element using the
+        ///   specified comparer and returns the zero-based index of the elemment.
+        /// </summary>
+        /// <param name="index">
+        ///   The zero-based starting index of the range to search.
+        /// </param>
+        /// <param name="count">
+        ///   The length of the range to search.
+        /// </param>
+        /// <param name="item">
+        ///   The object to locate. The value can be <see langword="null"/> for reference types.
+        /// </param>
+        /// <param name="comparer">
+        ///   The <see cref="IComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/>
+        ///   to use the default comparer <see cref="Comparer{T}.Default"/>.
+        /// </param>
+        /// <returns>
+        ///   The zero-based inex of <paramref name="item"/> in the sorted <see cref="RelationList{T}"/>, if
+        ///   <paramref name="item"/> is found; otherwise, a negative number that is the bitwise complement of the
+        ///   index of the next element that is larger than <paramref name="item"/> or, if there is no larger element,
+        ///   the bitwise complement of <see cref="Count"/>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="item"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="count"/> is less than <c>0</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   if <paramref name="index"/> and <paramref name="count"/> do not denote a valid range in the
+        ///   <see cref="RelationList{T}"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   <paramref name="comparer"/> is <see langword="null"/>, and the default comparer
+        ///   <see cref="Comparer{T}.Default"/> cannot find an implementation of the <see cref="IComparable{T}"/>
+        ///   generic interface or the <see cref="IComparable"/> interface for type <typeparamref name="T"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int BinarySearch(int index, int count, T item, Comparer<T>? comparer) {
+            return impl_.BinarySearch(index, count, item, comparer);
+        }
+
+        /// <inheritdoc/>
+        public void Clear() {
+            for (int idx = 0; idx < impl_.Count; ++idx) {
+                BookkeepRemoval(idx);
+            }
+            impl_.Clear();
+        }
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        public bool Contains(T item) {
+            return impl_.Contains(item);
+        }
+
+        /// <summary>
+        ///   Converts the elements in the current <see cref="RelationList{T}"/> to another type, and returns a list
+        ///   containing the converted elements.
+        /// </summary>
+        /// <typeparam name="TOutput">
+        ///   The type of the elements of the target array.
+        /// </typeparam>
+        /// <param name="converter">
+        ///   A <see cref="Converter{TInput, TOutput}"/> delegate that converts each element from one type to another
+        ///   type.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="List{T}"/> of the target type containing the converted elements from the current
+        ///   <see cref="RelationList{T}"/>.
+        /// </returns>
+        [ExcludeFromCodeCoverage]
+        public List<TOutput> ConvertAll<TOutput>(Converter<T, TOutput> converter) {
+            return impl_.ConvertAll(converter);
+        }
+
+        /// <summary>
+        ///   Copies the entire <see cref="RelationList{T}"/> to a compatible one-dimensional array, starting at the
+        ///   beginning of the target array.
+        /// </summary>
+        /// <param name="array">
+        ///   The one-dimensional <see cref="Array"/> that is the destination of the elements copied from the
+        ///   <see cref="RelationList{T}"/>. The <see cref="Array"/> must have zero-based indexing.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   if the number of elements in the source <see cref="RelationList{T}"/> is greater than the number of
+        ///   elements that the destination <paramref name="array"/> can contain.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public void CopyTo(T[] array) {
+            impl_.CopyTo(array);
+        }
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        public void CopyTo(T[] array, int arrayIndex) {
+            impl_.CopyTo(array, arrayIndex);
+        }
+
+        /// <summary>
+        ///   Copies a range of elements from the <see cref="RelationList{T}"/> to a compatible one-dimensional array,
+        ///   starting at the specified index of the target array.
+        /// </summary>
+        /// <param name="index">
+        ///   The zero-based index in the source <see cref="RelationList{T}"/> at which copying begins.
+        /// </param>
+        /// <param name="array">
+        ///   The one-dimensional <see cref="Array"/> that is the destination of the elements copied from the
+        ///   <see cref="RelationList{T}"/>. The <see cref="Array"/> must have zero-based indexing.
+        /// </param>
+        /// <param name="arrayIndex">
+        ///   The zero-based index in <paramref name="array"/> at which copying begins.
+        /// </param>
+        /// <param name="count">
+        ///   The number of elements to copy.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="arrayIndex"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="count"/> is less than <c>0</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   if <paramref name="index"/> is equal to or greater than the <see cref="Count"/> of the source
+        ///   <see cref="RelationList{T}"/>
+        ///     --or--
+        ///   if the number of elements from <paramref name="index"/> to the end of the source
+        ///   <see cref="RelationList{T}"/> is greater than the available space from <paramref name="arrayIndex"/> to
+        ///   the end of the destination <paramref name="array"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) {
+            impl_.CopyTo(index, array, arrayIndex, count);
+        }
+
+        /// <inheritdoc/>
+        public sealed override bool Equals(object? obj) {
+            return (obj is RelationList<T> list) &&
+                   impl_.Equals(list.impl_) &&
+                   statuses_.Equals(list.statuses_) &&
+                   deletions_.Equals(list.deletions_);
+        }
+
+        /// <summary>
+        ///   Determines whether the <see cref="RelationList{T}"/> contains elements that match the conditions defined
+        ///   by the specified predicate.
+        /// </summary>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions of the elements to search for.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the <see cref="RelationList{T}"/> contains one or more elements that match the
+        ///   conditions defined by the specified predicate; otherwise, <see langword="false"/>.
+        /// </returns>
+        [ExcludeFromCodeCoverage]
+        public bool Exists(Predicate<T> match) {
+            return impl_.Exists(match);
+        }
+
+        /// <summary>
+        ///   Searches for an element that matches the conditions defined by the specified predicate, and returns the
+        ///   first occurrence within the entire <see cref="RelationList{T}"/>.
+        /// </summary>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions of the element to search for.
+        /// </param>
+        /// <returns>
+        ///   The first element that matches the condition defined by the specified predicate, if found; otherwise, the
+        ///   default value for type <typeparamref name="T"/>.
+        /// </returns>
+        [ExcludeFromCodeCoverage]
+        public T? Find(Predicate<T> match) {
+            return impl_.Find(match);
+        }
+
+        /// <summary>
+        ///   Retrieves all the elements that match the conditions defined by the specified predicate.
+        /// </summary>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions of the elements to search for.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="List{T}"/> containing all the elements that match the conditions defined by the specified
+        ///   predicate, if found; otherwise, an empty <see cref="List{T}"/>.
+        /// </returns>
+        [ExcludeFromCodeCoverage]
+        public List<T> FindAll(Predicate<T> match) {
+            return impl_.FindAll(match);
+        }
+
+        /// <summary>
+        ///   Searches for an element that matches the conditions defined by the specified predicate, and returns the
+        ///   zero-based index of the first occurrence within the entire <see cref="RelationList{T}"/>.
+        /// </summary>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions of the element to search for.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of the first occurrence of an element that matches the conditions defined by
+        ///   <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+        /// </returns> 
+        [ExcludeFromCodeCoverage]
+        public int FindIndex(Predicate<T> match) {
+            return impl_.FindIndex(match);
+        }
+
+        /// <summary>
+        ///   Searches for an element that matches the conditions defined by the specified predicate, and returns the
+        ///   zero-based index of the first occurrence within the range of elements in the
+        ///   <see cref="RelationList{T}"/> that extends from the specified index to the last element.
+        /// </summary>
+        /// <param name="startIndex">
+        ///   The zero-based starting index of the search.
+        /// </param>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions of the element to search for.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of the first occurrence of an element that matches the conditions defined by
+        ///   <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///    if <paramref name="startIndex"/> is outside the range of valid indexes for the
+        ///    <see cref="RelationList{T}"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int FindIndex(int startIndex, Predicate<T> match) {
+            return impl_.FindIndex(startIndex, match);
+        }
+
+        /// <summary>
+        ///   Searches for an element that matches the conditions defined by the specified predicate, and returns the
+        ///   zero-based index of the first occurrence within the range of elements in the
+        ///   <see cref="RelationList{T}"/> that starts at the specified index and contains the specified number of
+        ///   elements.
+        /// </summary>
+        /// <param name="startIndex">
+        ///    The zero-based starting index of the search.
+        /// </param>
+        /// <param name="count">
+        ///   The number of elements in the section to search.
+        /// </param>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions of the elements to search for.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of the first occurrence of an element that matches the conditions defined by
+        ///   <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///    if <paramref name="startIndex"/> is outside the range of valid indexes for the
+        ///    <see cref="RelationList{T}"/>
+        ///      --or--
+        ///    if <paramref name="count"/> is less than <c>0</c>
+        ///      --or--
+        ///    if <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section in the
+        ///    <see cref="RelationList{T}"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int FindIndex(int startIndex, int count, Predicate<T> match) {
+            return impl_.FindIndex(startIndex, count, match);
+        }
+
+        /// <summary>
+        ///   Searches for an element that matches the conditions defined by the specified predicate, and returns the
+        ///   last occurrence within the entire <see cref="RelationList{T}"/>.
+        /// </summary>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions of the element to search for.
+        /// </param>
+        /// <returns>
+        ///   The last element that matches the conditions defined by the specified predicate, if found; otherwise, the
+        ///   default value for type <typeparamref name="T"/>.
+        /// </returns>
+        [ExcludeFromCodeCoverage]
+        public T? FindLast(Predicate<T> match) {
+            return impl_.FindLast(match);
+        }
+
+        /// <summary>
+        ///   Searches for an element that matches the conditions defined by the specified predicate, and returns the
+        ///   zero-based index of the last occurrence within the entire <see cref="RelationList{T}"/>.
+        /// </summary>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions of the element to search for.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of the last occurrence of an element that matches the conditions defined by
+        ///   <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+        /// </returns>
+        [ExcludeFromCodeCoverage]
+        public int FindLastIndex(Predicate<T> match) {
+            return impl_.FindLastIndex(match);
+        }
+
+        /// <summary>
+        ///   Searches for an element that matchs the conditions defined by the specified predicate, and returns the
+        ///   zero-based index of the last occurrence within the range of elements in the <see cref="RelationList{T}"/>
+        ///   that extends from the first element to the specified index.
+        /// </summary>
+        /// <param name="startIndex">
+        ///   The zero-based starting index of the backward search.
+        /// </param>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions of the element to search for.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of the last occurrence of an element that matches the conditions defined by
+        ///   <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="startIndex"/> is outside the range of valid indexes for the
+        ///   <see cref="RelationList{T}"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int FindLastIndex(int startIndex, Predicate<T> match) {
+            return impl_.FindLastIndex(startIndex, match);
+        }
+
+        /// <summary>
+        ///   Searches for an element that matches the conditions defined by the specified predicate, and returns the
+        ///   zero-based index of the last occurrence within the range of elements in the <see cref="RelationList{T}"/>
+        ///   that contains the specified number of elements and ends at the specified index.
+        /// </summary>
+        /// <param name="startIndex">
+        ///   The zero-based starting index of the backward search.
+        /// </param>
+        /// <param name="count">
+        ///   The number of elements in the section to search.
+        /// </param>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions of the element to search for.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of the last occurrence of an element that matches the conditions defined by
+        ///   <paramref name="match"/>, if found; otherwise, <c>-1</c>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="startIndex"/> is outside the range of valid indexes for the
+        ///   <see cref="RelationList{T}"/>
+        ///     --or--
+        ///   if <paramref name="count"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section in the
+        ///   <see cref="RelationList{T}"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) {
+            return impl_.FindLastIndex(startIndex, count, match);
+        }
+
+        /// <summary>
+        ///   Performs the specified action on each element of the <see cref="RelationList{T}"/>.
+        /// </summary>
+        /// <param name="action">
+        ///   The <see cref="Action{T}"/> delegate to perform on each element of the <see cref="RelationList{T}"/>.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        ///   if an element in the collection has been modified.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public void ForEach(Action<T> action) {
+            impl_.ForEach(action);
+        }
+
+        /// <summary>
+        ///   Returns an enumerator that iterates through the <see cref="RelationList{T}"/>.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="List{T}.Enumerator"/> for the <see cref="RelationList{T}"/>.
+        /// </returns>
+        public List<T>.Enumerator GetEnumerator() {
+            return impl_.GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        public sealed override int GetHashCode() {
+            return HashCode.Combine(impl_.GetHashCode(), statuses_.GetHashCode(), deletions_.GetHashCode());
+        }
+
+        /// <summary>
+        ///   Creates a shallow copy of a range of elements in the source <see cref="RelationList{T}"/>.
+        /// </summary>
+        /// <param name="index">
+        ///   The zero-based <see cref="RelationList{T}"/> index at which the range stats.
+        /// </param>
+        /// <param name="count">
+        ///   The number of elements in the range.
+        /// </param>
+        /// <returns>
+        ///   A shallow copy of a range of elements in the source <see cref="RelationList{T}"/>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="count"/> is less than <c>0</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   if <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements in the
+        ///   <see cref="RelationList{T}"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public List<T> GetRange(int index, int count) {
+            return impl_.GetRange(index, count);
+        }
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        public int IndexOf(T item) {
+            return impl_.IndexOf(item);
+        }
+
+        /// <summary>
+        ///   Searches for the specified object and returns the zero-based index of the first occurrence within the
+        ///   range of elements in the <see cref="RelationList{T}"/> that extends from the specified index to the last
+        ///   element.
+        /// </summary>
+        /// <param name="item">
+        ///   The object to locate in the <see cref="RelationList{T}"/>. The value can be <see langword="null"/> for
+        ///   reference types.
+        /// </param>
+        /// <param name="index">
+        ///   The zero-based starting index of the sarch. <c>0</c> (zero) is valid in an empty list.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of the first occurrence of <paramref name="item"/> within the range of elements in
+        ///   the <see cref="RelationList{T}"/> that extends from <paramref name="index"/> to the last element, if
+        ///   found; otherwise, <c>-1</c>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="index"/> is outside the range of valid indexes for the <see cref="RelationList{T}"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int IndexOf(T item, int index) {
+            return impl_.IndexOf(item, index);
+        }
+
+        /// <summary>
+        ///   Searches for the specified object and returns the zero-based index of the first occurrence within the
+        ///   range of elements in the <see cref="RelationList{T}"/> that starts at the specified index and contains
+        ///   the specified number of elements.
+        /// </summary>
+        /// <param name="item">
+        ///   The object to locate in the <see cref="RelationList{T}"/>. The value can be <see langword="null"/> for
+        ///   reference tpes.
+        /// </param>
+        /// <param name="index">
+        ///   The zero-based starting index of the search. <c>0</c> (zero) is valid in an empty list.
+        /// </param>
+        /// <param name="count">
+        ///   The number of elements in the section to search.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of teh first occurrence of <paramref name="item"/> within the range of elements in
+        ///   the <see cref="RelationList{T}"/> that starts at <paramref name="index"/> and contains
+        ///   <paramref name="count"/> number of elements, if found; otherwise, <c>-1</c>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is outside the range of valid indexes of the <see cref="RelationList{T}"/>
+        ///     --or--
+        ///   if <paramref name="count"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="index"/> and <paramref name="count"/> do not specify a valid section in the
+        ///   <see cref="RelationList{T}"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int IndexOf(T item, int index, int count) {
+            return impl_.IndexOf(item, index, count);
+        }
+
+        /// <inheritdoc/>
+        public void Insert(int index, T item) {
+            statuses_.Insert(index, Status.New);                // do this first to trigger exception checking
+            statuses_[index] = BookkeepAddition(item);
+            impl_.Insert(index, item);
+        }
+
+        /// <summary>
+        ///   Inserts the elements of a collection into the <see cref="RelationList{T}"/> at the specified index.
+        /// </summary>
+        /// <param name="index">
+        ///   The zero-based index at which the new elements sould be inserted.
+        /// </param>
+        /// <param name="collection">
+        ///   The collection whose elements should be inserted into the <see cref="RelationList{T}"/>. The collection
+        ///   itself cannot be <see langword="null"/>, but it cacn contain elements that are <see langword="null"/> if
+        ///   type <typeparamref name="T"/> is a reference type.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="index"/> is greater than <see cref="Count"/>.
+        /// </exception>
+        public void InsertRange(int index, IEnumerable<T> collection) {
+            Guard.Against.Null(collection, nameof(collection));
+
+            foreach (var item in collection) {
+                Insert(index++, item);
+            }
+        }
+
+        /// <summary>
+        ///   Searchs for the specified object and returns the zero-based index of the last occurrence within the
+        ///   entire <see cref="RelationList{T}"/>.
+        /// </summary>
+        /// <param name="item">
+        ///   The object to locate in the <see cref="RelationList{T}"/>. The value can be <see langword="null"/> for
+        ///   reference types.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of the last occurrence of <paramref name="item"/> within the entire
+        ///   <see cref="RelationList{T}"/>, if found; otherwise, <c>-1</c>.
+        /// </returns>
+        [ExcludeFromCodeCoverage]
+        public int LastIndexOf(T item) {
+            return impl_.LastIndexOf(item);
+        }
+
+        /// <summary>
+        ///   Searches for the specified object and returns the zero-based index of the last occurrence within the
+        ///   range of elements in the <see cref="RelationList{T}"/> that extends from the first element to the
+        ///   specified index.
+        /// </summary>
+        /// <param name="item">
+        ///   The object to locate in the <see cref="RelationList{T}"/>. The value can be <see langword="null"/> for
+        ///   reference types.
+        /// </param>
+        /// <param name="index">
+        ///   The zero-based starting index of the backward search.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements in
+        ///   the <see cref="RelationList{T}"/> that extends from the first element to <paramref name="index"/>, if
+        ///   found; otherwise, <c>-1</c>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is outside the range of valid indexes for the <see cref="RelationList{T}"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int LastIndexOf(T item, int index) {
+            return impl_.LastIndexOf(item, index);
+        }
+
+        /// <summary>
+        ///   Searches for the specified object and returns the zero-based index of the last occurrence within the
+        ///   range of elements in the <see cref="RelationList{T}"/> that contains the specified number of elements and
+        ///   ends at the specified index.
+        /// </summary>
+        /// <param name="item">
+        ///   The object to locate in the <see cref="RelationList{T}"/>. The value can be <see langword="null"/> for
+        ///   reference types.
+        /// </param>
+        /// <param name="index">
+        ///   The zero-based starting index of the backward search.
+        /// </param>
+        /// <param name="count">
+        ///   The number of elements in the section to search.
+        /// </param>
+        /// <returns>
+        ///   The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements in
+        ///   the <see cref="RelationList{T}"/> that contains <paramref name="count"/> number of elements and ends at
+        ///   <paramref name="index"/>, if found; otherwise, <c>-1</c>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is outside the range of valid indexes for the <see cref="RelationList{T}"/>
+        ///     --or--
+        ///   if <paramref name="count"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="index"/> and <paramref name="count"/> do not specify a valid section in the
+        ///   <see cref="RelationList{T}"/>.
+        /// </exception>
+        [ExcludeFromCodeCoverage]
+        public int LastIndexOf(T item, int index, int count) {
+            return impl_.LastIndexOf(item, index, count);
+        }
+
+        /// <inheritdoc/>
+        public bool Remove(T item) {
+            var idx = IndexOf(item);
+            if (idx == -1) {
+                return false;
+            }
+
+            RemoveAt(idx);
+            return true;
+        }
+
+        /// <summary>
+        ///   Removes all the elements that match the conditions defined by the specified predicate.
+        /// </summary>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that dfines the conditions of the elements to remove.
+        /// </param>
+        /// <returns>
+        ///   The number of elements removed from the <see cref="RelationList{T}"/>.
+        /// </returns>
+        public int RemoveAll(Predicate<T> match) {
+            int count = 0;
+            for (int idx = impl_.Count - 1; idx >= 0; --idx) {
+                if (match(impl_[idx])) {
+                    ++count;
+                    RemoveAt(idx);
+                }
+            }
+            return count;
+        }
+
+        /// <inheritdoc/>
+        public void RemoveAt(int index) {
+            BookkeepRemoval(index);
+            impl_.RemoveAt(index);
+            statuses_.RemoveAt(index);
+        }
+
+        /// <summary>
+        ///   Removes a range of elements from the <see cref="RelationList{T}"/>.
+        /// </summary>
+        /// <param name="index">
+        ///   The zero-based starting index of the range of elements to remove.
+        /// </param>
+        /// <param name="count">
+        ///   The number of elements to remove.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="count"/> is less than <c>0</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   if <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements in the
+        ///   <see cref="RelationList{T}"/>.
+        /// </exception>
+        public int RemoveRange(int index, int count) {
+            Guard.Against.OutOfRange(count, nameof(count), 0, int.MaxValue);
+            Guard.Against.OutOfRange(index, nameof(index), 0, impl_.Count - 1);
+            Guard.Against.InvalidInput(count, nameof(count), c => index + count < impl_.Count);
+
+            for (int c = 1; c <= count; ++c) {
+                RemoveAt(index);
+            }
+            return count;
+        }
+
+        /// <summary>
+        ///   Reverses the order of the elements in the entire <see cref="RelationList{T}"/>.
+        /// </summary>
+        public void Reverse() {
+            impl_.Reverse();
+            statuses_.Reverse();
+        }
+
+        /// <summary>
+        ///   Reverses the order of the elements in the specified range.
+        /// </summary>
+        /// <param name="index">
+        ///   The zero-based staring index of the range to reverse.
+        /// </param>
+        /// <param name="count">
+        ///   The number of elements in the range to reverse.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="count"/> is less than <c>0</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   if <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements in the
+        ///   <see cref="RelationList{T}"/>.
+        /// </exception>
+        public void Reverse(int index, int count) {
+            impl_.Reverse(index, count);
+            statuses_.Reverse(index, count);
+        }
+
+        /// <summary>
+        ///   Sorts the elements in the entire <see cref="RelationList{T}"/> using the default comparer.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///   if the default comparer <see cref="Comparer{ThreadStaticAttribute}.Default"/> cannot find an
+        ///   implementation of the <see cref="IComparable{T}"/> generic interface or the <see cref="IComparable"/>
+        ///   interface for type <typeparamref name="T"/>.
+        /// </exception>
+        public void Sort() {
+            Sort(Comparer<T>.Default);
+        }
+
+        /// <summary>
+        ///   Sorts the elements in the entire <see cref="RelationList{T}"/> using the specified
+        ///   <see cref="Comparison{T}"/>.
+        /// </summary>
+        /// <param name="comparison">
+        ///   The <see cref="Comparison{T}"/> to use when comparing elements.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   The implementation of <paramref name="comparison"/> caused an error during the sort. For example,
+        ///   <paramref name="comparison"/> might not return <c>0</c> when comparing an item with itself.
+        /// </exception>
+        public void Sort(Comparison<T> comparison) {
+            var tmp = new List<(T item, Status status)>(impl_.Count);
+            for (int idx = 0; idx < impl_.Count; ++idx) {
+                tmp.Add((impl_[idx], statuses_[idx]));
+            }
+
+            tmp.Sort((lhs, rhs) => comparison(lhs.item, rhs.item));
+            for (int idx = 0; idx < impl_.Count; ++idx) {
+                impl_[idx] = tmp[idx].item;
+                statuses_[idx] = tmp[idx].status;
+            }
+        }
+
+        /// <summary>
+        ///   Sorts the elements in the entire <see cref="RelationList{T}"/> using the specified comparer.
+        /// </summary>
+        /// <param name="comparer">
+        ///   The <see cref="IComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/>
+        ///   to use the default comparer <see cref="Comparer{T}.Default"/>.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        ///   if <paramref name="comparer"/> is <see langword="null"/>, and the default comparer
+        ///   <see cref="Comparer{T}.Default"/> cannot find an implementation of the <see cref="IComparable{T}"/>
+        ///   generic interface or the <see cref="IComparable"/> interface for type <typeparamref name="T"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   if the implementation of <paramref name="comparer"/> caused an error during the sort. For example,
+        ///   <paramref name="comparer"/> might not return <c>0</c> when comparing an item with itself.
+        /// </exception>
+        public void Sort(IComparer<T>? comparer) {
+            Sort((lhs, rhs) => comparer!.Compare(lhs, rhs));
+        }
+
+        /// <summary>
+        ///   Sorts the elements in a range of elements in the <see cref="RelationList{T}"/> using the specified
+        ///   comparer.
+        /// </summary>
+        /// <param name="index">
+        ///   The zero-based starting index of the range to sort.
+        /// </param>
+        /// <param name="count">
+        ///   The length of the range to sort.
+        /// </param>
+        /// <param name="comparer">
+        ///   The <see cref="IComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/>
+        ///   to use the default comparer <see cref="Comparer{T}.Default"/>.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   if <paramref name="index"/> is less than <c>0</c>
+        ///     --or--
+        ///   if <paramref name="count"/> is less than <c>0</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   if <paramref name="index"/> and <paramref name="count"/> do not specify a valid range in the
+        ///   <see cref="RelationList{T}"/>
+        ///     --or--
+        ///   if the implementation of <paramref name="comparer"/> caused an error during the sort. For example,
+        ///   <paramref name="comparer"/> might not return <c>0</c> when comparing an item with itself.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   if <paramref name="comparer"/> is <see langword="null"/>, and the default comparer
+        ///   <see cref="Comparer{T}.Default"/> cannot find an implementation of the <see cref="IComparable{T}"/>
+        ///   generic interface or the <see cref="IComparable"/> interface for type <typeparamref name="T"/>.
+        /// </exception>
+        public void Sort(int index, int count, IComparer<T>? comparer) {
+            Guard.Against.Null(comparer, nameof(comparer));
+
+            var tmp = new List<(T item, Status status)>(count);
+            for (int idx = index; idx < index + count; ++idx) {
+                tmp.Add((impl_[idx], statuses_[idx]));
+            }
+
+            tmp.Sort((lhs, rhs) => comparer.Compare(lhs.item, rhs.item));
+            for (int offset = 0; offset < count; ++offset) {
+                impl_[index + offset] = tmp[offset].item;
+                statuses_[index + offset] = tmp[offset].status;
+            }
+        }
+
+        /// <summary>
+        ///   Copies the elements of the <see cref="RelationList{T}"/> to a new array.
+        /// </summary>
+        /// <returns>
+        ///   An array containing copies of the elements of the <see cref="RelationList{T}"/>.
+        /// </returns>
+        [ExcludeFromCodeCoverage]
+        public T[] ToArray() {
+            return impl_.ToArray();
+        }
+
+        /// <inheritdoc/>
+        public sealed override string? ToString() {
+            var builder = new StringBuilder();
+            for (int idx = 0; idx < impl_.Count; ++idx) {
+                builder.Append($"{impl_[idx]} [{statuses_[idx]}");
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///   Sets the capacity to the actual number of elements in the <see cref="RelationList{T}"/>, if that number
+        ///   is less than a threshold value.
+        /// </summary>
+        [ExcludeFromCodeCoverage]
+        public void TrimExcess() {
+            impl_.TrimExcess();
+            statuses_.TrimExcess();
+            deletions_.TrimExcess();
+        }
+
+        /// <summary>
+        ///   Determines whether every element in the <see cref="RelationList{T}"/> matches the conditions defined by
+        ///   the speified predicate.
+        /// </summary>
+        /// <param name="match">
+        ///   The <see cref="Predicate{T}"/> delegate that defines the conditions to check against the elements.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if every element in the <see cref="RelationList{T}"/> matches the conditions
+        ///   defined by the specified predicate; otherise, <see langword="false"/>. If the list contains no elements,
+        ///   the return value is <see langword="true"/>.
+        /// </returns>
+        [ExcludeFromCodeCoverage]
+        public bool TrueForAll(Predicate<T> match) {
+            return impl_.TrueForAll(match);
+        }
+
+        // ******************************** EXPLICIT INTERFACE IMPLS ********************************
+
+        /// <inheritdoc/>
+        Type IRelation.ConnectionType => typeof(T);
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        bool IList.IsFixedSize => (impl_ as IList).IsFixedSize;
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        bool ICollection<T>.IsReadOnly => (impl_ as ICollection<T>).IsReadOnly;
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        bool IList.IsReadOnly => (impl_ as IList).IsReadOnly;
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        bool ICollection.IsSynchronized => (impl_ as ICollection).IsSynchronized;
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        object ICollection.SyncRoot => (impl_ as ICollection).SyncRoot;
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        object? IList.this[int index] {
+            get {
+                return this[index];
+            }
+            set {
+                Guard.Against.Null(value, nameof(value));
+                this[index] = (T)value;
+            }
+        }
+
+        /// <inheritdoc/>
+        int IList.Add(object? value) {
+            Guard.Against.Null(value, nameof(value));
+            Add((T)value);
+            return impl_.Count - 1;
+        }
+
+        /// <inheritdoc/>
+        void IRelation.Canonicalize() {
+            deletions_.Clear();
+            for (int idx = 0; idx < statuses_.Count; ++idx) {
+                statuses_[idx] = Status.Saved;
+            }
+        }
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        bool IList.Contains(object? value) {
+            return (impl_ as IList).Contains(value);
+        }
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        void ICollection.CopyTo(Array array, int index) {
+            (impl_ as ICollection).CopyTo(array, index);
+        }
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        IEnumerator IEnumerable.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        IEnumerator<(object Item, Status Status)> IRelation.GetEnumerator() {
+            for (int idx = 0; idx < deletions_.Count; ++idx) {
+                yield return (deletions_[idx]!, Status.Deleted);
+            }
+            for (int idx = 0; idx < impl_.Count; ++idx) {
+                yield return (impl_[idx]!, statuses_[idx]);
+            }
+        }
+
+        /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        int IList.IndexOf(object? value) {
+            return (impl_ as IList).IndexOf(value);
+        }
+
+        /// <inheritdoc/>
+        void IList.Insert(int index, object? value) {
+            Guard.Against.Null(value, nameof(value));
+            Insert(index, (T)value);
+        }
+
+        /// <inheritdoc/>
+        void IList.Remove(object? value) {
+            Guard.Against.Null(value, nameof(value));
+            Remove((T)value);
+        }
+
+        // ************************************ HELPER FUNCTIONS ************************************
+
+        /// <summary>
+        ///   Removes an item from the deletions of the current <see cref="RelationList{T}"/> if it's there, and
+        ///   determines the status of a to-be-added item.
+        /// </summary>
+        /// <remarks>
+        ///   Note that this method does <i>NOT</i> add put the item into the collection. This method is viable for any
+        ///   form of addition: insertions, overwrites, and appends. If the deletions contains multiple copies of the
+        ///   item, only one instance is removed.
+        /// </remarks>
+        /// <param name="addition">
+        ///   The item that is being added to the <see cref="RelationList{T}"/>.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="Status"/> of the item being added: either <see cref="Status.New"/> if the item was not
+        ///   deleted from the <see cref="RelationList{T}"/> since the last canonicalization, or
+        ///   <see cref="Status.Deleted"/> if the item is currently marked for deletion.
+        /// </returns>
+        private Status BookkeepAddition(T addition) {
+            var addedStatus = deletions_.Contains(addition) ? Status.Saved : Status.New;
+            if (addedStatus == Status.Saved) {
+                deletions_.Remove(addition);
+            }
+            return addedStatus;
+        }
+
+        /// <summary>
+        ///   Updates the internal set of deletions with the item at a particular index if the item at that index is
+        ///   currently in the <see cref="Status.Saved"/> state. Otherwise, this method has no impact.
+        /// </summary>
+        /// <param name="removalIndex">
+        ///   The index of the item in the <see cref="RelationList{T}"/> to be removed.
+        /// </param>
+        private void BookkeepRemoval(int removalIndex) {
+            if (statuses_[removalIndex] == Status.Saved) {
+                deletions_.Add(impl_[removalIndex]);
+            }
+        }
+
+        // ************************************ MEMBER VARIABLES ************************************
+
+        private readonly List<T> impl_;
+        private readonly List<Status> statuses_;
+        private readonly List<T> deletions_;
+    }
+}

--- a/src/Kvasir/Relations/Status.cs
+++ b/src/Kvasir/Relations/Status.cs
@@ -1,0 +1,19 @@
+﻿namespace Kvasir.Relations {
+    /// <summary>
+    ///   An enumeration indicating the state of an entry in a relational collection relative to the back-end database.
+    /// </summary>
+    internal enum Status {
+        /// <summary>The relation connection has yet to be written to the back-end database.</summary>
+        New,
+
+        /// <summary>The relation connection is already in the back-end database.</summary>
+        Saved,
+
+        /// <summary>The relation connection needs to be deleted from the back-end database.</summary>
+        Deleted,
+
+        /// <summary>The relation connection has been modified relative to the entry in the back-end datbase.</summary>
+        /// <remarks>This status is generally useful only for ordered collections, to indicate a reordering.</remarks>
+        Modified
+    }
+}

--- a/test/UnitTests/Kvasir/Relations/RelationListTests.cs
+++ b/test/UnitTests/Kvasir/Relations/RelationListTests.cs
@@ -1,0 +1,951 @@
+﻿using FluentAssertions;
+using Kvasir.Relations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace UT.Kvasir.Relations {
+    [TestClass, TestCategory("RelationList")]
+    public class RelationListTests {
+        [TestMethod] public void DefaultConstruct() {
+            // Arrange
+
+            // Act
+            var list = new RelationList<string>();
+
+            // Assert
+            list.Count.Should().Be(0);
+            (list as IRelation).ConnectionType.Should().Be(typeof(string));
+            list.Should().HaveEntryCount(0);
+        }
+
+        [TestMethod] public void ConstructFromElements() {
+            // Arrange
+            var elements = new string[] { "Kalispell", "Bethesda", "Yuma", "Oregon City", "Unalaska" };
+
+            // Act
+            var list = new RelationList<string>(elements);
+
+            // Assert
+            list.Count.Should().Be(5);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(elements[2]);
+            list[3].Should().Be(elements[3]);
+            list[4].Should().Be(elements[4]);
+            list.Capacity.Should().BeGreaterOrEqualTo(5);
+            list.Should().HaveConnectionType<string>();
+            list.Should().HaveEntryCount(elements.Length);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.New);
+            list.Should().ExposeEntry(elements[1], Status.New);
+            list.Should().ExposeEntry(elements[2], Status.New);
+            list.Should().ExposeEntry(elements[3], Status.New);
+            list.Should().ExposeEntry(elements[4], Status.New);
+        }
+
+        [TestMethod] public void ConstructFromCapacity() {
+            // Arrange
+            var capacity = 37;
+
+            // Act
+            var list = new RelationList<string>(capacity);
+
+            // Assert
+            list.Count.Should().Be(0);
+            list.Capacity.Should().BeGreaterOrEqualTo(capacity);
+            list.Should().HaveConnectionType<string>();
+            list.Should().HaveEntryCount(0);
+        }
+
+        [TestMethod] public void CanonicalizeNoneDeleted() {
+            // Arrange
+            var elements = new string[] { "Evansville", "Dubuque", "Newport News", "Sitka" };
+            var list = new RelationList<string>(elements);
+
+            // Act
+            (list as IRelation).Canonicalize();
+
+            // Assert
+            list.Count.Should().Be(4);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().ExposeEntry(elements[3], Status.Saved);
+        }
+
+        [TestMethod] public void RemoveExistingNewItem() {
+            // Arrange
+            var elements = new string[] { "Burlington", "Stockton", "College Station" };
+            var list = new RelationList<string>(elements);
+
+            // Act
+            var success = list.Remove(elements[1]);
+
+            // Assert
+            list.Count.Should().Be(2);
+            success.Should().BeTrue();
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[2]);
+            list.Should().HaveEntryCount(2);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.New);
+            list.Should().NotExposeEntryFor(elements[1]);
+            list.Should().ExposeEntry(elements[2], Status.New);
+        }
+
+        [TestMethod] public void RemoveExistingSavedItem() {
+            // Arrange
+            var elements = new string[] { "Hardin", "Kailua", "Youngstown" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+
+            // Act
+            var success = list.Remove(elements[0]);
+
+            // Assert
+            list.Count.Should().Be(2);
+            success.Should().BeTrue();
+            list[0].Should().Be(elements[1]);
+            list[1].Should().Be(elements[2]);
+            list.Should().HaveEntryCount(3);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Deleted);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+        }
+
+        [TestMethod] public void RemoveTwiceThenReplace() {
+            // Arrange
+            var elements = new string[] { "Morgantown", "Oxnard", "Daytona Beach", "Carmel" };
+            var list = new RelationList<string>(elements);
+            var duplicate = elements[1];
+            list.Add(duplicate);
+            (list as IRelation).Canonicalize();
+
+            // Act
+            var removals = list.RemoveAll(s => s == duplicate);
+            list.Add(duplicate);
+
+            // Assert
+            removals.Should().Be(2);
+            list.Count.Should().Be(4);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[2]);
+            list[2].Should().Be(elements[3]);
+            list[3].Should().Be(duplicate);
+            list.Should().HaveEntryCount(5);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Deleted);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().ExposeEntry(elements[3], Status.Saved);
+        }
+
+        [TestMethod] public void RemoveNonexistingItem() {
+            // Arrange
+            var list = new RelationList<string>() { "Lake Charles", "Nashua" };
+
+            // Act
+            var success = list.Remove("Auburn");
+
+            // Assert
+            list.Count.Should().Be(2);
+            success.Should().BeFalse();
+        }
+
+        [TestMethod] public void RemoveItemByIndex() {
+            // Arrange
+            var elements = new string[] { "Flint", "Kirkland", "Norman", "Alexandria" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+
+            // Act
+            list.RemoveAt(2);
+
+            // Assert
+            list.Count.Should().Be(3);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(elements[3]);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Deleted);
+            list.Should().ExposeEntry(elements[3], Status.Saved);
+        }
+
+        [TestMethod] public void RemoveAtNegativeIndex() {
+            // Arrange
+            var list = new RelationList<string>() { "West Covina", "Palatine" };
+
+            // Act
+            Action act = () => list.RemoveAt(-3);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void RemoveAtOverlargeIndex() {
+            // Arrange
+            var list = new RelationList<string>() { "Gulfport" };
+
+            // Act
+            Action act = () => list.RemoveAt(list.Count * 17);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void RemoveRangeOfItems() {
+            // Arrange
+            var elements = new string[] { "Reston", "Rancho Cucamonga", "Lake Placid", "Eau Claire", "Worcester" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+
+            // Act
+            list.RemoveRange(1, 3);
+
+            // Assert
+            list.Count.Should().Be(2);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[4]);
+            list.Should().HaveEntryCount(5);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Deleted);
+            list.Should().ExposeEntry(elements[2], Status.Deleted);
+            list.Should().ExposeEntry(elements[3], Status.Deleted);
+            list.Should().ExposeEntry(elements[4], Status.Saved);
+        }
+
+        [TestMethod] public void RemoveRangeZeroItems() {
+            // Arrange
+            var elements = new string[] { "Waterloo", "Ketchikan", "Waimanalo", "North Platte" };
+            var list = new RelationList<string>(elements);
+
+            // Act
+            list.RemoveRange(2, 0);
+
+            // Assert
+            list.Count.Should().Be(4);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(elements[2]);
+            list[3].Should().Be(elements[3]);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.New);
+            list.Should().ExposeEntry(elements[1], Status.New);
+            list.Should().ExposeEntry(elements[2], Status.New);
+            list.Should().ExposeEntry(elements[3], Status.New);
+        }
+
+        [TestMethod] public void RemoveInvalidRange() {
+            // Arrange
+            var list = new RelationList<string>() { "Fort Hood", "Manassas", "Narragansett Pier" };
+
+            // Act
+            Action act0 = () => list.RemoveRange(-3, 7);
+            Action act1 = () => list.RemoveRange(1, -6);
+            Action act2 = () => list.RemoveRange(2, 4);
+
+            // Assert
+            act0.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+            act1.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+            act2.Should().ThrowExactly<ArgumentException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void Clear() {
+            // Arrange
+            var elements = new string[] { "Macon", "Brownsville", "Naperville" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var single = "Hollywood";
+            list.Add(single);
+
+            // Act
+            list.Clear();
+
+            // Assert
+            list.Count.Should().Be(0);
+            list.Should().HaveEntryCount(3);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Deleted);
+            list.Should().ExposeEntry(elements[1], Status.Deleted);
+            list.Should().ExposeEntry(elements[2], Status.Deleted);
+            list.Should().NotExposeEntryFor(single);
+        }
+
+        [TestMethod] public void CanonicalizeSomeDeleted() {
+            // Arrange
+            var elements = new string[] { "Huntsville", "Pembroke Pines", "Champaign", "Bowling Green", "Casper" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            list.Remove(elements[1]);
+            list.Remove(elements[3]);
+
+            // Act
+            (list as IRelation).Canonicalize();
+
+            // Assert
+            list.Count.Should().Be(3);
+            list.Should().HaveEntryCount(3);
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().NotExposeEntryFor(elements[1]);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().NotExposeEntryFor(elements[3]);
+            list.Should().ExposeEntry(elements[4], Status.Saved);
+        }
+
+        [TestMethod] public void AddNewItem() {
+            // Arrange
+            var list = new RelationList<string>();
+            var element0 = "High Point";
+            var element1 = "Aynor";
+
+            // Act
+            list.Add(element0);
+            list.Add(element1);
+
+            // Assert
+            list.Count.Should().Be(2);
+            list[0].Should().Be(element0);
+            list[1].Should().Be(element1);
+            list.Should().HaveEntryCount(2);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(element0, Status.New);
+            list.Should().ExposeEntry(element1, Status.New);
+        }
+
+        [TestMethod] public void AddExistingNewItem() {
+            // Arrange
+            var elements = new string[] { "Pocatello", "Wheeling" };
+            var list = new RelationList<string>(elements);
+            var repeat = list[0];
+
+            // Act
+            list.Add(repeat);
+
+            // Assert
+            list.Count.Should().Be(3);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(repeat);
+            list.Should().HaveEntryCount(3);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(repeat, Status.New, 2);
+        }
+
+        [TestMethod] public void AddExitingSavedItem() {
+            // Arrange
+            var elements = new string[] { "Pawtucket", "Kettering", "Joplin" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var repeat = list[2];
+
+            // Act
+            list.Add(repeat);
+
+            // Assert
+            list.Count.Should().Be(4);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(elements[2]);
+            list[3].Should().Be(repeat);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(repeat, Status.Saved);
+            list.Should().ExposeEntry(repeat, Status.New);
+        }
+
+        [TestMethod] public void AddExistingDeletedItem() {
+            // Arrange
+            var elements = new string[] { "Berkeley", "Erie", "Altoona" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var deleted = elements[1];
+            list.Remove(deleted);
+
+            // Act
+            list.Add(deleted);
+
+            // Assert
+            list.Count.Should().Be(3);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[2]);
+            list[2].Should().Be(deleted);
+            list.Should().HaveEntryCount(3);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(deleted, Status.Saved);
+        }
+
+        [TestMethod] public void InsertNewItem() {
+            // Arrange
+            var elements = new string[] { "Farmington Hills", "Terre Haute", "Tupelo" };
+            var list = new RelationList<string>(elements);
+            var insertion = "Kaneohe";
+
+            // Act
+            list.Insert(1, insertion);
+
+            // Assert
+            list.Count.Should().Be(4);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(insertion);
+            list[2].Should().Be(elements[1]);
+            list[3].Should().Be(elements[2]);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(insertion, Status.New);
+        }
+
+        [TestMethod] public void InsertExistingNewItem() {
+            // Arrange
+            var elements = new string[] { "Whitefish", "Fayetteville" };
+            var list = new RelationList<string>(elements);
+            var repeat = list[0];
+
+            // Act
+            list.Insert(0, repeat);
+
+            // Assert
+            list.Count.Should().Be(3);
+            list[0].Should().Be(repeat);
+            list[1].Should().Be(elements[0]);
+            list[2].Should().Be(elements[1]);
+            list.Should().HaveEntryCount(3);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(repeat, Status.New, 2);
+        }
+
+        [TestMethod] public void InsertExitingSavedItem() {
+            // Arrange
+            var elements = new string[] { "Waterbury", "Toms River", "Decatur" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var repeat = list[2];
+
+            // Act
+            list.Insert(2, repeat);
+
+            // Assert
+            list.Count.Should().Be(4);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(repeat);
+            list[3].Should().Be(elements[2]);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(repeat, Status.Saved);
+            list.Should().ExposeEntry(repeat, Status.New);
+        }
+
+        [TestMethod] public void InsertExistingDeletedItem() {
+            // Arrange
+            var elements = new string[] { "Rochester", "Stamford", "Kennewick" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var deleted = elements[1];
+            list.Remove(deleted);
+
+            // Act
+            list.Insert(0, deleted);
+
+            // Assert
+            list.Count.Should().Be(3);
+            list[0].Should().Be(elements[1]);
+            list[1].Should().Be(elements[0]);
+            list[2].Should().Be(elements[2]);
+            list.Should().HaveEntryCount(3);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(deleted, Status.Saved);
+        }
+
+        [TestMethod] public void InsertNegativeIndex() {
+            // Arrange
+            var list = new RelationList<string>() { "Lander", "East Hartford" };
+
+            // Act
+            Action act = () => list.Insert(-4, "Shaker Heights");
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void InsertOverlargeIndex() {
+            // Arrange
+            var list = new RelationList<string>();
+
+            // Act
+            Action act = () => list.Insert(9, "Danbury");
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void InsertRangeOfItemsAllNew() {
+            // Arrange
+            var elements = new string[] { "Wasilla", "Pine Bluff" };
+            var list = new RelationList<string>(elements);
+            var insertions = new string[] { "Minnetonka", "Bristol" };
+
+            // Act
+            list.InsertRange(1, insertions);
+
+            // Assert
+            list.Count.Should().Be(4);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(insertions[0]);
+            list[2].Should().Be(insertions[1]);
+            list[3].Should().Be(elements[1]);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.New);
+            list.Should().ExposeEntry(elements[1], Status.New);
+            list.Should().ExposeEntry(insertions[0], Status.New);
+            list.Should().ExposeEntry(insertions[1], Status.New);
+        }
+
+        [TestMethod] public void InsertRangeOfItemsSomeDuplicates() {
+            // Arrange
+            var elements = new string[] { "Lima", "Germantown", "Cairo" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var single = "Zzyzx";
+            list.Add(single);
+            var insertions = new string[] { "Cape Girardeau", "Yonkers" };
+
+            // Act
+            list.InsertRange(2, insertions);
+
+            // Assert
+            list.Count.Should().Be(6);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(insertions[0]);
+            list[3].Should().Be(insertions[1]);
+            list[4].Should().Be(elements[2]);
+            list[5].Should().Be(single);
+            list.Should().HaveEntryCount(6);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().ExposeEntry(single, Status.New);
+            list.Should().ExposeEntry(insertions[0], Status.New);
+            list.Should().ExposeEntry(insertions[1], Status.New);
+        }
+
+        [TestMethod] public void InsertRangeBringBackDeleted() {
+            // Arrange
+            var elements = new string[] { "Burbank", "Kenosha", "Levittown" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            list.Remove(elements[1]);
+            var insertions = new string[] { "Spearfish", elements[1], "Grand Forks" };
+
+            // Act
+            list.InsertRange(1, insertions);
+
+            // Assert
+            list.Count.Should().Be(5);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(insertions[0]);
+            list[2].Should().Be(insertions[1]);
+            list[3].Should().Be(insertions[2]);
+            list[4].Should().Be(elements[2]);
+            list.Should().HaveEntryCount(5);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().ExposeEntry(insertions[0], Status.New);
+            list.Should().ExposeEntry(insertions[2], Status.New);
+        }
+
+        [TestMethod] public void InsertNullRange() {
+            // Arrange
+            var list = new RelationList<string>();
+
+            // Act
+            Action act = () => list.InsertRange(0, null!);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void InsertInvalidRange() {
+            // Arrange
+            var list = new RelationList<string>() { "Pontiac", "Quincy", "Tafuna" };
+
+            // Act
+            var insertion = new string[] { "Christiansted", "Miramar" };
+            Action act0 = () => list.InsertRange(-189, insertion);
+            Action act1 = () => list.InsertRange(list.Count * 3, insertion);
+
+            // Assert
+            act0.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+            act1.Should().ThrowExactly<ArgumentOutOfRangeException>().WithAnyMessage();
+        }
+
+        [TestMethod] public void OvewriteNewSelfWithSelf() {
+            // Arrange
+            var elements = new string[] { "Carbondale", "Charlottesville", "Port St. Lucie" };
+            var list = new RelationList<string>(elements);
+            var single = "Fort Myers";
+            var replacement = elements[1];
+            (list as IRelation).Canonicalize();
+            list.Add(single);
+
+            // Act
+            list[^1] = single;
+            list[1] = replacement;
+
+            // Assert
+            list.Count.Should().Be(4);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(elements[2]);
+            list[3].Should().Be(single);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().ExposeEntry(single, Status.New);
+        }
+
+        [TestMethod] public void OverwriteSavedSelfWithSelf() {
+            // Arrange
+            var elements = new string[] { "Hagåtña", "Dededo", "Charlotte Amalie" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+
+            // Act
+            list[0] = elements[0];
+            list[1] = elements[1];
+            list[2] = elements[2];
+
+            // Assert
+            list.Count.Should().Be(3);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(elements[2]);
+            list.Should().HaveEntryCount(3);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+        }
+
+        [TestMethod] public void OverwriteNewWithNonexistent() {
+            // Arrange
+            var elements = new string[] { "Malibu", "Hattiesburg", "Macomb" };
+            var list = new RelationList<string>(elements);
+            var replacement = "Iowa City";
+
+            // Act
+            list[2] = replacement;
+
+            // Assert
+            list.Count.Should().Be(3);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(replacement);
+            list.Should().HaveEntryCount(3);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.New);
+            list.Should().ExposeEntry(elements[1], Status.New);
+            list.Should().ExposeEntry(replacement, Status.New);
+            list.Should().NotExposeEntryFor(elements[2]);
+        }
+
+        [TestMethod] public void OverwriteNewWithNew() {
+            // Arrange
+            var elements = new string[] { "Urbana", "Missoula" };
+            var list = new RelationList<string>(elements);
+
+            // Act
+            list[0] = elements[1];
+
+            // Assert
+            list.Count.Should().Be(2);
+            list[0].Should().Be(elements[1]);
+            list[1].Should().Be(elements[1]);
+            list.Should().HaveEntryCount(2);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[1], Status.New, 2);
+        }
+
+        [TestMethod] public void OverwriteNewWithSaved() {
+            // Arrange
+            var elements = new string[] { "Oxford", "New Rochelle", "Des Plaines" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var single = "San Luis Obispo";
+            list.Add(single);
+
+            // Act
+            list[^1] = list[1];
+
+            // Assert
+            list.Count.Should().Be(4);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(elements[2]);
+            list[3].Should().Be(elements[1]);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.New);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().NotExposeEntryFor(single);
+        }
+
+        [TestMethod] public void OverwriteNewWithDeleted() {
+            // Arrange
+            var elements = new string[] { "West Point", "Chapel Hill" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var single = "Santa Barbara";
+            list.RemoveAt(0);
+            list.Add(single);
+
+            // Act
+            list[^1] = elements[0];
+
+            // Assert
+            list.Count.Should().Be(2);
+            list[0].Should().Be(elements[1]);
+            list[1].Should().Be(elements[0]);
+            list.Should().HaveEntryCount(2);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().NotExposeEntryFor(single);
+        }
+
+        [TestMethod] public void OverwriteSavedWithNonexistent() {
+            // Arrange
+            var elements = new string[] { "Eureka" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var single = "Coral Gables";
+
+            // Act
+            list[0] = single;
+
+            // Assert
+            list.Count.Should().Be(1);
+            list[0].Should().Be(single);
+            list.Should().HaveEntryCount(2);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Deleted);
+            list.Should().ExposeEntry(single, Status.New);
+        }
+
+        [TestMethod] public void OverwriteSavedWithNew() {
+            // Arrange
+            var elements = new string[] { "San Juan", "Pago Pago" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var single = "Saipan";
+            list.Add(single);
+
+            // Act
+            list[0] = single;
+
+            // Assert
+            list.Count.Should().Be(3);
+            list[0].Should().Be(single);
+            list[1].Should().Be(elements[1]);
+            list[2].Should().Be(single);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Deleted);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(single, Status.New, 2);
+        }
+
+        [TestMethod] public void OverwriteSavedWithSaved() {
+            // Arrange
+            var elements = new string[] { "Andersonville", "Nauvoo" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+
+            // Act
+            list[1] = list[0];
+
+            // Assert
+            list.Count.Should().Be(2);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(elements[0]);
+            list.Should().HaveEntryCount(3);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[0], Status.New);
+            list.Should().ExposeEntry(elements[1], Status.Deleted);
+        }
+
+        [TestMethod] public void OverwriteSavedWithDeleted() {
+            // Arrange
+            var elements = new string[] { "Key West", "Wabaunsee" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            list.Remove(elements[0]);
+
+            // Act
+            list[0] = elements[0];
+
+            // Assert
+            list.Count.Should().Be(1);
+            list[0].Should().Be(elements[0]);
+            list.Should().HaveEntryCount(2);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Deleted);
+        }
+
+        [TestMethod] public void Sort() {
+            // Arrange
+            var elements = new string[] { "Jackson Hole", "Irving", "Kokomo" };
+            var list = new RelationList<string>(elements);
+            var single0 = "Seward";
+            var single1 = "Lahaina";
+            (list as IRelation).Canonicalize();
+            list.Insert(0, single0);
+            list.Add(single1);
+
+            // Act
+            list.Remove(elements[1]);
+            list.Sort();
+
+            // Assert
+            list.Count.Should().Be(4);
+            list[0].Should().Be("Jackson Hole");
+            list[1].Should().Be("Kokomo");
+            list[2].Should().Be("Lahaina");
+            list[3].Should().Be("Seward");
+            list.Should().HaveEntryCount(5);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Deleted);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().ExposeEntry(single0, Status.New);
+            list.Should().ExposeEntry(single1, Status.New);
+        }
+
+        [TestMethod] public void SortCustomComparer() {
+            // Arrange
+            var elements = new string[] { "paterson", "Owensboro", "deKalb" };
+            var list = new RelationList<string>(elements);
+            var single0 = "Smyrna";
+            var single1 = "buena Vista";
+            (list as IRelation).Canonicalize();
+            list.Add(single0);
+            list.Add(single1);
+
+            // Act
+            list.Sort(StringComparer.OrdinalIgnoreCase);
+
+            // Assert
+            list.Count.Should().Be(5);
+            list[0].Should().Be("buena Vista");
+            list[1].Should().Be("deKalb");
+            list[2].Should().Be("Owensboro");
+            list[3].Should().Be("paterson");
+            list[4].Should().Be("Smyrna");
+            list.Should().HaveEntryCount(5);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().ExposeEntry(single0, Status.New);
+            list.Should().ExposeEntry(single1, Status.New);
+        }
+
+        [TestMethod] public void SortSubrange() {
+            // Arrange
+            var elements = new string[] {
+                "Metairie", "Georgetown", "Schenectady", "La Crosse", "Alomogordo", "Frankfort", "Langley"
+            };
+            var list = new RelationList<string>(elements);
+
+            // Act
+            list.Sort(2, 4, StringComparer.Ordinal);
+
+            // Assert
+            list.Count.Should().Be(7);
+            list[0].Should().Be("Metairie");
+            list[1].Should().Be("Georgetown");
+            list[2].Should().Be("Alomogordo");
+            list[3].Should().Be("Frankfort");
+            list[4].Should().Be("La Crosse");
+            list[5].Should().Be("Schenectady");
+            list[6].Should().Be("Langley");
+            list.Should().HaveEntryCount(7);
+            list.Should().ExposeEntry(elements[0], Status.New);
+            list.Should().ExposeEntry(elements[1], Status.New);
+            list.Should().ExposeEntry(elements[2], Status.New);
+            list.Should().ExposeEntry(elements[3], Status.New);
+            list.Should().ExposeEntry(elements[4], Status.New);
+            list.Should().ExposeEntry(elements[5], Status.New);
+            list.Should().ExposeEntry(elements[6], Status.New);
+        }
+
+        [TestMethod] public void Reverse() {
+            // Arrange
+            var elements = new string[] { "Butte", "Appleton", "Novi", };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var single = "Oshkosh";
+            list.Add(single);
+
+            // Act
+            list.Reverse();
+
+            // Assert
+            list.Count.Should().Be(4);
+            list[0].Should().Be(single);
+            list[1].Should().Be(elements[^1]);
+            list[2].Should().Be(elements[^2]);
+            list[3].Should().Be(elements[^3]);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().ExposeEntry(single, Status.New);
+        }
+
+        [TestMethod] public void ReverseSubsequence() {
+            // Arrange
+            var elements = new string[] { "Racine", "Tahlequa", "St. Cloud" };
+            var list = new RelationList<string>(elements);
+            (list as IRelation).Canonicalize();
+            var single = "Florida City";
+            list.Insert(2, single);
+
+            // Act
+            list.Reverse(1, 2);
+
+            // Assert
+            list.Count.Should().Be(4);
+            list[0].Should().Be(elements[0]);
+            list[1].Should().Be(single);
+            list[2].Should().Be(elements[1]);
+            list[3].Should().Be(elements[2]);
+            list.Should().HaveEntryCount(4);
+            list.Should().ExposeDeletesFirst();
+            list.Should().ExposeEntry(elements[0], Status.Saved);
+            list.Should().ExposeEntry(elements[1], Status.Saved);
+            list.Should().ExposeEntry(elements[2], Status.Saved);
+            list.Should().ExposeEntry(single, Status.New);
+        }
+    }
+}

--- a/test/UnitTests/_FluentExtensions/RelationAssertions.cs
+++ b/test/UnitTests/_FluentExtensions/RelationAssertions.cs
@@ -1,0 +1,93 @@
+﻿using FluentAssertions.Execution;
+using Kvasir.Relations;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FluentAssertions {
+    internal static partial class AssertionExtensions {
+        public static RelationAssertion Should<T>(this RelationList<T> self) {
+            return new RelationAssertion(self);
+        }
+
+        public class RelationAssertion : Primitives.ObjectAssertions {
+            public new IRelation Subject { get; }
+            private List<(object Item, Status Status)> SubjectList { get; }
+            public RelationAssertion(IRelation subject)
+                : base(subject) {
+
+                Subject = subject;
+                SubjectList = new List<(object Item, Status status)>();
+
+                var iter = subject.GetEnumerator();
+                while (iter.MoveNext()) {
+                    SubjectList.Add(iter.Current);
+                }
+            }
+            protected override string Identifier => "Relation";
+
+            [CustomAssertion]
+            public AndConstraint<RelationAssertion> HaveEntryCount(int count, string because = "",
+                params object[] becauseArgs) {
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(SubjectList.Count == count)
+                    .FailWith($"Expected {{context:relation}} to expose {count} entr{(count == 1 ? "y" : "ies")}" +
+                              $"{{reason}}, but got {SubjectList.Count}");
+
+                return new AndConstraint<RelationAssertion>(this);
+            }
+
+            [CustomAssertion]
+            public AndConstraint<RelationAssertion> HaveConnectionType<T>(string because = "",
+                params object[] becauseArgs) {
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.ConnectionType == typeof(T))
+                    .FailWith($"Expected {{context:relation}} to have connection type of {typeof(T).Name}{{reason}}");
+
+                return new AndConstraint<RelationAssertion>(this);
+            }
+
+            [CustomAssertion]
+            public AndConstraint<RelationAssertion> ExposeDeletesFirst(string because = "",
+                params object[] becauseArgs) {
+
+                var firstNonDeleted = SubjectList.FindIndex(e => e.Status != Status.Deleted);
+                var lastDeleted = SubjectList.FindIndex(e => e.Status == Status.Deleted);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(firstNonDeleted == -1 || firstNonDeleted > lastDeleted)
+                    .FailWith("Expected {context:relation} to expose all DELETED entries first{reason}");
+
+                return new AndConstraint<RelationAssertion>(this);
+            }
+
+            [CustomAssertion]
+            public AndConstraint<RelationAssertion> ExposeEntry(object item, Status status, int count = 1,
+                string because = "", params object[] becauseArgs) {
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(SubjectList.Count(entry => entry.Item == item && entry.Status == status) == count)
+                    .FailWith($"Expected {{context:relation}} to expose the entry ({item}, {status}){{reason}} (x{count})");
+
+                return new AndConstraint<RelationAssertion>(this);
+            }
+
+            [CustomAssertion]
+            public AndConstraint<RelationAssertion> NotExposeEntryFor(object item, string because = "",
+                params object[] becauseArgs) {
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(SubjectList.FindIndex(entry => entry.Item == item) == -1)
+                    .FailWith($"Expected {{context:relation}} not to expose an entry for {item}{{reason}}");
+
+                return new AndConstraint<RelationAssertion>(this);
+            }
+        }
+    }
+}

--- a/test/UnitTests/_TestCities.txt
+++ b/test/UnitTests/_TestCities.txt
@@ -4,27 +4,36 @@ Abilene
 Akron
 Albany
 Albuquerque
+Alexandria
+Alomogordo
 Alpharetta
+Altoona
 Amarillo
 Ames
 Anaheim
 Anchorage
+Andersonville
 Ann Arbor
 Annapolis
+Appleton
 Arlington
 Asheville
 Athens
 Atlanta
 Atlantic City
+Auburn
 Augusta
 Aurora
 Austin
+Aynor
 Bakersfield
 Baltimore
 Baton Rouge
 Beaumont
 Bellevue
 Bentonville
+Berkeley
+Bethesda
 Billings
 Biloxi
 Birmingham
@@ -34,16 +43,33 @@ Boca Raton
 Boise
 Boston
 Boulder
+Bowling Green
 Bozeman
 Bridgeport
+Bristol
+Brownsville
+Buena Vista
 Buffalo
+Burbank
+Burlington
+Butte
 Cambridge
+Cairo
 Canton
+Cape Girardeau
+Carbondale
+Carmel
+Carlsbad
 Carson City
+Casper
+Chapel Hill
 Charleston
 Charlotte
-Carlsbad
+Charlotte Amalie
+Charlottesville
+Christiansted
 Cedar Rapids
+Champaign
 Chattanooga
 Cheyenne
 Chicago
@@ -51,121 +77,212 @@ Chula Vista
 Cincinnati
 Cleveland
 Coeur d'Alene
+College Station
 Colorado Springs
 Columbia
 Columbus
 Concord
 Cooperstown
+Coral Gables
 Corpus Christi
 Dallas
+Danbury
 Davenport
 Dayton
+Daytona Beach
 Dearborn
+Decatur
+Dededo
+DeKalb
 Denver
 Des Moines
+Des Plaines
 Detroit
 Dover
+Dubuque
 Duluth
 Durham
+East Hartford
 East St. Louis
+Eau Claire
 El Paso
+Erie
 Eugene
+Eureka
+Evansville
 Fairbanks
 Fargo
+Farmington Hills
+Fayetteville
 Flagstaff
+Flint
+Florida City
+Fort Hood
 Fort Lauderdale
+Fort Myers
 Fort Wayne
 Fort Worth
+Frankfort
 Fresno
 Gainesville
 Galveston
 Gary
+Georgetown
+Germantown
 Gilbert
 Glendale
+Grand Forks
 Grand Rapids
 Green Bay
 Greensboro
+Gulfport
+Hagåtña
+Hardin
 Harrisburg
 Hartford
+Hattiesburg
 Helena
 Hershey
 Hialeah
+High Point
+Hollywood
 Honolulu
 Hot Springs
 Houston
+Huntsville
 Indianapolis
 Inglewood
+Iowa City
+Irving
 Ithaca
 Jackson
+Jackson Hole
 Jacksonville
 Jefferson City
 Jersey City
 Joliet
+Joplin
 Juneau
 Jupiter
+Kailua
 Kalamazoo
+Kalispell
+Kaneohe
 Kansas City
+Kennewick
+Kenosha
+Ketchikan
+Kettering
+Key West
+Kirkland
+Kokomo
 Knoxville
+La Crosse
 Lafayette
+Lahaina
+Lake Charles
+Lake Placid
+Lander
+Langley
 Lansing
 Laramie
 Laredo
 Las Cruces
 Las Vegas
 Lawrence
+Levittown
 Lexington
 Lincoln
+Lima
 Little Rock
 Long Beach
 Los Alamos
 Los Angeles
 Louisville
 Lubbock
+Macomb
+Macon
 Madison
+Malibu
+Manassas
 Manchester
 Memphis
 Mesa
 Miami
 Milwaukee
 Minneapolis
+Minnetonka
+Miramar
+Missoula
+Metairie
 Mobile
 Modesto
 Montgomery
 Montpelier
+Morgantown
 Murfreesboro
 Myrtle Beach
+Naperville
+Narragansett Pier
+Nashua
 Nashville
+Nauvoo
 New Haven
 New Orleans
+New Rochelle
 New York City
 Newark
+Newport News
 Nome
 Norfolk
+Norman
 North Las Vegas
+North Platte
+Novi
 Oakland
 Oconomowoc
 Oklahoma City
 Omaha
+Oregon City
 Orlando
+Oshkosh
+Owensboro
+Oxford
+Oxnard
+Pago Pago
+Palatine
 Palm Beach
 Pasadena
+Paterson
+Pawtucket
 Pearl City
+Pembroke Pines
 Peoria
 Philadelphia
 Phoenix
 Pierre
+Pine Bluff
 Pittsburgh
 Plano
+Pocatello
 Pomona
+Pontiac
+Port St. Lucie
 Portland
 Providence
 Provo
+Quincy
+Racine
 Raleigh
+Rancho Cucamonga
 Reno
+Reston
 Riverside
 Roanoke
+Rochester
 Roswell
 Round Rock
+Saipan
 Salem
 Salinas
 San Antonio
@@ -174,48 +291,81 @@ San Diego
 San Francisco
 San Jacinto
 San Jose
+San Juan
+San Luis Obispo
 Sandy Springs
 Santa Ana
+Santa Barbara
 Santa Clara
 Santa Cruz
 Santa Fe
 Savannah
+Schenectady
 Scottsdale
 Scranton
 Seattle
 Selma
+Seward
+Shaker Heights
 Shreveport
 Sioux City
 Sioux Falls
+Sitka
+Smyrna
 South Bend
+Spearfish
 Spokane
 Springfield
 St. Augustine
+St. Cloud
 St. Louis
 St. Paul
+Stamford
 Stillwater
+Stockton
 Syracuse
 Tacoma
+Tafuna
+Tahlequa
 Tallahassee
 Tampa
+Terre Haute
 Texarkana
 Toledo
+Toms River
 Topeka
 Trenton
 Tucson
 Tulsa
+Tupelo
 Tuscaloosa
+Unalaska
+Urbana
 Valparaiso
 Virginia Beach
 Waco
 Walla Walla
+Waimanalo
 Washington, D.C.
+Wasilla
+Waterbury
+Wabaunsee
+Waterloo
 Waukesha
+West Covina
 West Lafayette
+West Point
+Wheeling
+Whitefish
 Wichita
 Wichita Falls
 Wilkes-Barre
 Wilmington
 Winston-Salem
 Wisconsin Dells
+Worcester
+Yonkers
+Youngstown
 Ypsilanti
+Yuma
+Zzyzx


### PR DESCRIPTION
This commit implements RelationList<T>, the first collection type of the Kvasir framework. RelationLists are unordered
collections that track mutating operations (insert, append, overwrite, remove) and can expose the current 'state' of
their elements for appropriate interaction with a back-end relational database. The API of a RelationList is identical
to that of a standard List<T>, with the addition of a few explicit interface implementations of the new IRelation API
(which is internal, and therefore hidden from users). RelationLists should only be used with immutable elements, and
while they technically permit duplicates, this should be strenuously avoided.

This is the first of at least three planned Kvasir collections: the enxt two are a set-like collection and a map-like
collection. They will follow the same patterns (implement the IRelation API plus the APIs of the standard collection
they mimic), which will collectively allow for seamless integration with the Extraction, Reconstitution, and Translation
layers of the framework.