### PR TITLE
Remove Data Conversion from Extraction/Reconstitution Steps

### DIFF
--- a/src/Kvasir/Extraction/DataExtractionPlan.cs
+++ b/src/Kvasir/Extraction/DataExtractionPlan.cs
@@ -10,7 +10,7 @@ using System.Linq;
 namespace Kvasir.Extraction {
     /// <summary>
     ///   A description of the way in which data for a particular CLR object type is to be extracted from instances,
-    ///   transformd, and prepared to be stored in a back-end database.
+    ///   transformed, and prepared to be stored in a back-end database.
     /// </summary>
     public sealed class DataExtractionPlan {
         /// <summary>
@@ -23,12 +23,12 @@ namespace Kvasir.Extraction {
         ///   Constructs a new <see cref="DataExtractionPlan"/>.
         /// </summary>
         /// <param name="steps">
-        ///   The ordered sequence of <see cref="IExtractionStep">extraction steps</see> that produce the extrinsically
-        ///   converted values from a source CLR object.
+        ///   The ordered sequence of <see cref="IExtractionStep">extraction steps</see> that produce the unconverted
+        ///   values from a source CLR object.
         /// </param>
         /// <param name="converters">
-        ///   The ordered sequence of <see cref="DataConverter">data converters</see> that intrinsically transform the
-        ///   values produced by <paramref name="steps"/>.
+        ///   The ordered sequence of <see cref="DataConverter">data converters</see> that transform the values produced
+        ///   by <paramref name="steps"/>.
         /// </param>
         /// <pre>
         ///   <paramref name="steps"/> is not empty

--- a/src/Kvasir/Extraction/IExtractionStep.cs
+++ b/src/Kvasir/Extraction/IExtractionStep.cs
@@ -9,8 +9,8 @@ namespace Kvasir.Extraction {
     /// <remarks>
     ///   The <see cref="IExtractionStep"/> interface is a companion to the <see cref="IFieldExtractor"/> interface,
     ///   separating the logic for what to do with a piece of extracted data from how to obtain it. The data produced
-    ///   by executing an <see cref="IExtractionStep"/> instance is fully decomposed and has had an opportunity to
-    ///   undergo extrinsic transformation.
+    ///   by executing an <see cref="IExtractionStep"/> instance is fully decomposed but has not undergone any
+    ///   transforms.
     /// </remarks>
     public interface IExtractionStep {
         /// <summary>
@@ -24,19 +24,10 @@ namespace Kvasir.Extraction {
         ///   that can be stored in a back-end database.
         /// </summary>
         /// <remarks>
-        ///   <para>
-        ///     Every extraction plan has two phases of data transformation. The first is the extrinsic phase, in which
-        ///     the value is modified (and its type possibly changed) according to a user-provided rule. The second is
-        ///     the intrinsic phase, in which the once-transformed value undergoe a transformation specific to the
-        ///     storage mechanics of the target back-end relational database. The values produced by executing an
-        ///     <see cref="IExtractionStep"/> will have completed the first phase only.
-        ///   </para>
-        ///   <para>
-        ///     Executing an <see cref="IExtractionStep"/> on a <see langword="null"/> source object will produce a
-        ///     sequence of <see cref="DBValue.NULL"/> of the appropriate length. This ensures that a particular
-        ///     <see cref="IExtractionStep"/> instance always produces sequences of equal length independent of the
-        ///     source object's nullity.
-        ///   </para>
+        ///   Executing an <see cref="IExtractionStep"/> on a <see langword="null"/> source object will produce a
+        ///   sequence of <see cref="DBValue.NULL"/> of the appropriate length. This ensures that a particular
+        ///   <see cref="IExtractionStep"/> instance always produces sequences of equal length independent of the
+        ///   source object's nullity.
         /// </remarks>
         /// <param name="sourceObject">
         ///   The source object on which to execute this <see cref="IExtractionStep"/>.

--- a/src/Kvasir/Extraction/PrimitiveExtractionStep.cs
+++ b/src/Kvasir/Extraction/PrimitiveExtractionStep.cs
@@ -19,27 +19,13 @@ namespace Kvasir.Extraction {
         /// <param name="extractor">
         ///   The <see cref="IFieldExtractor"/> defining how the primitive value is to be obtained.
         /// </param>
-        /// <param name="converter">
-        ///   A <see cref="DataConverter"/> defining how to transform the primitive value extracted according to
-        ///   <paramref name="extractor"/>. If no transformation is desired, an
-        ///   <see cref="DataConverter.Identity{T}">identity conversion</see> should be provided.
-        /// </param>
         /// <pre>
-        ///   The <see cref="DataConverter.SourceType">SourceType</see> of <paramref name="converter"/> is the same as
-        ///   the <see cref="IFieldExtractor.FieldType">FieldType</see> of <paramref name="extractor"/>, or is a base
-        ///   class or interface thereof
-        ///     --and--
         ///   The <see cref="IFieldExtractor.FieldType">FieldType</see> of <paramref name="extractor"/> is a data type
         ///   supported by the Framework.
         /// </pre>
-        internal PrimitiveExtractionStep(IFieldExtractor extractor, DataConverter converter) {
+        internal PrimitiveExtractionStep(IFieldExtractor extractor) {
             Guard.Against.Null(extractor, nameof(extractor));
-            Guard.Against.Null(converter, nameof(converter));
-            Debug.Assert(extractor.FieldType.IsInstanceOf(converter.SourceType));
-            Debug.Assert(DBType.IsSupported(converter.SourceType));
-
             extractor_ = extractor;
-            converter_ = converter;
             ExpectedSource = extractor_.ExpectedSource;
         }
 
@@ -56,12 +42,10 @@ namespace Kvasir.Extraction {
             // this and produce DBValue.NULL. The PrimitiveExtractionStep can only ever return a collection of size 1,
             // so this heuristic is sufficient to satisfy all postconditions.
             var extraction = extractor_.Execute(source);
-            var conversion = converter_.Convert(extraction);
-            return new DBValue[] { DBValue.Create(conversion) };
+            return new DBValue[] { DBValue.Create(extraction) };
         }
 
 
         private readonly IFieldExtractor extractor_;
-        private readonly DataConverter converter_;
     }
 }

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -1083,7 +1083,7 @@
         <member name="T:Kvasir.Extraction.DataExtractionPlan">
             <summary>
               A description of the way in which data for a particular CLR object type is to be extracted from instances,
-              transformd, and prepared to be stored in a back-end database.
+              transformed, and prepared to be stored in a back-end database.
             </summary>
         </member>
         <member name="P:Kvasir.Extraction.DataExtractionPlan.ExpectedSource">
@@ -1097,12 +1097,12 @@
               Constructs a new <see cref="T:Kvasir.Extraction.DataExtractionPlan"/>.
             </summary>
             <param name="steps">
-              The ordered sequence of <see cref="T:Kvasir.Extraction.IExtractionStep">extraction steps</see> that produce the extrinsically
-              converted values from a source CLR object.
+              The ordered sequence of <see cref="T:Kvasir.Extraction.IExtractionStep">extraction steps</see> that produce the unconverted
+              values from a source CLR object.
             </param>
             <param name="converters">
-              The ordered sequence of <see cref="T:Cybele.Core.DataConverter">data converters</see> that intrinsically transform the
-              values produced by <paramref name="steps"/>.
+              The ordered sequence of <see cref="T:Cybele.Core.DataConverter">data converters</see> that transform the values produced
+              by <paramref name="steps"/>.
             </param>
             <pre>
               <paramref name="steps"/> is not empty
@@ -1214,8 +1214,8 @@
             <remarks>
               The <see cref="T:Kvasir.Extraction.IExtractionStep"/> interface is a companion to the <see cref="T:Kvasir.Extraction.IFieldExtractor"/> interface,
               separating the logic for what to do with a piece of extracted data from how to obtain it. The data produced
-              by executing an <see cref="T:Kvasir.Extraction.IExtractionStep"/> instance is fully decomposed and has had an opportunity to
-              undergo extrinsic transformation.
+              by executing an <see cref="T:Kvasir.Extraction.IExtractionStep"/> instance is fully decomposed but has not undergone any
+              transforms.
             </remarks>
         </member>
         <member name="P:Kvasir.Extraction.IExtractionStep.ExpectedSource">
@@ -1230,19 +1230,10 @@
               that can be stored in a back-end database.
             </summary>
             <remarks>
-              <para>
-                Every extraction plan has two phases of data transformation. The first is the extrinsic phase, in which
-                the value is modified (and its type possibly changed) according to a user-provided rule. The second is
-                the intrinsic phase, in which the once-transformed value undergoe a transformation specific to the
-                storage mechanics of the target back-end relational database. The values produced by executing an
-                <see cref="T:Kvasir.Extraction.IExtractionStep"/> will have completed the first phase only.
-              </para>
-              <para>
-                Executing an <see cref="T:Kvasir.Extraction.IExtractionStep"/> on a <see langword="null"/> source object will produce a
-                sequence of <see cref="P:Kvasir.Schema.DBValue.NULL"/> of the appropriate length. This ensures that a particular
-                <see cref="T:Kvasir.Extraction.IExtractionStep"/> instance always produces sequences of equal length independent of the
-                source object's nullity.
-              </para>
+              Executing an <see cref="T:Kvasir.Extraction.IExtractionStep"/> on a <see langword="null"/> source object will produce a
+              sequence of <see cref="P:Kvasir.Schema.DBValue.NULL"/> of the appropriate length. This ensures that a particular
+              <see cref="T:Kvasir.Extraction.IExtractionStep"/> instance always produces sequences of equal length independent of the
+              source object's nullity.
             </remarks>
             <param name="sourceObject">
               The source object on which to execute this <see cref="T:Kvasir.Extraction.IExtractionStep"/>.
@@ -1304,23 +1295,14 @@
         <member name="P:Kvasir.Extraction.PrimitiveExtractionStep.ExpectedSource">
             <inheritdoc/>
         </member>
-        <member name="M:Kvasir.Extraction.PrimitiveExtractionStep.#ctor(Kvasir.Extraction.IFieldExtractor,Cybele.Core.DataConverter)">
+        <member name="M:Kvasir.Extraction.PrimitiveExtractionStep.#ctor(Kvasir.Extraction.IFieldExtractor)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Extraction.PrimitiveExtractionStep"/>.
             </summary>
             <param name="extractor">
               The <see cref="T:Kvasir.Extraction.IFieldExtractor"/> defining how the primitive value is to be obtained.
             </param>
-            <param name="converter">
-              A <see cref="T:Cybele.Core.DataConverter"/> defining how to transform the primitive value extracted according to
-              <paramref name="extractor"/>. If no transformation is desired, an
-              <see cref="M:Cybele.Core.DataConverter.Identity``1">identity conversion</see> should be provided.
-            </param>
             <pre>
-              The <see cref="P:Cybele.Core.DataConverter.SourceType">SourceType</see> of <paramref name="converter"/> is the same as
-              the <see cref="P:Kvasir.Extraction.IFieldExtractor.FieldType">FieldType</see> of <paramref name="extractor"/>, or is a base
-              class or interface thereof
-                --and--
               The <see cref="P:Kvasir.Extraction.IFieldExtractor.FieldType">FieldType</see> of <paramref name="extractor"/> is a data type
               supported by the Framework.
             </pre>
@@ -1487,8 +1469,8 @@
               <see cref="T:Kvasir.Reconstitution.DataReconstitutionPlan"/> is executed.
             </param>
             <param name="reverters">
-              The ordered sequence of <see cref="T:Cybele.Core.DataConverter">data converters</see> that intrinsically transform the
-              values extracted from the back-end database..
+              The ordered sequence of <see cref="T:Cybele.Core.DataConverter">data converters</see> that transform the values
+              extracted from the back-end database..
             </param>
             <pre>
               <paramref name="reverters"/> is not empty
@@ -1588,19 +1570,9 @@
               relational database
             </summary>
             <remarks>
-              <para>
-                The process of creating a CLR object from a "row" of database values is a two-step process. In the first
-                step, the object is <i>created</i>; that is, some valid CLR object is brought into existence according to
-                the APIs exposed by the target type. In the second step, that object is modified so that its state reflects
-                the full slate of values in the "row." This two-step dance allows for the use of, for exaple, read-only
-                properties in conjunction with constructors, which is a more natural object model for most users (as
-                compared to requiring that all properties be writeable).
-              </para>
-              <para>
-                The <see cref="T:Kvasir.Reconstitution.IObjectCreator"/> interface describes the shape of the first step in the object-building
-                process only. The guarantee of the interface is that a produced object is valid according to the domain
-                object being created, though it is not necessarily fully reflective of the database state.
-              </para>
+              The <see cref="T:Kvasir.Reconstitution.IObjectCreator"/> interface describes the shape of the first step in the object-building
+              process only. The guarantee of the interface is that a produced object is valid according to the domain object
+              being created, though it is not necessarily fully reflective of the database state.
             </remarks>
             <seealso cref="T:Kvasir.Reconstitution.IMutationStep"/>
             <seealso cref="T:Kvasir.Reconstitution.Reconstitutor"/>
@@ -1713,23 +1685,18 @@
         <member name="P:Kvasir.Reconstitution.PrimitiveCreator.Target">
             <inheritdoc/>
         </member>
-        <member name="M:Kvasir.Reconstitution.PrimitiveCreator.#ctor(System.Index,Cybele.Core.DataConverter)">
+        <member name="M:Kvasir.Reconstitution.PrimitiveCreator.#ctor(System.Index,System.Type)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Reconstitution.PrimitiveCreator"/>.
             </summary>
             <param name="index">
               The index in the to-be-provided array of database values at which the target primitive value resides.
             </param>
-            <param name="reverter">
-              A <see cref="T:Cybele.Core.DataConverter"/> defining how to undo the transform performed on the primitive value. If no
-              transformation was applied on storage, an <see cref="M:Cybele.Core.DataConverter.Identity``1">identity conversion</see>
-              should be provided.
+            <param name="targetType">
+              The type of primitive type that can be handled.
             </param>
             <pre>
-              <paramref name="reverter"/> supports bidirectional conversion
-                --and--
-              The <see cref="P:Cybele.Core.DataConverter.ResultType"/> of <paramref name="reverter"/> is a data type supported by the
-              Framework.
+              <paramref name="targetType"/> is a data type supported by the Framework.
             </pre>
         </member>
         <member name="M:Kvasir.Reconstitution.PrimitiveCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
@@ -5095,7 +5062,7 @@
               [deduced] The type of declaration produced by <paramref name="builder"/>.
             </typeparam>
             <param name="builder">
-              The <see cref="T:Kvasir.Transcription.IForeignKeyDeclBuilder`1"/> to use to create the declaratory SQL expression.
+              The <see cref="T:Kvasir.Transcription.IForeignKeyDeclBuilder`1"/> to use to create the declaration.
             </param>
             <pre>
               <paramref name="builder"/> is not <see langword="null"/>.
@@ -5305,7 +5272,7 @@
               [deduced] The type of declaration produced by <paramref name="builder"/>.
             </typeparam>
             <param name="builder">
-              The <see cref="T:Kvasir.Transcription.IKeyDeclBuilder`1"/> to use to create the declaratory SQL expression.
+              The <see cref="T:Kvasir.Transcription.IKeyDeclBuilder`1"/> to use to create the declaration.
             </param>
             <pre>
               <paramref name="builder"/> is not <see langword="null"/>.

--- a/src/Kvasir/Reconstitution/DataReconstitutionPlan.cs
+++ b/src/Kvasir/Reconstitution/DataReconstitutionPlan.cs
@@ -26,8 +26,8 @@ namespace Kvasir.Reconstitution {
         ///   <see cref="DataReconstitutionPlan"/> is executed.
         /// </param>
         /// <param name="reverters">
-        ///   The ordered sequence of <see cref="DataConverter">data converters</see> that intrinsically transform the
-        ///   values extracted from the back-end database..
+        ///   The ordered sequence of <see cref="DataConverter">data converters</see> that transform the values
+        ///   extracted from the back-end database..
         /// </param>
         /// <pre>
         ///   <paramref name="reverters"/> is not empty

--- a/src/Kvasir/Reconstitution/IObjectCreator.cs
+++ b/src/Kvasir/Reconstitution/IObjectCreator.cs
@@ -6,19 +6,9 @@ namespace Kvasir.Reconstitution {
     ///   relational database
     /// </summary>
     /// <remarks>
-    ///   <para>
-    ///     The process of creating a CLR object from a "row" of database values is a two-step process. In the first
-    ///     step, the object is <i>created</i>; that is, some valid CLR object is brought into existence according to
-    ///     the APIs exposed by the target type. In the second step, that object is modified so that its state reflects
-    ///     the full slate of values in the "row." This two-step dance allows for the use of, for exaple, read-only
-    ///     properties in conjunction with constructors, which is a more natural object model for most users (as
-    ///     compared to requiring that all properties be writeable).
-    ///   </para>
-    ///   <para>
-    ///     The <see cref="IObjectCreator"/> interface describes the shape of the first step in the object-building
-    ///     process only. The guarantee of the interface is that a produced object is valid according to the domain
-    ///     object being created, though it is not necessarily fully reflective of the database state.
-    ///   </para>
+    ///   The <see cref="IObjectCreator"/> interface describes the shape of the first step in the object-building
+    ///   process only. The guarantee of the interface is that a produced object is valid according to the domain object
+    ///   being created, though it is not necessarily fully reflective of the database state.
     /// </remarks>
     /// <seealso cref="IMutationStep"/>
     /// <seealso cref="Reconstitutor"/>

--- a/src/Kvasir/Reconstitution/PrimitiveCreator.cs
+++ b/src/Kvasir/Reconstitution/PrimitiveCreator.cs
@@ -18,42 +18,28 @@ namespace Kvasir.Reconstitution {
         /// <param name="index">
         ///   The index in the to-be-provided array of database values at which the target primitive value resides.
         /// </param>
-        /// <param name="reverter">
-        ///   A <see cref="DataConverter"/> defining how to undo the transform performed on the primitive value. If no
-        ///   transformation was applied on storage, an <see cref="DataConverter.Identity{T}">identity conversion</see>
-        ///   should be provided.
+        /// <param name="targetType">
+        ///   The type of primitive type that can be handled.
         /// </param>
         /// <pre>
-        ///   <paramref name="reverter"/> supports bidirectional conversion
-        ///     --and--
-        ///   The <see cref="DataConverter.ResultType"/> of <paramref name="reverter"/> is a data type supported by the
-        ///   Framework.
+        ///   <paramref name="targetType"/> is a data type supported by the Framework.
         /// </pre>
-        internal PrimitiveCreator(Index index, DataConverter reverter) {
-            Guard.Against.Null(reverter, nameof(reverter));
-            Debug.Assert(reverter.IsBidirectional);
-            Debug.Assert(DBType.IsSupported(reverter.SourceType));
-
-            Target = reverter.SourceType;
+        internal PrimitiveCreator(Index index, Type targetType) {
+            Target = targetType;
             index_ = index;
-            reverter_ = reverter;
         }
 
         /// <inheritdoc/>
         public object? Execute(DBData values) {
             Guard.Against.NullOrEmpty(values, nameof(values));
 
-            // DataConverters operate on raw values, of which DBNull is not one. If we pass DBNull to the revert
-            // method (or, for that matter, the convert method) we'll get an error because DBNull is not an instance of
-            // the expected type.
             if (values[index_] == DBValue.NULL) {
-                return reverter_.Revert(null);
+                return null;
             }
-            return reverter_.Revert(values[index_].Datum);
+            return values[index_].Datum;
         }
 
 
         private readonly Index index_;
-        private readonly DataConverter reverter_;
     }
 }

--- a/test/UnitTests/Kvasir/Extraction/ExtractionPlans.cs
+++ b/test/UnitTests/Kvasir/Extraction/ExtractionPlans.cs
@@ -115,7 +115,7 @@ namespace UT.Kvasir.Extraction {
             mockExtractor.Setup(e => e.Execute(It.IsAny<object>())).Returns(mockRelation.Object);
 
             var step = new IdentityExtractor<string>();
-            var steps = new IExtractionStep[] { new PrimitiveExtractionStep(step, DataConverter.Identity<string>()) };
+            var steps = new IExtractionStep[] { new PrimitiveExtractionStep(step) };
             var converters = new DataConverter[] { DataConverter.Identity<string>() };
             var entityPlan = new DataExtractionPlan(steps, converters);
 

--- a/test/UnitTests/Kvasir/Extraction/ExtractionSteps.cs
+++ b/test/UnitTests/Kvasir/Extraction/ExtractionSteps.cs
@@ -14,24 +14,22 @@ namespace UT.Kvasir.Extraction {
             var mockExtractor = new Mock<IFieldExtractor>();
             mockExtractor.Setup(e => e.ExpectedSource).Returns(typeof(string));
             mockExtractor.Setup(e => e.FieldType).Returns(typeof(int));
-            var conv = DataConverter.Identity<int>();
 
             // Act
-            var step = new PrimitiveExtractionStep(mockExtractor.Object, conv);
+            var step = new PrimitiveExtractionStep(mockExtractor.Object);
 
             // Assert
             step.ExpectedSource.Should().Be(typeof(string));
         }
 
-        [TestMethod] public void ExtractWithIdentityConversion() {
+        [TestMethod] public void ExtractFromExact() {
             // Arrange
             var result = 10;
             var mockExtractor = new Mock<IFieldExtractor>();
             mockExtractor.Setup(e => e.ExpectedSource).Returns(typeof(string));
             mockExtractor.Setup(e => e.FieldType).Returns(typeof(int));
             mockExtractor.Setup(e => e.Execute(It.IsAny<string>())).Returns(result);
-            var conv = DataConverter.Identity<int>();
-            var step = new PrimitiveExtractionStep(mockExtractor.Object, conv);
+            var step = new PrimitiveExtractionStep(mockExtractor.Object);
             var source = "Grand Rapids";
 
             // Act
@@ -42,25 +40,6 @@ namespace UT.Kvasir.Extraction {
             value.Should().BeEquivalentTo(new DBValue[] { DBValue.Create(result) });
         }
 
-        [TestMethod] public void ExtractWithNonIdentityConversion() {
-            // Arrange
-            var result = 10;
-            var mockExtractor = new Mock<IFieldExtractor>();
-            mockExtractor.Setup(e => e.ExpectedSource).Returns(typeof(string));
-            mockExtractor.Setup(e => e.FieldType).Returns(typeof(int));
-            mockExtractor.Setup(e => e.Execute(It.IsAny<string>())).Returns(result);
-            var conv = DataConverter.Create<int, int>(i => i * 2);
-            var step = new PrimitiveExtractionStep(mockExtractor.Object, conv);
-            var source = "Detroit";
-
-            // Act
-            var value = step.Execute(source);
-
-            // Assert
-            mockExtractor.Verify(e => e.Execute(source), Times.Once);
-            value.Should().BeEquivalentTo(new DBValue[] { DBValue.Create(conv.Convert(result)) });
-        }
-
         [TestMethod] public void ExtractFromDerived() {
             // Arrange
             var result = 10;
@@ -68,8 +47,7 @@ namespace UT.Kvasir.Extraction {
             mockExtractor.Setup(e => e.ExpectedSource).Returns(typeof(Exception));
             mockExtractor.Setup(e => e.FieldType).Returns(typeof(int));
             mockExtractor.Setup(e => e.Execute(It.IsAny<Exception>())).Returns(result);
-            var conv = DataConverter.Identity<int>();
-            var step = new PrimitiveExtractionStep(mockExtractor.Object, conv);
+            var step = new PrimitiveExtractionStep(mockExtractor.Object);
             var source = new NullReferenceException();
 
             // Act
@@ -87,8 +65,7 @@ namespace UT.Kvasir.Extraction {
             mockExtractor.Setup(e => e.ExpectedSource).Returns(typeof(string));
             mockExtractor.Setup(e => e.FieldType).Returns(typeof(int));
             mockExtractor.Setup(e => e.Execute(It.IsAny<string>())).Returns(result);
-            var conv = DataConverter.Identity<int>();
-            var step = new PrimitiveExtractionStep(mockExtractor.Object, conv);
+            var step = new PrimitiveExtractionStep(mockExtractor.Object);
             string? source = null;
 
             // Act

--- a/test/UnitTests/Kvasir/Reconstitution/Lookups.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/Lookups.cs
@@ -14,7 +14,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void MatchesFirstPossibleEntity() {
             // Arrange
             var conv = DataConverter.Identity<string>();
-            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>(), conv);
+            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>());
             var plan = new DataExtractionPlan(new IExtractionStep[] { step }, new DataConverter[] { conv });
             var data = new string[] { "Juárez", "Tarawa", "Leeds" };
             var target = data[0];
@@ -30,7 +30,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void MatchesIntermediatePossibleEntity() {
             // Arrange
             var conv = DataConverter.Identity<string>();
-            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>(), conv);
+            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>());
             var plan = new DataExtractionPlan(new IExtractionStep[] { step }, new DataConverter[] { conv });
             var data = new string[] { "Düsseldorf", "Naypyidaw", "Tirana" };
             var target = data[1];
@@ -46,7 +46,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void MatchesLastPossibleEntity() {
             // Arrange
             var conv = DataConverter.Identity<string>();
-            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>(), conv);
+            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>());
             var plan = new DataExtractionPlan(new IExtractionStep[] { step }, new DataConverter[] { conv });
             var data = new string[] { "Siem Reap", "Caesarea", "Bissau" };
             var target = data[2];
@@ -62,7 +62,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void NoMatchingEntity() {
             // Arrange
             var conv = DataConverter.Identity<string>();
-            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>(), conv);
+            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>());
             var plan = new DataExtractionPlan(new IExtractionStep[] { step }, new DataConverter[] { conv });
             var data = new string[] { "Corfu", "Cologne", "Victoria" };
             var target = "Monterrey";
@@ -81,7 +81,7 @@ namespace UT.Kvasir.Reconstitution {
             var data = new string[] { "Bamako", "Monte Carlo", "Genoa" };
             var target = data[^1];
             var key = new List<DBValue>() { DBValue.Create(target), DBValue.Create("!!!") };
-            var step0 = new PrimitiveExtractionStep(new IdentityExtractor<string>(), conv);
+            var step0 = new PrimitiveExtractionStep(new IdentityExtractor<string>());
             var mockStep = new Mock<IExtractionStep>();
             mockStep.Setup(e => e.ExpectedSource).Returns(typeof(string));
             mockStep.Setup(e => e.Execute(It.Is<string>(s => s == target))).Returns(new List<DBValue>() { key[1] });

--- a/test/UnitTests/Kvasir/Reconstitution/ObjectCreators.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/ObjectCreators.cs
@@ -11,36 +11,22 @@ using System.Collections.Generic;
 namespace UT.Kvasir.Reconstitution {
     [TestClass, TestCategory("PrimitiveCreator")]
     public class PrimitiveCreatorTests {
-        [TestMethod] public void ConstructNoReversion() {
+        [TestMethod] public void Construct() {
             // Arrange
             var idx = new Index(3);
-            var reverter = DataConverter.Identity<int>();
 
             // Act
-            var creator = new PrimitiveCreator(idx, reverter);
+            var creator = new PrimitiveCreator(idx, typeof(int));
 
             // Assert
             creator.Target.Should().Be(typeof(int));
         }
 
-        [TestMethod] public void ConstructWithReversion() {
-            // Arrange
-            var idx = new Index(491);
-            var reverter = DataConverter.Create<char, int>(c => c, i => (char)i);
-
-            // Act
-            var creator = new PrimitiveCreator(idx, reverter);
-
-            // Assert
-            creator.Target.Should().Be(typeof(char));
-        }
-
-        [TestMethod] public void ProduceNonNullNoReversion() {
+        [TestMethod] public void ProduceNonNull() {
             // Arrange
             var idx = new Index(1);
-            var reverter = DataConverter.Identity<string>();
             var data = new DBValue[] { DBValue.Create(7), DBValue.Create("Jefferson City") };
-            var creator = new PrimitiveCreator(idx, reverter);
+            var creator = new PrimitiveCreator(idx, typeof(string));
 
             // Act
             var value = creator.Execute(data);
@@ -49,40 +35,11 @@ namespace UT.Kvasir.Reconstitution {
             value.Should().Be(data[idx].Datum);
         }
 
-        [TestMethod] public void ProduceNonNullWithReversion() {
-            // Arrange
-            var idx = new Index(0);
-            var reverter = DataConverter.Create<int, string>(i => i.ToString(), s => int.Parse(s));
-            var data = new DBValue[] { DBValue.Create("7"), DBValue.NULL, DBValue.Create(7) };
-            var creator = new PrimitiveCreator(idx, reverter);
-
-            // Act
-            var value = creator.Execute(data);
-
-            // Assert
-            value.Should().Be(7);
-        }
-
-        [TestMethod] public void ProduceNullNoReversion() {
+        [TestMethod] public void ProduceNull() {
             // Arrange
             var idx = new Index(1);
-            var reverter = DataConverter.Identity<ushort>();
             var data = new DBValue[] { DBValue.Create('&'), DBValue.NULL, DBValue.Create(-4L) };
-            var creator = new PrimitiveCreator(idx, reverter);
-
-            // Act
-            var value = creator.Execute(data);
-
-            // Assert
-            value.Should().BeNull();
-        }
-
-        [TestMethod] public void ProduceNullWithReversion() {
-            // Arrange
-            var idx = new Index(1);
-            var reverter = DataConverter.Create<DateTime, int>(d => d.Year, i => new DateTime(i, 1, 1));
-            var data = new DBValue[] { DBValue.Create("Bloomington"), DBValue.NULL };
-            var creator = new PrimitiveCreator(idx, reverter);
+            var creator = new PrimitiveCreator(idx, typeof(ushort));
 
             // Act
             var value = creator.Execute(data);
@@ -219,7 +176,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void Construct() {
             // Arrange
             var conv = DataConverter.Identity<string>();
-            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>(), conv);
+            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>());
             var plan = new DataExtractionPlan(new IExtractionStep[] { step }, new DataConverter[] { conv });
 
             // Act
@@ -232,7 +189,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void ProduceFromNonNullKey() {
             // Arrange
             var conv = DataConverter.Identity<string>();
-            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>(), conv);
+            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>());
             var plan = new DataExtractionPlan(new IExtractionStep[] { step, step }, new DataConverter[] { conv, conv });
             var entities = new string[] { "Belo Horizonte", "Gladstone", "Cluj-Napoca" };
             var target = entities[2];
@@ -249,7 +206,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void ProduceFromNullKey() {
             // Arrange
             var conv = DataConverter.Identity<string>();
-            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>(), conv);
+            var step = new PrimitiveExtractionStep(new IdentityExtractor<string>());
             var plan = new DataExtractionPlan(new IExtractionStep[] { step, step }, new DataConverter[] { conv, conv });
             var entities = new string[] { "Whanganui", "Valladolid", "Chișinău" };
             var target = entities[0];

--- a/test/UnitTests/Kvasir/Reconstitution/ReconstitutionPlans.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/ReconstitutionPlans.cs
@@ -60,7 +60,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void Construct() {
             // Arrange
             var converter = DataConverter.Identity<string>();
-            var creator = new PrimitiveCreator(0, converter);
+            var creator = new PrimitiveCreator(0, typeof(string));
             var reconstitutor = new Reconstitutor(creator, Enumerable.Empty<IMutationStep>());
             var entityPlan = new DataReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
 
@@ -77,7 +77,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void ExecuteOnEmptyRows() {
             // Arrange
             var converter = DataConverter.Identity<string>();
-            var creator = new PrimitiveCreator(0, converter);
+            var creator = new PrimitiveCreator(0, typeof(string));
             var reconstitutor = new Reconstitutor(creator, Enumerable.Empty<IMutationStep>());
             var entityPlan = new DataReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
 
@@ -97,7 +97,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void ExecuteOnSingleRow() {
             // Arrange
             var converter = DataConverter.Identity<string>();
-            var creator = new PrimitiveCreator(0, converter);
+            var creator = new PrimitiveCreator(0, typeof(string));
             var reconstitutor = new Reconstitutor(creator, Enumerable.Empty<IMutationStep>());
             var entityPlan = new DataReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
 
@@ -121,7 +121,7 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void ExecuteOnMultipleRows() {
             // Arrange
             var converter = DataConverter.Identity<string>();
-            var creator = new PrimitiveCreator(0, converter);
+            var creator = new PrimitiveCreator(0, typeof(string));
             var reconstitutor = new Reconstitutor(creator, Enumerable.Empty<IMutationStep>());
             var entityPlan = new DataReconstitutionPlan(reconstitutor, Enumerable.Repeat(converter, 1));
 
@@ -130,13 +130,14 @@ namespace UT.Kvasir.Reconstitution {
             var plan = new RelationReconstitutionPlan(entityPlan, mockRepopulator.Object);
             var source = new object();
 
-            var values = new string[] { "Fairfax", "Highland Park", "Nacogdoches", "Taos Pubelo", "Hilo" };
+            var values = new string[] { "Fairfax", "Highland Park", "Nacogdoches", "Taos Pubelo", "Hilo", "Detroit" };
             var data = new List<List<DBValue>>() {
                 new List<DBValue>(){ DBValue.Create(values[0]) },
                 new List<DBValue>(){ DBValue.Create(values[1]) },
                 new List<DBValue>(){ DBValue.Create(values[2]) },
                 new List<DBValue>(){ DBValue.Create(values[3]) },
-                new List<DBValue>(){ DBValue.Create(values[4]) }
+                new List<DBValue>(){ DBValue.Create(values[4]) },
+                new List<DBValue>(){ DBValue.Create(values[5]) }
             };
 
             // Act

--- a/test/UnitTests/Kvasir/Reconstitution/Repopulators.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/Repopulators.cs
@@ -26,7 +26,7 @@ namespace UT.Kvasir.Reconstitution {
             // Arrange
             var mockRelation = new Mock<IRelation>();
             var source = new Tuple<IRelation>(mockRelation.Object);
-            var entries = new List<string>() { "Seneca Falls", "Richmond", "Hackensack", "Ogden" };
+            var entries = new List<string>() { "Seneca Falls", "Richmond", "Hackensack", "Ogden", "Bloomington" };
             var repopulator = new FromPropertyRepopulator(source.GetType().GetProperty("Item1")!);
 
             // Sequence
@@ -35,6 +35,7 @@ namespace UT.Kvasir.Reconstitution {
             sequence.Add(r => r.Repopulate(entries[1]));
             sequence.Add(r => r.Repopulate(entries[2]));
             sequence.Add(r => r.Repopulate(entries[3]));
+            sequence.Add(r => r.Repopulate(entries[4]));
 
             // Act
             repopulator.Execute(source, entries);


### PR DESCRIPTION
This commit removes the responsibility of performign ANY data conversion/reversion from the PrimitiveExtractionStep and
the PrimitiveObjectCreator. The transforms are still performed, but at the higher level; this is because, fundamentally,
the steps in the plans for Extraction and Reconstitution are predicated on the target type, and should be fully divorced
from the source Entity type. This change, for example, makes the DecomposingExtractionStep something that can be reused
across different Fields, even if those Fields wish to apply different extrinsic transforms. The Translation layer will
have to compound the intrinsic and extrinsic transformation logic into one that is applied either at the end (for
Extraction) or the beginning (for Reconstitution). This also may have a slight performance benefit, eliding the need to
do multiple identity conversions when no transforms are requested.