### PR TITLE
IdentityExtractor<T>

### DIFF
--- a/src/Kvasir/Extraction/IdentityExtractor.cs
+++ b/src/Kvasir/Extraction/IdentityExtractor.cs
@@ -1,0 +1,34 @@
+﻿using Cybele.Extensions;
+using System;
+using System.Diagnostics;
+
+namespace Kvasir.Extraction {
+    /// <summary>
+    ///   An <see cref="IFieldExtractor"/> that simply returns the value it was provided.
+    /// </summary>
+    /// <remarks>
+    ///   The <see cref="IdentityExtractor{T}"/> class is intended to be used with collection elements, where primitive
+    ///   values may be stored directly. In such circumstances, there is no wrapping Entity and therefore no property
+    ///   or function that can be used to access the value. Note, however, that if the element type of a collection is
+    ///   itself a complex type (either an Entity or an Aggregate), the <see cref="IdentityExtractor{T}"/> should not
+    ///   be used.
+    /// </remarks>
+    public sealed class IdentityExtractor<T> : IFieldExtractor {
+        /// <inheritdoc/>
+        public Type ExpectedSource => typeof(T);
+
+        /// <inheritdoc/>
+        public Type FieldType => typeof(T);
+
+        /// <summary>
+        ///   Constructs a new <see cref="IdentityExtractor{T}"/>.
+        /// </summary>
+        internal IdentityExtractor() {}
+
+        /// <inheritdoc/>
+        public object? Execute(object? source) {
+            Debug.Assert(source is null || source.GetType().IsInstanceOf(ExpectedSource));
+            return source;
+        }
+    }
+}

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -1147,6 +1147,32 @@
               <paramref name="entity"/>.
             </returns>
         </member>
+        <member name="T:Kvasir.Extraction.IdentityExtractor`1">
+            <summary>
+              An <see cref="T:Kvasir.Extraction.IFieldExtractor"/> that simply returns the value it was provided.
+            </summary>
+            <remarks>
+              The <see cref="T:Kvasir.Extraction.IdentityExtractor`1"/> class is intended to be used with collection elements, where primitive
+              values may be stored directly. In such circumstances, there is no wrapping Entity and therefore no property
+              or function that can be used to access the value. Note, however, that if the element type of a collection is
+              itself a complex type (either an Entity or an Aggregate), the <see cref="T:Kvasir.Extraction.IdentityExtractor`1"/> should not
+              be used.
+            </remarks>
+        </member>
+        <member name="P:Kvasir.Extraction.IdentityExtractor`1.ExpectedSource">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Extraction.IdentityExtractor`1.FieldType">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Extraction.IdentityExtractor`1.#ctor">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Extraction.IdentityExtractor`1"/>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Extraction.IdentityExtractor`1.Execute(System.Object)">
+            <inheritdoc/>
+        </member>
         <member name="T:Kvasir.Extraction.IExtractionStep">
             <summary>
               The interface describing a unit of logic that extracts and potentially decomposes one or more values out of

--- a/test/UnitTests/Kvasir/Extraction/FieldExtractors.cs
+++ b/test/UnitTests/Kvasir/Extraction/FieldExtractors.cs
@@ -57,4 +57,42 @@ namespace UT.Kvasir.Extraction {
             value.Should().BeNull();
         }
     }
+
+    [TestClass, TestCategory("IdentityExtractor")]
+    public class IdentityExtractorTests {
+        [TestMethod] public void Construct() {
+            // Arrange
+
+            // Act
+            var extractor = new IdentityExtractor<int>();
+
+            // Assert
+            extractor.FieldType.Should().Be(typeof(int));
+            extractor.ExpectedSource.Should().Be(typeof(int));
+        }
+
+        [TestMethod] public void ExtractFromPrimitive() {
+            // Arrange
+            var extractor = new IdentityExtractor<bool>();
+            bool? source = false;
+
+            // Act
+            var value = extractor.Execute(source);
+
+            // Assert
+            value.Should().Be(source);
+        }
+
+        [TestMethod] public void ExtractFromNull() {
+            // Arrange
+            var extractor = new IdentityExtractor<DateTime>();
+            DateTime? source = null;
+
+            // Act
+            var value = extractor.Execute(source);
+
+            // Assert
+            value.Should().BeNull();
+        }
+    }
 }


### PR DESCRIPTION
This commit adds IdentityExtractor<T>, a new IFieldExtractor implementation that returns its input directly. This is
intended to be used when extracting from collections of primitives, in which case there is no Entity on which to perform
a property read.