### PR TITLE
New Attributes: ExcludeNamespaceFromName and PathSeparator

### DIFF
--- a/src/Kvasir/Annotations/PathingAttributes.cs
+++ b/src/Kvasir/Annotations/PathingAttributes.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace Kvasir.Annotations {
+    /// <summary>
+    ///   An annotation that specifies that the namespace of an Entity should not be included in the corresponding Table
+    ///   name.
+    /// </summary>
+    /// <remarks>
+    ///   The Kvasir framework will automatically determine the name of primary backing Tables based on the namespace
+    ///   and name of the POCO. The namespace is included to ensure uniqueness among all Tables, since different C#
+    ///   namespaces can define classes with the same name. The <see cref="ExcludeNamespaceFromNameAttribute"/> directs
+    ///   Kvasir to ignore the POCO's namespace entirely, making a promise that the POCO's name is globally unique among
+    ///   types being treated by the framework.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed class ExcludeNamespaceFromNameAttribute : Attribute {}
+
+    /// <summary>
+    ///   An annotation that specifies how the properties in the path of a POCO property nested in an Aggregate are
+    ///   combined into a single Field name.
+    /// </summary>
+    /// <remarks>
+    ///   The Kvasir framework will automatically determine the name of backing Fields for POCO properties defined on
+    ///   Aggregates by concatenating the access path to each property with a specific character. The character used by
+    ///   default is dependent on the specific back-end database provider, pursuant to its syntax rules. The
+    ///   <see cref="PathSeparatorAttribute"/> directs Kvasir to use a specific character instead. This directive
+    ///   applies to all Fields dervied from the annotated Aggregate property, except for those whose names are
+    ///   explicitly specified by a <see cref="NameAttribute"/>.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public sealed class PathSeparatorAttribute : Attribute {
+        /// <summary>
+        ///   The separator.
+        /// </summary>
+        public char Separator { internal get; init; }
+
+        /// <summary>
+        ///   Constructs a new instance of the <see cref="PathSeparatorAttribute"/>.
+        /// </summary>
+        /// <param name="separator">
+        ///   The separator.
+        /// </param>
+        public PathSeparatorAttribute(char separator) {
+            Separator = separator;
+        }
+    }
+}

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -751,6 +751,46 @@
             </remarks>
             <seealso cref="T:Kvasir.Annotations.NonNullableAttribute"/>
         </member>
+        <member name="T:Kvasir.Annotations.ExcludeNamespaceFromNameAttribute">
+            <summary>
+              An annotation that specifies that the namespace of an Entity should not be included in the corresponding Table
+              name.
+            </summary>
+            <remarks>
+              The Kvasir framework will automatically determine the name of primary backing Tables based on the namespace
+              and name of the POCO. The namespace is included to ensure uniqueness among all Tables, since different C#
+              namespaces can define classes with the same name. The <see cref="T:Kvasir.Annotations.ExcludeNamespaceFromNameAttribute"/> directs
+              Kvasir to ignore the POCO's namespace entirely, making a promise that the POCO's name is globally unique among
+              types being treated by the framework.
+            </remarks>
+        </member>
+        <member name="T:Kvasir.Annotations.PathSeparatorAttribute">
+            <summary>
+              An annotation that specifies how the properties in the path of a POCO property nested in an Aggregate are
+              combined into a single Field name.
+            </summary>
+            <remarks>
+              The Kvasir framework will automatically determine the name of backing Fields for POCO properties defined on
+              Aggregates by concatenating the access path to each property with a specific character. The character used by
+              default is dependent on the specific back-end database provider, pursuant to its syntax rules. The
+              <see cref="T:Kvasir.Annotations.PathSeparatorAttribute"/> directs Kvasir to use a specific character instead. This directive
+              applies to all Fields dervied from the annotated Aggregate property, except for those whose names are
+              explicitly specified by a <see cref="T:Kvasir.Annotations.NameAttribute"/>.
+            </remarks>
+        </member>
+        <member name="P:Kvasir.Annotations.PathSeparatorAttribute.Separator">
+            <summary>
+              The separator.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Annotations.PathSeparatorAttribute.#ctor(System.Char)">
+            <summary>
+              Constructs a new instance of the <see cref="T:Kvasir.Annotations.PathSeparatorAttribute"/>.
+            </summary>
+            <param name="separator">
+              The separator.
+            </param>
+        </member>
         <member name="T:Kvasir.Annotations.PrimaryKeyAttribute">
             <summary>
               An attribute that specifies that the Field backing a particular property is part of the owning Entity's

--- a/test/UnitTests/Kvasir/Annotations/NameAttributes.cs
+++ b/test/UnitTests/Kvasir/Annotations/NameAttributes.cs
@@ -118,5 +118,27 @@ namespace UT.Kvasir.Annotations {
             // Assert
             act.Should().ThrowExactly<ArgumentException>().WithAnyMessage();
         }
+
+        [TestMethod] public void PathSeparator() {
+            // Arrange
+            var value = ':';
+
+            // Act
+            var attr = new PathSeparatorAttribute(value);
+
+            // Assert
+            attr.Separator.Should().Be(value);
+        }
+
+        [TestMethod] public void PathSeparator_UniqueId() {
+            // Arrange
+            var attr = new PathSeparatorAttribute(' ');
+
+            // Act
+            var isUnique = ids_.Add(attr.TypeId);
+
+            // Assert
+            isUnique.Should().BeTrue();
+        }
     }
 }

--- a/test/UnitTests/Kvasir/Annotations/TagAttributes.cs
+++ b/test/UnitTests/Kvasir/Annotations/TagAttributes.cs
@@ -132,5 +132,25 @@ namespace UT.Kvasir.Annotations {
             // Assert
             isUnique.Should().BeTrue();
         }
+
+        [TestMethod] public void ExcludeNamespace_Construct() {
+            // Arrange
+
+            // Act
+            _ = new ExcludeNamespaceFromNameAttribute();
+
+            // Assert
+        }
+
+        [TestMethod] public void ExcludeNamespace_UniqueId() {
+            // Arrange
+            var attr = new ExcludeNamespaceFromNameAttribute();
+
+            // Act
+            var isUnique = ids_.Add(attr.TypeId);
+
+            // Assert
+            isUnique.Should().BeTrue();
+        }
     }
 }


### PR DESCRIPTION
This commit adds two new attributes that can be used to control how names for components are determined by Kvasir. The
first is the ExcludeNamespaceFromNameAttribute, which directs Kvasir to ignore the C# namespace when creating the name
of a POCO entity's primary table. The second is the PathSeparatorAttribute, which directs Kvasir to use a specific
character to separate portions of a property gleaned from an Aggregate.

This PR closes #44.