### PR TITLE
Fix Malformed XML Comment in IBuilderFactory.cs

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -5095,7 +5095,7 @@
               [deduced] The type of declaration produced by <paramref name="builder"/>.
             </typeparam>
             <param name="builder">
-              The <see cref="T:Kvasir.Transcription.IForeignKeyDeclBuilder`1"/> to use to create the declaratory SQL expression.
+              The <see cref="T:Kvasir.Transcription.IForeignKeyDeclBuilder`1"/> to use to create the declaration.
             </param>
             <pre>
               <paramref name="builder"/> is not <see langword="null"/>.
@@ -5305,7 +5305,7 @@
               [deduced] The type of declaration produced by <paramref name="builder"/>.
             </typeparam>
             <param name="builder">
-              The <see cref="T:Kvasir.Transcription.IKeyDeclBuilder`1"/> to use to create the declaratory SQL expression.
+              The <see cref="T:Kvasir.Transcription.IKeyDeclBuilder`1"/> to use to create the declaration.
             </param>
             <pre>
               <paramref name="builder"/> is not <see langword="null"/>.

--- a/src/Kvasir/Transcription/IBuilderFactory.cs
+++ b/src/Kvasir/Transcription/IBuilderFactory.cs
@@ -26,7 +26,7 @@
         /// <summary>
         ///   Creates a new instance of the <see cref="IConstraintDeclBuilder{TDecl}"/> interface that produces
         ///   declarations consistent with the rules of this
-        ///   <see cref="IBuilderFactory{TFieldDecl, TKeyDecl, TConstraintDecl, TFKDecl}"/>.
+        ///   <see cref="IBuilderFactory{TTableDecl, TFieldDecl, TKeyDecl, TConstraintDecl, TFKDecl}"/>.
         /// </summary>
         /// <returns>
         ///   A new <see cref="IConstraintDeclBuilder{TDecl}"/>.


### PR DESCRIPTION
This commit fixes a comment in IBuilderFactory.cs that was missing a template argument name in a see cref. This is
producing warnings both locally and on CI, but wasn't noticed in the original commit.

This PR closes #55 