### PR TITLE
Rename EntityExtraction and EntityReconstitution Plans

### DIFF
--- a/src/Kvasir/Extraction/DataExtractionPlan.cs
+++ b/src/Kvasir/Extraction/DataExtractionPlan.cs
@@ -9,22 +9,22 @@ using System.Linq;
 
 namespace Kvasir.Extraction {
     /// <summary>
-    ///   A description of the way in which data for a particular Entity type is to be extracted from instances,
-    ///   transformed, and prepared to be stored in a back-end database.
+    ///   A description of the way in which data for a particular CLR object type is to be extracted from instances,
+    ///   transformd, and prepared to be stored in a back-end database.
     /// </summary>
-    public sealed class EntityExtractionPlan {
+    public sealed class DataExtractionPlan {
         /// <summary>
-        ///   The <see cref="Type"/> of source object on which this <see cref="EntityExtractionPlan"/> is capable of
+        ///   The <see cref="Type"/> of source object on which this <see cref="DataExtractionPlan"/> is capable of
         ///   being executed.
         /// </summary>
         public Type ExpectedSource { get; }
 
         /// <summary>
-        ///   Constructs a new <see cref="EntityExtractionPlan"/>.
+        ///   Constructs a new <see cref="DataExtractionPlan"/>.
         /// </summary>
         /// <param name="steps">
         ///   The ordered sequence of <see cref="IExtractionStep">extraction steps</see> that produce the extrinsically
-        ///   converted values from a source entity.
+        ///   converted values from a source CLR object.
         /// </param>
         /// <param name="converters">
         ///   The ordered sequence of <see cref="DataConverter">data converters</see> that intrinsically transform the
@@ -40,7 +40,7 @@ namespace Kvasir.Extraction {
         ///   by <paramref name="steps"/> (note that this is not necessarily the number of elements in
         ///   <paramref name="steps"/>, as an <see cref="IExtractionStep"/> may produce multiple values).
         /// </pre>
-        internal EntityExtractionPlan(IEnumerable<IExtractionStep> steps, IEnumerable<DataConverter> converters) {
+        internal DataExtractionPlan(IEnumerable<IExtractionStep> steps, IEnumerable<DataConverter> converters) {
             Guard.Against.Null(steps, nameof(steps));
             Guard.Against.Null(converters, nameof(converters));
             Debug.Assert(!steps.IsEmpty());
@@ -53,28 +53,28 @@ namespace Kvasir.Extraction {
         }
 
         /// <summary>
-        ///   Execute this <see cref="EntityExtractionPlan"/> on a source object, producing an ordered sequence of
+        ///   Execute this <see cref="DataExtractionPlan"/> on a source object, producing an ordered sequence of
         ///   values that can be stored in a back-end database.
         /// </summary>
-        /// <param name="entity">
+        /// <param name="source">
         ///   The source object on which to execute this <see cref="IExtractionStep"/>.
         /// </param>
         /// <pre>
-        ///   <see cref="ExpectedSource"/> is the dynamic type of <paramref name="entity"/> or is a base class or
+        ///   <see cref="ExpectedSource"/> is the dynamic type of <paramref name="source"/> or is a base class or
         ///   interface thereof.
         /// </pre>
         /// <returns>
         ///   An immutable, indexable, ordered sequence of <see cref="DBValue">database values</see> extracted from
-        ///   <paramref name="entity"/>.
+        ///   <paramref name="source"/>.
         /// </returns>
-        public IReadOnlyList<DBValue> Execute(object entity) {
-            Debug.Assert(entity.GetType().IsInstanceOf(ExpectedSource));
+        public IReadOnlyList<DBValue> Execute(object source) {
+            Debug.Assert(source.GetType().IsInstanceOf(ExpectedSource));
 
             List<DBValue> results = new List<DBValue>();
             var converterIter = converters_.GetEnumerator();
 
             foreach (var step in paramSteps_) {
-                var extractedParams = step.Execute(entity);
+                var extractedParams = step.Execute(source);
                 foreach (var param in extractedParams) {
                     converterIter.MoveNext();
 

--- a/src/Kvasir/Extraction/IdentityExtractor.cs
+++ b/src/Kvasir/Extraction/IdentityExtractor.cs
@@ -8,7 +8,7 @@ namespace Kvasir.Extraction {
     /// </summary>
     /// <remarks>
     ///   The <see cref="IdentityExtractor{T}"/> class is intended to be used with collection elements, where primitive
-    ///   values may be stored directly. In such circumstances, there is no wrapping Entity and therefore no property
+    ///   values may be stored directly. In such circumstances, there is no wrapping object and therefore no property
     ///   or function that can be used to access the value. Note, however, that if the element type of a collection is
     ///   itself a complex type (either an Entity or an Aggregate), the <see cref="IdentityExtractor{T}"/> should not
     ///   be used.

--- a/src/Kvasir/Extraction/RelationExtractionPlan.cs
+++ b/src/Kvasir/Extraction/RelationExtractionPlan.cs
@@ -18,7 +18,7 @@ namespace Kvasir.Extraction {
 
     /// <summary>
     ///   A description of the way in which data is extracted from an <see cref="IRelation"/> stored on a particular
-    ///   Entity type and then transformed and prepared to be stored in a back-end database.
+    ///   CLR object type and then transformed and prepared to be stored in a back-end database.
     /// </summary>
     public sealed class RelationExtractionPlan {
         /// <summary>
@@ -32,10 +32,10 @@ namespace Kvasir.Extraction {
         /// </summary>
         /// <param name="relationExtractor">
         ///   The <see cref="IFieldExtractor"/> that describes how to obtain the target <see cref="IRelation"/> from a
-        ///   source entity.
+        ///   source object.
         /// </param>
         /// <param name="plan">
-        ///   The <see cref="EntityExtractionPlan"/> that describes how to extract data from an entry in the relation
+        ///   The <see cref="DataExtractionPlan"/> that describes how to extract data from an entry in the relation
         ///   obtained from <paramref name="relationExtractor"/>.
         /// </param>
         /// <pre>
@@ -43,9 +43,9 @@ namespace Kvasir.Extraction {
         ///   implements the <see cref="IRelation"/> interface (or is that interface itself)
         ///     --and--
         ///   The type of data stored in the relation obtained from <paramref name="relationExtractor"/> is compatible
-        ///   with the <see cref="EntityExtractionPlan.ExpectedSource"/> of <paramref name="plan"/>.
+        ///   with the <see cref="DataExtractionPlan.ExpectedSource"/> of <paramref name="plan"/>.
         /// </pre>
-        internal RelationExtractionPlan(IFieldExtractor relationExtractor, EntityExtractionPlan plan) {
+        internal RelationExtractionPlan(IFieldExtractor relationExtractor, DataExtractionPlan plan) {
             Guard.Against.Null(relationExtractor, nameof(relationExtractor));
             Guard.Against.Null(plan, nameof(plan));
             Debug.Assert(relationExtractor.FieldType.IsInstanceOf(typeof(IRelation)));
@@ -63,19 +63,19 @@ namespace Kvasir.Extraction {
         /// <summary>
         ///   Execute this <see cref="RelationExtractionPlan"/> on a source object.
         /// </summary>
-        /// <param name="entity">
+        /// <param name="source">
         ///   The source object on which to execute this <see cref="RelationExtractionPlan"/>.
         /// </param>
         /// <pre>
-        ///   <see cref="ExpectedSource"/> is the dynamic type of <paramref name="entity"/> or is a base class or
+        ///   <see cref="ExpectedSource"/> is the dynamic type of <paramref name="source"/> or is a base class or
         ///   interface thereof.
         /// </pre>
         /// <returns>
         ///   A <see cref="ExtractedRelationData"/> containing the values extracted from the relation targeted on
-        ///   <paramref name="entity"/> by this <see cref="RelationExtractionPlan"/>.
+        ///   <paramref name="source"/> by this <see cref="RelationExtractionPlan"/>.
         /// </returns>
-        public ExtractedRelationData Execute(object entity) {
-            Debug.Assert(entity.GetType().IsInstanceOf(ExpectedSource));
+        public ExtractedRelationData Execute(object source) {
+            Debug.Assert(source.GetType().IsInstanceOf(ExpectedSource));
 
             // In order to keep the API of the extracted data wrapper "read only," we have to build up the containers
             // a priori and then construct the wrapper, rather than constructing the wrapper with empty containers and
@@ -87,7 +87,7 @@ namespace Kvasir.Extraction {
             // It's a little annoying that we can't just do a for-each loop over the contents of the Relation, but
             // that's inhibited by the GetEnumerator() function in the IRelation interface being internal. We don't
             // want to change that, because we only want the Framework to have access to that introspection.
-            IRelation relation = (IRelation)extractor_.Execute(entity)!;
+            IRelation relation = (IRelation)extractor_.Execute(source)!;
             var iter = relation.GetEnumerator();
             while (iter.MoveNext()) {
                 switch (iter.Current.Status) {
@@ -112,6 +112,6 @@ namespace Kvasir.Extraction {
 
 
         private readonly IFieldExtractor extractor_;
-        private readonly EntityExtractionPlan plan_;
+        private readonly DataExtractionPlan plan_;
     }
 }

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -1080,6 +1080,58 @@
               The contextual information about the source or destination.
             </param>
         </member>
+        <member name="T:Kvasir.Extraction.DataExtractionPlan">
+            <summary>
+              A description of the way in which data for a particular CLR object type is to be extracted from instances,
+              transformd, and prepared to be stored in a back-end database.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Extraction.DataExtractionPlan.ExpectedSource">
+            <summary>
+              The <see cref="T:System.Type"/> of source object on which this <see cref="T:Kvasir.Extraction.DataExtractionPlan"/> is capable of
+              being executed.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Extraction.DataExtractionPlan.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Extraction.IExtractionStep},System.Collections.Generic.IEnumerable{Cybele.Core.DataConverter})">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Extraction.DataExtractionPlan"/>.
+            </summary>
+            <param name="steps">
+              The ordered sequence of <see cref="T:Kvasir.Extraction.IExtractionStep">extraction steps</see> that produce the extrinsically
+              converted values from a source CLR object.
+            </param>
+            <param name="converters">
+              The ordered sequence of <see cref="T:Cybele.Core.DataConverter">data converters</see> that intrinsically transform the
+              values produced by <paramref name="steps"/>.
+            </param>
+            <pre>
+              <paramref name="steps"/> is not empty
+                --and--
+              Each element of <paramref name="steps"/> expects the same type of
+              <see cref="P:Kvasir.Extraction.IExtractionStep.ExpectedSource">source object</see>
+                --and--
+              The number of elements in <paramref name="converters"/> matche the number of values, in total, produced
+              by <paramref name="steps"/> (note that this is not necessarily the number of elements in
+              <paramref name="steps"/>, as an <see cref="T:Kvasir.Extraction.IExtractionStep"/> may produce multiple values).
+            </pre>
+        </member>
+        <member name="M:Kvasir.Extraction.DataExtractionPlan.Execute(System.Object)">
+            <summary>
+              Execute this <see cref="T:Kvasir.Extraction.DataExtractionPlan"/> on a source object, producing an ordered sequence of
+              values that can be stored in a back-end database.
+            </summary>
+            <param name="source">
+              The source object on which to execute this <see cref="T:Kvasir.Extraction.IExtractionStep"/>.
+            </param>
+            <pre>
+              <see cref="P:Kvasir.Extraction.DataExtractionPlan.ExpectedSource"/> is the dynamic type of <paramref name="source"/> or is a base class or
+              interface thereof.
+            </pre>
+            <returns>
+              An immutable, indexable, ordered sequence of <see cref="T:Kvasir.Schema.DBValue">database values</see> extracted from
+              <paramref name="source"/>.
+            </returns>
+        </member>
         <member name="T:Kvasir.Extraction.DecomposingExtractionStep">
             <summary>
               An <see cref="T:Kvasir.Extraction.IExtractionStep"/> that produces a collection of primitive values obtained by recursively
@@ -1113,65 +1165,13 @@
         <member name="M:Kvasir.Extraction.DecomposingExtractionStep.Execute(System.Object)">
             <inheritdoc/>
         </member>
-        <member name="T:Kvasir.Extraction.EntityExtractionPlan">
-            <summary>
-              A description of the way in which data for a particular Entity type is to be extracted from instances,
-              transformed, and prepared to be stored in a back-end database.
-            </summary>
-        </member>
-        <member name="P:Kvasir.Extraction.EntityExtractionPlan.ExpectedSource">
-            <summary>
-              The <see cref="T:System.Type"/> of source object on which this <see cref="T:Kvasir.Extraction.EntityExtractionPlan"/> is capable of
-              being executed.
-            </summary>
-        </member>
-        <member name="M:Kvasir.Extraction.EntityExtractionPlan.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Extraction.IExtractionStep},System.Collections.Generic.IEnumerable{Cybele.Core.DataConverter})">
-            <summary>
-              Constructs a new <see cref="T:Kvasir.Extraction.EntityExtractionPlan"/>.
-            </summary>
-            <param name="steps">
-              The ordered sequence of <see cref="T:Kvasir.Extraction.IExtractionStep">extraction steps</see> that produce the extrinsically
-              converted values from a source entity.
-            </param>
-            <param name="converters">
-              The ordered sequence of <see cref="T:Cybele.Core.DataConverter">data converters</see> that intrinsically transform the
-              values produced by <paramref name="steps"/>.
-            </param>
-            <pre>
-              <paramref name="steps"/> is not empty
-                --and--
-              Each element of <paramref name="steps"/> expects the same type of
-              <see cref="P:Kvasir.Extraction.IExtractionStep.ExpectedSource">source object</see>
-                --and--
-              The number of elements in <paramref name="converters"/> matche the number of values, in total, produced
-              by <paramref name="steps"/> (note that this is not necessarily the number of elements in
-              <paramref name="steps"/>, as an <see cref="T:Kvasir.Extraction.IExtractionStep"/> may produce multiple values).
-            </pre>
-        </member>
-        <member name="M:Kvasir.Extraction.EntityExtractionPlan.Execute(System.Object)">
-            <summary>
-              Execute this <see cref="T:Kvasir.Extraction.EntityExtractionPlan"/> on a source object, producing an ordered sequence of
-              values that can be stored in a back-end database.
-            </summary>
-            <param name="entity">
-              The source object on which to execute this <see cref="T:Kvasir.Extraction.IExtractionStep"/>.
-            </param>
-            <pre>
-              <see cref="P:Kvasir.Extraction.EntityExtractionPlan.ExpectedSource"/> is the dynamic type of <paramref name="entity"/> or is a base class or
-              interface thereof.
-            </pre>
-            <returns>
-              An immutable, indexable, ordered sequence of <see cref="T:Kvasir.Schema.DBValue">database values</see> extracted from
-              <paramref name="entity"/>.
-            </returns>
-        </member>
         <member name="T:Kvasir.Extraction.IdentityExtractor`1">
             <summary>
               An <see cref="T:Kvasir.Extraction.IFieldExtractor"/> that simply returns the value it was provided.
             </summary>
             <remarks>
               The <see cref="T:Kvasir.Extraction.IdentityExtractor`1"/> class is intended to be used with collection elements, where primitive
-              values may be stored directly. In such circumstances, there is no wrapping Entity and therefore no property
+              values may be stored directly. In such circumstances, there is no wrapping object and therefore no property
               or function that can be used to access the value. Note, however, that if the element type of a collection is
               itself a complex type (either an Entity or an Aggregate), the <see cref="T:Kvasir.Extraction.IdentityExtractor`1"/> should not
               be used.
@@ -1351,7 +1351,7 @@
         <member name="T:Kvasir.Extraction.RelationExtractionPlan">
             <summary>
               A description of the way in which data is extracted from an <see cref="T:Kvasir.Relations.IRelation"/> stored on a particular
-              Entity type and then transformed and prepared to be stored in a back-end database.
+              CLR object type and then transformed and prepared to be stored in a back-end database.
             </summary>
         </member>
         <member name="P:Kvasir.Extraction.RelationExtractionPlan.ExpectedSource">
@@ -1360,16 +1360,16 @@
               being executed.
             </summary>
         </member>
-        <member name="M:Kvasir.Extraction.RelationExtractionPlan.#ctor(Kvasir.Extraction.IFieldExtractor,Kvasir.Extraction.EntityExtractionPlan)">
+        <member name="M:Kvasir.Extraction.RelationExtractionPlan.#ctor(Kvasir.Extraction.IFieldExtractor,Kvasir.Extraction.DataExtractionPlan)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Extraction.RelationExtractionPlan"/>.
             </summary>
             <param name="relationExtractor">
               The <see cref="T:Kvasir.Extraction.IFieldExtractor"/> that describes how to obtain the target <see cref="T:Kvasir.Relations.IRelation"/> from a
-              source entity.
+              source object.
             </param>
             <param name="plan">
-              The <see cref="T:Kvasir.Extraction.EntityExtractionPlan"/> that describes how to extract data from an entry in the relation
+              The <see cref="T:Kvasir.Extraction.DataExtractionPlan"/> that describes how to extract data from an entry in the relation
               obtained from <paramref name="relationExtractor"/>.
             </param>
             <pre>
@@ -1377,23 +1377,23 @@
               implements the <see cref="T:Kvasir.Relations.IRelation"/> interface (or is that interface itself)
                 --and--
               The type of data stored in the relation obtained from <paramref name="relationExtractor"/> is compatible
-              with the <see cref="P:Kvasir.Extraction.EntityExtractionPlan.ExpectedSource"/> of <paramref name="plan"/>.
+              with the <see cref="P:Kvasir.Extraction.DataExtractionPlan.ExpectedSource"/> of <paramref name="plan"/>.
             </pre>
         </member>
         <member name="M:Kvasir.Extraction.RelationExtractionPlan.Execute(System.Object)">
             <summary>
               Execute this <see cref="T:Kvasir.Extraction.RelationExtractionPlan"/> on a source object.
             </summary>
-            <param name="entity">
+            <param name="source">
               The source object on which to execute this <see cref="T:Kvasir.Extraction.RelationExtractionPlan"/>.
             </param>
             <pre>
-              <see cref="P:Kvasir.Extraction.RelationExtractionPlan.ExpectedSource"/> is the dynamic type of <paramref name="entity"/> or is a base class or
+              <see cref="P:Kvasir.Extraction.RelationExtractionPlan.ExpectedSource"/> is the dynamic type of <paramref name="source"/> or is a base class or
               interface thereof.
             </pre>
             <returns>
               A <see cref="T:Kvasir.Extraction.ExtractedRelationData"/> containing the values extracted from the relation targeted on
-              <paramref name="entity"/> by this <see cref="T:Kvasir.Extraction.RelationExtractionPlan"/>.
+              <paramref name="source"/> by this <see cref="T:Kvasir.Extraction.RelationExtractionPlan"/>.
             </returns>
         </member>
         <member name="T:Kvasir.Reconstitution.ByConstructorCreator">
@@ -1427,24 +1427,24 @@
         <member name="M:Kvasir.Reconstitution.ByConstructorCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
             <inheritdoc/>
         </member>
-        <member name="T:Kvasir.Reconstitution.EntityReconstitutionPlan">
+        <member name="T:Kvasir.Reconstitution.DataReconstitutionPlan">
             <summary>
-              A description of the way in which data for a particular Entity type is to be extracted from a back-end
-              database, transformed, and reimagined as an Entity data object.
+              A description of the way in which data for a particular CLR object type is to be extracted from a back-end
+              database, transformd, and reimaginged as an instance.
             </summary>
         </member>
-        <member name="P:Kvasir.Reconstitution.EntityReconstitutionPlan.Target">
+        <member name="P:Kvasir.Reconstitution.DataReconstitutionPlan.Target">
             <summary>
-              The <see cref="T:System.Type"/> of CLR object produced by this <see cref="T:Kvasir.Reconstitution.EntityReconstitutionPlan"/>.
+              The <see cref="T:System.Type"/> of CLR object produced by this <see cref="T:Kvasir.Reconstitution.DataReconstitutionPlan"/>.
             </summary>
         </member>
-        <member name="M:Kvasir.Reconstitution.EntityReconstitutionPlan.#ctor(Kvasir.Reconstitution.IReconstitutor,System.Collections.Generic.IEnumerable{Cybele.Core.DataConverter})">
+        <member name="M:Kvasir.Reconstitution.DataReconstitutionPlan.#ctor(Kvasir.Reconstitution.IReconstitutor,System.Collections.Generic.IEnumerable{Cybele.Core.DataConverter})">
             <summary>
-              Construct a new <see cref="T:Kvasir.Reconstitution.EntityReconstitutionPlan"/>.
+              Construct a new <see cref="T:Kvasir.Reconstitution.DataReconstitutionPlan"/>.
             </summary>
             <param name="reconstitutor">
               The <see cref="T:Kvasir.Reconstitution.IReconstitutor"/> with which to produce the CLR object when the new
-              <see cref="T:Kvasir.Reconstitution.EntityReconstitutionPlan"/> is executed.
+              <see cref="T:Kvasir.Reconstitution.DataReconstitutionPlan"/> is executed.
             </param>
             <param name="reverters">
               The ordered sequence of <see cref="T:Cybele.Core.DataConverter">data converters</see> that intrinsically transform the
@@ -1456,9 +1456,9 @@
               each element of <paramref name="reverters"/> is a bidirectional <see cref="T:Cybele.Core.DataConverter"/>.
             </pre>
         </member>
-        <member name="M:Kvasir.Reconstitution.EntityReconstitutionPlan.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+        <member name="M:Kvasir.Reconstitution.DataReconstitutionPlan.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
             <summary>
-              Execute this <see cref="T:Kvasir.Reconstitution.EntityReconstitutionPlan"/> to create a brand new CLR object from a "row" of
+              Execute this <see cref="T:Kvasir.Reconstitution.DataReconstitutionPlan"/> to create a brand new CLR object from a "row" of
               database values.
             </summary>
             <param name="rawValues">
@@ -1468,8 +1468,8 @@
               <paramref name="rawValues"/> is not empty.
             </pre>
             <returns>
-              A CLR object of type <see cref="P:Kvasir.Reconstitution.EntityReconstitutionPlan.Target"/> that, when run through the dedicated extractor for
-              <see cref="P:Kvasir.Reconstitution.EntityReconstitutionPlan.Target"/>, produces <paramref name="rawValues"/>.
+              A CLR object of type <see cref="P:Kvasir.Reconstitution.DataReconstitutionPlan.Target"/> that, when run through the dedicated extractor for
+              <see cref="P:Kvasir.Reconstitution.DataReconstitutionPlan.Target"/>, produces <paramref name="rawValues"/>.
             </returns>
         </member>
         <member name="T:Kvasir.Reconstitution.FromPropertyRepopulator">
@@ -1750,12 +1750,12 @@
               operate.
             </summary>
         </member>
-        <member name="M:Kvasir.Reconstitution.RelationReconstitutionPlan.#ctor(Kvasir.Reconstitution.EntityReconstitutionPlan,Kvasir.Reconstitution.IRepopulator)">
+        <member name="M:Kvasir.Reconstitution.RelationReconstitutionPlan.#ctor(Kvasir.Reconstitution.DataReconstitutionPlan,Kvasir.Reconstitution.IRepopulator)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Reconstitution.RelationReconstitutionPlan"/>.
             </summary>
             <param name="plan">
-              The <see cref="T:Kvasir.Reconstitution.EntityReconstitutionPlan"/> with which to reconstitute the individual elements of the
+              The <see cref="T:Kvasir.Reconstitution.DataReconstitutionPlan"/> with which to reconstitute the individual elements of the
               relation.
             </param>
             <param name="repopulator">

--- a/src/Kvasir/Reconstitution/DataReconstitutionPlan.cs
+++ b/src/Kvasir/Reconstitution/DataReconstitutionPlan.cs
@@ -9,21 +9,21 @@ using System.Linq;
 
 namespace Kvasir.Reconstitution {
     /// <summary>
-    ///   A description of the way in which data for a particular Entity type is to be extracted from a back-end
-    ///   database, transformed, and reimagined as an Entity data object.
+    ///   A description of the way in which data for a particular CLR object type is to be extracted from a back-end
+    ///   database, transformd, and reimaginged as an instance.
     /// </summary>
-    public sealed class EntityReconstitutionPlan {
+    public sealed class DataReconstitutionPlan {
         /// <summary>
-        ///   The <see cref="Type"/> of CLR object produced by this <see cref="EntityReconstitutionPlan"/>.
+        ///   The <see cref="Type"/> of CLR object produced by this <see cref="DataReconstitutionPlan"/>.
         /// </summary>
         public Type Target { get; }
 
         /// <summary>
-        ///   Construct a new <see cref="EntityReconstitutionPlan"/>.
+        ///   Construct a new <see cref="DataReconstitutionPlan"/>.
         /// </summary>
         /// <param name="reconstitutor">
         ///   The <see cref="IReconstitutor"/> with which to produce the CLR object when the new
-        ///   <see cref="EntityReconstitutionPlan"/> is executed.
+        ///   <see cref="DataReconstitutionPlan"/> is executed.
         /// </param>
         /// <param name="reverters">
         ///   The ordered sequence of <see cref="DataConverter">data converters</see> that intrinsically transform the
@@ -34,7 +34,7 @@ namespace Kvasir.Reconstitution {
         ///     --and--
         ///   each element of <paramref name="reverters"/> is a bidirectional <see cref="DataConverter"/>.
         /// </pre>
-        internal EntityReconstitutionPlan(IReconstitutor reconstitutor, IEnumerable<DataConverter> reverters) {
+        internal DataReconstitutionPlan(IReconstitutor reconstitutor, IEnumerable<DataConverter> reverters) {
             Guard.Against.Null(reconstitutor, nameof(reconstitutor));
             Guard.Against.Null(reverters, nameof(reverters));
             Debug.Assert(!reverters.IsEmpty());
@@ -46,7 +46,7 @@ namespace Kvasir.Reconstitution {
         }
 
         /// <summary>
-        ///   Execute this <see cref="EntityReconstitutionPlan"/> to create a brand new CLR object from a "row" of
+        ///   Execute this <see cref="DataReconstitutionPlan"/> to create a brand new CLR object from a "row" of
         ///   database values.
         /// </summary>
         /// <param name="rawValues">

--- a/src/Kvasir/Reconstitution/RelationReconstitutionPlan.cs
+++ b/src/Kvasir/Reconstitution/RelationReconstitutionPlan.cs
@@ -22,14 +22,14 @@ namespace Kvasir.Reconstitution {
         ///   Constructs a new <see cref="RelationReconstitutionPlan"/>.
         /// </summary>
         /// <param name="plan">
-        ///   The <see cref="EntityReconstitutionPlan"/> with which to reconstitute the individual elements of the
+        ///   The <see cref="DataReconstitutionPlan"/> with which to reconstitute the individual elements of the
         ///   relation.
         /// </param>
         /// <param name="repopulator">
         ///   The <see cref="IRepopulator"/> dictating how elements are to be placed into the
         ///   <see cref="Relations.IRelation"/> during repopulation.
         /// </param>
-        internal RelationReconstitutionPlan(EntityReconstitutionPlan plan, IRepopulator repopulator) {
+        internal RelationReconstitutionPlan(DataReconstitutionPlan plan, IRepopulator repopulator) {
             Guard.Against.Null(plan, nameof(plan));
             Guard.Against.Null(repopulator, nameof(repopulator));
 
@@ -71,7 +71,7 @@ namespace Kvasir.Reconstitution {
         }
 
 
-        private readonly EntityReconstitutionPlan plan_;
+        private readonly DataReconstitutionPlan plan_;
         private readonly IRepopulator repopulator_;
     }
 }

--- a/test/UnitTests/Kvasir/Extraction/ExtractionPlans.cs
+++ b/test/UnitTests/Kvasir/Extraction/ExtractionPlans.cs
@@ -10,8 +10,8 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace UT.Kvasir.Extraction {
-    [TestClass, TestCategory("EntityExtractionPlan")]
-    public class EntityExtractionPlanTests {
+    [TestClass, TestCategory("DataExtractionPlan")]
+    public class DataExtractionPlanTests {
         [TestMethod] public void Construct() {
             // Arrange
             var mockExtractor = new Mock<IExtractionStep>();
@@ -22,7 +22,7 @@ namespace UT.Kvasir.Extraction {
             // Act
             var extractors = new IExtractionStep[] { mockExtractor.Object };
             var converters = new DataConverter[] { converter };
-            var plan = new EntityExtractionPlan(extractors, converters);
+            var plan = new DataExtractionPlan(extractors, converters);
 
             // Assert
             plan.ExpectedSource.Should().Be(typeof(string));
@@ -49,7 +49,7 @@ namespace UT.Kvasir.Extraction {
 
             var extractors = new IExtractionStep[] { ymd.Object, hms.Object };
             var converters = Enumerable.Repeat(offsetCnv, 3).Concat(Enumerable.Repeat(identityCnv, 3));
-            var plan = new EntityExtractionPlan(extractors, converters);
+            var plan = new DataExtractionPlan(extractors, converters);
             var source = DateTime.Now;
 
             // Act
@@ -82,7 +82,7 @@ namespace UT.Kvasir.Extraction {
 
             var steps = new IExtractionStep[] { mockStep.Object };
             var converters = new DataConverter[] { DataConverter.Identity<double>() };
-            var entityPlan = new EntityExtractionPlan(steps, converters);
+            var entityPlan = new DataExtractionPlan(steps, converters);
 
             // Act
             var relationPlan = new RelationExtractionPlan(mockExtractor.Object, entityPlan);
@@ -117,7 +117,7 @@ namespace UT.Kvasir.Extraction {
             var step = new IdentityExtractor<string>();
             var steps = new IExtractionStep[] { new PrimitiveExtractionStep(step, DataConverter.Identity<string>()) };
             var converters = new DataConverter[] { DataConverter.Identity<string>() };
-            var entityPlan = new EntityExtractionPlan(steps, converters);
+            var entityPlan = new DataExtractionPlan(steps, converters);
 
             var relationPlan = new RelationExtractionPlan(mockExtractor.Object, entityPlan);
 

--- a/test/UnitTests/Kvasir/Reconstitution/ReconstitutionPlans.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/ReconstitutionPlans.cs
@@ -10,8 +10,8 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace UT.Kvasir.Reconstitution {
-    [TestClass, TestCategory("EntityReconstitutionPlan")]
-    public class EntityReconstitutionPlanTests {
+    [TestClass, TestCategory("DataReconstitutionPlan")]
+    public class DataReconstitutionPlanTests {
         [TestMethod] public void Construction() {
             // Arrange
             var mockReconstitutor = new Mock<IReconstitutor>();
@@ -21,7 +21,7 @@ namespace UT.Kvasir.Reconstitution {
 
             // Act
             var reverters = new DataConverter[] { reverter };
-            var plan = new EntityReconstitutionPlan(mockReconstitutor.Object, reverters);
+            var plan = new DataReconstitutionPlan(mockReconstitutor.Object, reverters);
 
             // Assert
             plan.Target.Should().Be(typeof(string));
@@ -41,7 +41,7 @@ namespace UT.Kvasir.Reconstitution {
             reconstitutor.Setup(r => r.Target).Returns(typeof(DateTime));
             reconstitutor.Setup(r => r.ReconstituteFrom(It.IsAny<IReadOnlyList<DBValue>>())).Returns(new DateTime());
 
-            var plan = new EntityReconstitutionPlan(reconstitutor.Object, reverters);
+            var plan = new DataReconstitutionPlan(reconstitutor.Object, reverters);
 
             // Act
             _ = plan.ReconstituteFrom(values);
@@ -62,7 +62,7 @@ namespace UT.Kvasir.Reconstitution {
             var converter = DataConverter.Identity<string>();
             var creator = new PrimitiveCreator(0, converter);
             var reconstitutor = new Reconstitutor(creator, Enumerable.Empty<IMutationStep>());
-            var entityPlan = new EntityReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
+            var entityPlan = new DataReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
 
             var mockRepopulator = new Mock<IRepopulator>();
             mockRepopulator.Setup(r => r.ExpectedSubject).Returns(typeof(object));
@@ -79,7 +79,7 @@ namespace UT.Kvasir.Reconstitution {
             var converter = DataConverter.Identity<string>();
             var creator = new PrimitiveCreator(0, converter);
             var reconstitutor = new Reconstitutor(creator, Enumerable.Empty<IMutationStep>());
-            var entityPlan = new EntityReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
+            var entityPlan = new DataReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
 
             var mockRepopulator = new Mock<IRepopulator>();
             mockRepopulator.Setup(r => r.ExpectedSubject).Returns(typeof(object));
@@ -99,7 +99,7 @@ namespace UT.Kvasir.Reconstitution {
             var converter = DataConverter.Identity<string>();
             var creator = new PrimitiveCreator(0, converter);
             var reconstitutor = new Reconstitutor(creator, Enumerable.Empty<IMutationStep>());
-            var entityPlan = new EntityReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
+            var entityPlan = new DataReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
 
             var mockRepopulator = new Mock<IRepopulator>();
             mockRepopulator.Setup(r => r.ExpectedSubject).Returns(typeof(object));
@@ -123,7 +123,7 @@ namespace UT.Kvasir.Reconstitution {
             var converter = DataConverter.Identity<string>();
             var creator = new PrimitiveCreator(0, converter);
             var reconstitutor = new Reconstitutor(creator, Enumerable.Empty<IMutationStep>());
-            var entityPlan = new EntityReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
+            var entityPlan = new DataReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
 
             var mockRepopulator = new Mock<IRepopulator>();
             mockRepopulator.Setup(r => r.ExpectedSubject).Returns(typeof(object));


### PR DESCRIPTION
This commit performs a pair of renames: EntityExtractionPlan -> DataExtractionPlan and EntityReconstitutionPlan ->
DataReconstitutionPlan. This is to reflect the fact that these plans do not fully extract or reconstitute an Entity but
rather a single row's worth of data from an object. We will be creating an actual EntityExtractionPlan and
EntityReconstitutionPlan shortly to get operate on all of an Entity's data.