### PR TITLE
Fix Build Status Badges on README

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: Kvasir
+name: Ubuntu
 
 on:
   push:
@@ -11,8 +11,7 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
-        os: [ubuntu, windows]
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -24,14 +23,9 @@ jobs:
         run: dotnet restore
       - name: Build Project(s)
         run: dotnet build -c ${{ matrix.configuration }} --no-restore
-      - name: Run Unit Tests and Collect Coverage
-        if: ${{ matrix.os == 'ubuntu' }}
-        run: dotnet test --no-build  -c ${{ matrix.configuration }} -p:CollectCoverage=true -p:CoverletOutputFormat=lcov
       - name: Run Unit Tests
-        if: ${{ matrix.os != 'ubuntu' }}
-        run: dotnet test --no-build  -c ${{ matrix.configuration }}
+        run: dotnet test --no-build  -c ${{ matrix.configuration }} -p:CollectCoverage=true -p:CoverletOutputFormat=lcov
       - name: Upload Coverage to Coveralls
-        if: ${{ matrix.os == 'ubuntu' }}
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,27 @@
+name: Windows
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  CI:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 5.0.400
+      - name: Restore Dependencies
+        run: dotnet restore
+      - name: Build Project(s)
+        run: dotnet build -c ${{ matrix.configuration }} --no-restore
+      - name: Run Unit Tests
+        run: dotnet test --no-build  -c ${{ matrix.configuration }}

--- a/Kvasir.sln
+++ b/Kvasir.sln
@@ -1,16 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30804.86
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Files", "Solution Files", "{77E420B7-E7B3-46E9-A722-E4DEC2F3E4B4}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
-		.travis.yml = .travis.yml
-		appveyor.yml = appveyor.yml
 		CHANGELOG.md = CHANGELOG.md
 		LICENSE.txt = LICENSE.txt
 		README.md = README.md
+		.github\workflows\windows.yml = .github\workflows\windows.yml
+		.github\workflows\ubuntu.yml = .github\workflows\ubuntu.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kvasir", "src\Kvasir\Kvasir.csproj", "{D9AA0340-6BFA-4F53-B933-AC3F8364F0F6}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-﻿[![Ubuntu Build (travis-ci.com)](https://img.shields.io/travis/com/justin-millman/Kvasir?label=Ubuntu%20Build&logo=ubuntu)](https://travis-ci.com/justin-millman/Kvasir)
-[![Windows Build (appveyor.com)](https://img.shields.io/appveyor/build/justin-millman/Kvasir/master?label=Windows%20Build&logo=windows)](https://ci.appveyor.com/project/justin-millman/kvasir)
+﻿[![Windows Build](https://img.shields.io/github/workflow/status/justin-millman/Kvasir/Windows/master?label=Windows%20Build&logo=windows)](https://github.com/justin-millman/Kvasir/blob/master/.github/workflows/windows.yml)
+[![Ubuntu Build](https://img.shields.io/github/workflow/status/justin-millman/Kvasir/Ubuntu/master?label=Ubuntu%20Build&logo=ubuntu)](https://github.com/justin-millman/Kvasir/blob/master/.github/workflows/ubuntu.yml)
 [![Code Coverage (coveralls.com)](https://img.shields.io/coveralls/github/justin-millman/Kvasir/master)](https://coveralls.io/github/justin-millman/Kvasir)
 [![License](https://img.shields.io/github/license/justin-millman/Kvasir)](https://github.com/justin-millman/Kvasir/blob/master/LICENSE.txt)
 [![Languages](https://img.shields.io/github/languages/count/justin-millman/Kvasir?color=blueviolet)](https://github.com/justin-millman/Kvasir)


### PR DESCRIPTION
This commit fixes the build status badges in the README file, which were not updated in the previous commit when we
mirgarted to GitHub Actions. This necessitated splitting the workflow file into two, one for Ubuntu builds and one for
Windows build, as the badge URLs are based on the action name.