### PR TITLE
Specification Documentation for Schema Translation

### DIFF
--- a/src/Kvasir/Translation/Specification/Aggregate Properties.md
+++ b/src/Kvasir/Translation/Specification/Aggregate Properties.md
@@ -1,0 +1,64 @@
+﻿# Aggregate Properties
+
+An **Aggregate Property** is one whose CLR Type is a `struct` or `record struct` that is not `System.DateTime` or
+`System.Guid`. Aggregate Properties are useful for semantically grouping related data in the application's object model
+without creating an entirely new Entity and Table; for example, one might wish to break down the pieces of an address
+for efficient filtering by state, but having a dedicated Table for all addresses may be overkill. The Fields of an
+Aggregate Property are "lifted" into the Table of the owning Entity; because Aggregates can themselves have Aggregate
+Properties, this "lifting" may extend across multiple "levels."
+
+## General Field Annotations
+
+Aggregate Properties may be annotated much like Scalar Properties, except that the annotations may take an optional
+`Path` argument denoting the Nested Property to which the annotation applies. If there is no `Path` argument, the
+annotation affects the base property (and often therefore, _all_ Nested Properties), if possible; in some cases, this
+may be an error. It is an error for the `Path` argument of an annotation on an Aggregate Property to not resolve to an
+extant property or to resolve to a property that is not included in the Data Model.
+
+## Nullability
+
+Aggregate Properties, like Scalar Properties, may be nullable or non-nullable. This determination is made using the same
+rules as for Scalar Properties, with the same error conditions surrounding the use of the `[Nullable]` and
+`[NonNullable]` annotations. If an Aggregate Property is nullable, then all of the Fields that it contributes to the
+Data Model are also nullable; this overrides any nullability determination made for the Nested Properties in isolation.
+
+It is an error for a nullable Aggregate Property to only contribute Fields that, if the Aggregate Property were
+non-nullable, would themselves be nullable. This is because it such a situation creates an ambiguity when all `null`
+values are read from the database: does this indicate the absence of a value for the Aggregate Property, or the presence
+with all `null` Nested Properties? It is legal for individual Nested Properties to be nullable, but at least one must be
+non-nullable to avoid the confusion.
+
+## Naming
+
+The names of Fields contributed by Nested Properties of an Aggregate Property are determined by applying the following
+rules sequentially:
+
+1. Begin with `P` as the Aggregate Property on the Entity Type and `N` as the empty string
+1. If `P` is annotated with the theoretical annotation `[OverrideName(S)]` and `P` is a Scalar Property, then the name
+of the Field contributed by `P` is `N`
+1. Replace the theoretical annotation `[OverrideName(S)]`, if present, with `[Name(S)]`
+1. If `P` is annotated with `[Name(S)]`, append `S` following by a dot (`.`) to `N`
+1. For each annotation `[Name(S) { Path = "Q" }]` present on `P`, apply the theoretical annotation `[OverrideName(S)]`
+to the Nested Property at path `Q`
+1. For each Nested Property `P'` of `P`, repeat from (2) with `P = P'` 
+
+Note that this allows for `[Name(S)]` annotations on Nested Properties to serve as "default names" that can then be
+overridden by the ultimate owning Entity. It is therefore an error for a `[Name(S)]` attribute with a non-empty `Path`
+value to be present on an Aggregate Property that is itself in an Aggregate structure. Note also that name manipulation
+rules for other types of properties (e.g. Relation Properties, Reference Properties, etc.) still apply.
+
+## Column Ordering
+
+The Fields to which an Aggregate Property corresponds will always be ordered sequentially within the Table. By default,
+the starting column index for the Fields is undefined; however, one can specify a `0`-based column index for the set of
+Fields by using the `[Column(N)]` annotation. An Aggregate Property that is annotated with `[Column(N)]` will correspond
+to Fields whose smallest column index is exactly `N`. It is an error for a Field to have a negative column index, and it
+is also an error for two (or more) Fields in the same Table to have the same column index.
+
+## Default Values
+
+A nullable Aggregate Property may be annotated with `[Default(null)]` to indicate that the default value for all its
+corresponding Fields should be `null`. This is the only way to define default values for multiple Nested Properties with
+one annotaiton. Separately, Aggregate Properties may be annotated with `[Default(obj) { Path = "Q" }]`, in which case
+the annotation is treated as applying to the Field at path `Q` (as with any other `Path`-bearing annotation on an
+Aggregate Property).

--- a/src/Kvasir/Translation/Specification/Constraints.md
+++ b/src/Kvasir/Translation/Specification/Constraints.md
@@ -1,0 +1,79 @@
+﻿# Constraints
+
+## `UNIQUE` & Candidate Keys
+
+A **Candidate Key** is a set of one or more Fields that must form a unique tuple for each instance of an Entity. The
+Primary Key for a Table is necessarily a Candidate Key; additional Candidate Keys can be specified by applying the
+`[Unique]` annotation to a property. The `[Unique]` annotation takes an optional argument specifying the name of the
+Candidate Key: the Fields of properties annotated as `[Unique]` with the same name argument will be part of a common
+Candidate Key, while the name of a Candidate Key for a `[Unique]` annotation without a name argument will be
+implementation-defined. It is an error for two or more `[Unique]` annotations with the same name to be applied to the
+same property.
+
+It is an error for a `[Unique]` constraint to be placed on a Relation Property, even if a `Path` value is provided.
+
+## Signedness
+
+The `[Check.IsNonZero]`, `[Check.IsPositive]`, and `[Check.IsNegative]` annotations can be applied to properties that
+contribute Fields whose Data Type is numeric according to the following table:
+
+| Data Type | `[Check.IsNonZero]` | `[Check.IsPositive]` | `[Check.IsNegative]` |
+|:---------:|:-------------------:|:--------------------:|:--------------------:|
+| `Int8`    | Valid				  | Valid				 | Valid				|
+| `Int16`   | Valid				  | Valid				 | Valid				|
+| `Int32`   | Valid				  | Valid				 | Valid				|
+| `Int64`   | Valid				  | Valid				 | Valid				|
+| `UInt8`   | Valid				  | INVALID				 | INVALID				|
+| `UInt16`  | Valid				  | INVALID				 | INVALID				|
+| `UInt32`  | Valid				  | INVALID				 | INVALID				|
+| `UInt64`  | Valid				  | INVALID				 | INVALID				|
+| `Single`  | Valid				  | Valid				 | Valid				|
+| `Double`  | Valid				  | Valid				 | Valid				|
+| `Decimal` | Valid				  | Valid				 | Valid				|
+
+## Value Comparisons
+
+There are five annotations that can be applied to properties to constrain the values to those in some range. The
+`[Check.IsNot]` annotation can be applied to any property, while the other four (`[Check.IsGreaterThan]`,
+`[Check.IsGreaterThanOrEqualTo]`, `[Check.IsLessThan]`, and `[Check.IsLessThanOrEqualTo]`) can only be applied to
+properties that contribute Fields whose Data Type is numeric or is `Text` or `DateTime`. If multiple such annotations
+are applied to a single property, they form a _conjunction_ (i.e. an "and"); it is possible to mix the annotations.
+Kvasir will not apply any reductions, nor will it identify tautologically unsatisfiable predicates.
+
+The arguments to the five comparison annotations must be exactly the CLR Type of the property before its Extrinsic
+Data Conversion is performed; implicit type conversions (e.g. widening of integers) are not supported. The only
+exceptions to this rule are for Scalar Properties whoe pre-conversion CLR Type is either `System.DateTime` or
+`System.Guid`: because values of these types cannot be provided directly to a C# attribute, a `string` is expected
+(converted into the appropriate type based on the Translation Settings).
+
+## Inclusion & Exclusion
+
+The value of a Field can be restricted to one of a specific subset of values by applying the `[Check.IsOneOf]`
+annotation to the source property. Similarly, a specific subset of values can be _prohibited_ by applying the
+`[Check.IsNotOneOf]` annotation. These annotations may be applied to any property except one whose CLR Type is an
+enumeration. It is an error for more than one of either annotation, or for both, to be applied to a single property.
+
+The arguments to the two inclusion/exclusion annotations must be exactly the CLR Type of the property before its
+Extrinsic Data Conversion is performed; implicit type conversions (e.g. widening of integers) are not supported. The
+only exceptions to this rule are for Scalar Properties whoe pre-conversion CLR Type is either `System.DateTime` or
+`System.Guid`: because values of these types cannot be provided directly to a C# attribute, a `string` is expected
+(converted into the appropriate type based on the Translation Settings).
+
+## String Length
+
+A property that corresponds to a Field whose Data Type is `string` can be annotated to control the length of the text
+values. The `[Check.IsNonEmpty]`, `[Check.LengthIsAtLeast]`, `[Check.LenghtIsAtMost]`, and `[Check.LengthIsBetween]`
+attributes may not be applied to any other property. It is an error for a negative value to be provided as the argument
+to `[Check.LengthIsAtMost]` or for a non-positive number to be provided as the argument to `[Check.LengthIsAtLeast`]. It
+is similarly an error for the upper bound argument to `[Check.LengthIsBetween]` to be less than the lower bound
+argument.
+
+## Custom `CHECK`s
+
+Custom constraints can be applied to a Table by applying a `[Check.Complex(T, Fs...)]` annotation to either the Entity
+Type or the Relation Property. The first argument is interpreted as a Type that must be default constructible and
+implement the `IConstraintGenerator` interface, which permits the creation of arbitrarily complex predicates (including
+disjunctions). The remaining arguments, of which at least one is required, are the name of the Fields in the order in
+which they are used to populate the specified custom constraint. A single Field may appear more than once in this list;
+however, it is an error for any name to not be the actual name of a Field on the Table. (Note that the name must match
+after any name-changing annotations are considered.)

--- a/src/Kvasir/Translation/Specification/Data Conversions.md
+++ b/src/Kvasir/Translation/Specification/Data Conversions.md
@@ -1,0 +1,86 @@
+﻿# Data Conversions
+
+## Extrinsic Data Conversions
+
+An **Extrinsic Data Conversion** is one that is applied based on the presence of a `[DataConverter(T)]` annotation.
+Extrinsic Data Conversions are performed on the C# value extracted from a property before it is stored in the database
+(and, therefore, before it is subjected to constraints). Conversely, the reverse conversion is applied when the value is
+loaded out of the database prior to Entity Reconstitution. Within the Data Model, however, the application of a
+`[DataConverter(T)]` attribute effectively modifies the CLR Type of the annotated property, which can then impact the
+Data Type of the corresponding Fields. It is an error for a property to be annotated with more than one instance of the
+`[DataConverter(T)]` attribute with the same `Path` value.
+
+### For Scalar Properties
+
+When applied to a Scalar Property, it is an error for the `Path` of a `[DataConverter(T)]` annotation to be anything
+other than the empty string. Futhermore, the `SourceType` of `T` must be exactly the native type of the property;
+implicit type conversions (e.g. widening of integers) are not supported. The CLR Type of the Scalar Property is then
+the `ResultType` of `T`. It is an error for a Scalar Property to be directly annotated with more than one
+`[DataConverter(T)]` attributes; to achieve a complex, multi-step conversion, simply construct a suitable converter type
+`T`.
+
+A Scalar Property that is not annotated with `[DataConverter(T)]` has no Extrinsic Data Conversion: its CLR Type is the
+property's own native type.
+
+### For Enumeration Properties
+
+Enumeration Properties are special when it comes to Extrinsic Data Conversions, as they are the only category of
+property that _requires_ such a conversion to be present. This requirement is due to the fact that there is no real way
+to store a language-bound enumeration in a database directly: individual enumerators (i.e. the values) are just scoped
+names for integer constants. Some back-end database providers have native support for enumeration-type columns, which
+are generally implemented as numeric memory storage with a string interface; other providers have no such support.
+
+If an Enumeration Property is annotated with `[DataConverter(T)]` and `T` is neither an `enum` nor `string` (nullability
+notwithstanding), the behavior is identical to that of Scalar Properties. If the property is specifically a Flags
+Enumeration Property, the change to its CLR Type enacted by the conversion inhibits the normal "treated as-if it were a
+Relation" behavior.
+
+If an Enumeration Property is annotated as `[Numeric]`, then Kvasir will behave as if it were annotated with a
+`[DataProvider(T)]` attribute where `T` is a synthetic data converter that interoperates between instances of the
+property's native `enum` type and the underlying numeric representation thereof. In this case, the CLR Type of the
+property is viewed as that underlying numeric representation; however, this does _not_ inhibit the "treated as-if it
+were a Relation" behavior for Flags Enumeration Properties. It is an error for a property that is not an Enumeration
+Property to be annotated as `[Numeric]`, and it is also an error for a single property to be annotated as both
+`[Numeric]` and with `[DataConverter(T)]`.
+
+If an Enumeration Property has no `[DataConverter(T)]` annotation, then Kvasir will behave as if it _did_. Specifically,
+Kvasir will create a synthetic data converter whose `SourceType` is the property's native type, whose `ResultType` is
+`string` or `string?` (with nullability matching that of `SourceType`), and whose conversion/reversion is
+stringification (via `.ToString()`) and from-string parsing. This automatic Extrinsic Data Conversion is also applied if
+an Enumeration Property is annotated with `[DataConverter(T)]` where `T` is an `enum`, except that the `SourceType`
+becomes `T` instead. In either case, the CLR Type of the property is the `SourceType` of the automatic converter.
+
+If an Enumeration Property is annotated with `[DataConverter(T)]` and `T` is `string` or `string?`, then the CLR Type of
+the property is treated as if it were the property's native `enum` type with the nullability of the converter's
+`ResultType`. The presence of such an annotation inhibits the automatic Extrinsic Data Conversion described in the
+previous paragraph, and is generally useful to enact a custom string mapping.
+
+### For Reference Properties
+
+It is an error for a Reference Property to be annotated with `[DataConverter(T)]`, regardless of the presence or absence
+of a specified `Path`. The Nested Fields lifted out of the referenced Entity's Primary Key must match exactly, and so
+any Extrinsic Data Conversions are taken from the source definition.
+
+### For Relation Properties
+
+Any `[DataConverter(T)]` attribute applied to a Relation Property is treated as applying to the Synthetic Type of the
+Relation Pair. As such, it is an error for the `Path` of such an annotation to be the empty string.
+
+### For Aggregate Properties
+
+When applied to an Aggregate Property, a `[DataConverter(T)]` annotation is treated as if it had been applied to the
+Nested Property accessed via the annotation's `Path`. It is an error for no such property to exist or for the `Path` to
+be an empty string or for the `Path` to resolve to a property that is excluded from the Data Model. It is also an error
+if the target Nested Property is already annotated with its own `[DataConverter(T)]` attribute.
+
+If the Neted Property obtained via `Path` is an Enumeration Property, the application of the `[DataConverter(T)]` taken
+from the Aggregate Property is applied before any automatic Extrinsic Data Conversion is synthesized.
+
+## Intrinsic Data Conversions
+
+An **Intrinsic Data Conversion** is one that is applied automatically by the framework because the specific back-end
+database provider does not have a native data type that allows for the storage of a Field's data. For example, some
+RDBMSes support only signed integers, meaning that unsigned integers must be converted (e.g. via a bitwise
+reinterpretation) before being stored. Intrinsic Data Conversions occur after Extrinsic Data Conversions, as the former
+is predicated on the Data Type of the Field, which can be modified by the latter. Intrinsic Data Conversions cannot be
+controlled by the user.

--- a/src/Kvasir/Translation/Specification/Enumeration Properties.md
+++ b/src/Kvasir/Translation/Specification/Enumeration Properties.md
@@ -1,0 +1,22 @@
+﻿# Enumeration Properties
+
+An **Enumeration Property** is one whose CLR Type is a (possibly nullable) `enum`. Enumeration Properties are further
+classified into two disjoint subcategories: Standard Enumeration Properties and Flag Enumeration Properties
+
+## Standard Enumeration Properties
+
+A **Standard Enumeration Property** is one whose CLR Type is either `E` or `System.Nullable<E>` where `E` is an `enum`
+that is not annotated as `[System.Flags]`. A Standard Enumeration Property corresponds to exactly one Field whose Data
+Type is `Enumeration`. Aside from the Data Type mapping and some nuances surrounding Extrinsic Data Conversions, a
+Standard Enumeration Property is treated identically to a Scalar Property.
+
+The Field to which a Standard Enumeration Property corresponds is only allowed to take on certain values. Those values
+are known as the **Permitted Values** for the Field, and are determined by executing the Field's Extrinsic Data
+Conversion on the named enumerators of the source property's CLR Type.
+
+## Flags Enumeration Properties
+
+A **Flags Enumeration Property** is one whose CLR Type is either `E` or `System.Nullable<E>` where `E` is an `enum` that
+is annotated as `[System.Flags]`. A Flags Enumeration Property is treated identically to a Relation Property whose CLR
+Type is `RelationSet<E'>`, with `E'` being a non-flags version of `E` with any named combination enumerators (i.e. those
+whose numeric value is not a perfect power of two) removed.

--- a/src/Kvasir/Translation/Specification/General Identification.md
+++ b/src/Kvasir/Translation/Specification/General Identification.md
@@ -1,0 +1,97 @@
+﻿# General Identification
+
+## Entities
+
+An **Entity** is an `N`-tuple of data that describes some real-world (or in-application) object, concept, or idea; in
+the database, each Entity is realized as one or more Tables. A CLR Type that corresponds to an Entity is known as an
+**Entity Type**, the properties of which ultimately determine the structure of the database Table(s). Each CLR Type in
+the application's object model that meets the following criteria will be automatically identified by Kvasir as being an
+Entity Type:
+
+* It is defined in the application's assembly
+* It has `public` visibility
+* It is a `class` or a `record class`
+* It is not `abstract`
+* It is not generic
+
+A CLR Type that has non-`public` visibility but meets the other criteria may be added to the Data Model by applying the
+`[IncludeInModel]` annotation to the type's definition. However, applying this attribute to any other type (e.g. an
+`abstract` type, a generic type, a `struct`, etc.) will produce an error. Entity Types may be `partial` and may also be
+`sealed`. An Entity Type may have an inheritance hierarchy, though it is generally discouarged, as it may not result in
+Fields being identified as expected.
+
+A CLR Type that meets the above criteria but is _not_ annotated with `[IncludeInModel]` may still be included in the
+Data Model if it the CLR Type of a property that is included in the data model for an Entity or a Synthetic Entity.
+
+## Fields
+
+A **Field** is a single datum that describes an Entity, realized as a single Column in a database Table. A Table's
+Fields are automatically identified by Kvasir by looking at the properties of the source type (either an Entity Type or
+an Aggregate Type). Each property that meets the following criteria will correspond to at least one Field, depending on
+the type of the property and any annotations applied:
+
+* It has `public` visibility and a `public` `get` method
+* It is an instance method
+* It is not an indexer
+* It is not `abstract`
+* It is first declared by the source type (i.e. it is neither inherited nor declared by an interface)
+* It is not annotated as `[CodeOnly]`
+
+A property that has non-`public` visibility, has a non-`public` `get` method, and/or is `static` may be added to the
+Data Model by applying the `[IncludeInModel]` annotation to the property's definition. However, applying this attribute to
+any other type (e.g. an indexer, a property without a `get` method, etc.) will produce an error. Properties included in
+the Data Model may be `virtual`, though note that overridden `virtual` functions will be unconditionally excluded.
+
+Each property that is included in the Data Model is placed into one of five Property Categories that describes how the
+property maps to Fields, how those Fields are named, what annotations are valid on the property, etc. The rules for each
+category are describes in separate documents of the spec, but the categories themselves are:
+
+1. Scalar — the CLR Type is a built-in primitive, `string`, or one of a handful of standard library `struct`s
+1. Enumeration — the CLR Type is an `enum`
+1. Reference — the CLR Type is an Entity Type
+1. Relation — the CLR Type is a type that implements the `IRelation` interface
+1. Aggregate — the CLR Type is a `struct` or `record struct`
+
+It is an error for a property that is included in the Data Model to have a CLR Type that does not fall into one of these
+categories (e.g. a `delegate`, `System.Enum`, `dynamic`, etc.). Due to other rules regarding generic Entity Types and
+inheritance, it is also the case that the CLR Type of a property included in the Data Model cannot be generic. Nullable
+types are fully supported (both `System.Nullable<T>` instantations and nullable reference types); the category of a
+property with such a CLR Type is that of its non-nullable equivalent.
+
+Properties need not be writeable to be included in the Data Model: a property's `set` method can have `public`
+visibility, non-`public` visibility, or be absent altogether. That being said, the presence and/or absence of a `set`
+method may have an impact on the Reconstitution of Entity Types.
+
+Note that a property's CLR Type for the purpose of Field categorization is not always the actual `PropertyType` of the
+corresponding `System.Reflection.PropertyInfo`: the presencce of extrinsic data conversions may result in a different
+identification.
+
+## Data Types
+
+Each Field in the Data Model has a Data Type that broadly describes the domain of values that are valid for that Field.
+Data Types do not directly correspond to database storage, as some providers support storage formats that others do not
+(e.g. signed vs. unsigned integers). Additionally, the domain of permitted values may be shrunk by constraints applied
+to source properties, which is not embedded in a Field's Data Type. The Data Types supported by Kvasir are:
+
+| Data Type     | Allowed Values                                       |
+|:-------------:|:----------------------------------------------------:|
+| `Boolean`     | Either `true` or `false`                             |
+| `Character`   | A single UTF-16 code unit                            |
+| `DateTime`    | A calendar date and time                             |
+| `Decimal`     | A `16`-byte floating point number                    |
+| `Double`      | An `8`-byte floating point number                    |
+| `Enumeration` | A (varying) limited subset of strings                |
+| `Guid`        | A globally unique identifier                         |
+| `Int8`        | An `8`-bit signed integer                            |
+| `Int16`       | A `16`-bit signed integer                            |
+| `Int32`       | A `32`-bit signed integer                            |
+| `Int64`       | A `64`-bit signed integer                            |
+| `Single`      | A `4`-byte floating point number                     |
+| `Text`        | A sequence of UTF-16 code points of arbitrary length |
+| `UInt8`       | An `8`-bit unsigned integer                          |
+| `UInt16`      | A `16`-bit unsigned integer                          |
+| `UInt32`      | A `32`-bit unsigned integer                          |
+| `UInt64`      | A `64`-bit unsigned integer                          |
+
+Note that nullability is not embedded in the Data Type of a Field, either. Whether or not `null` is valid value for a
+Field is determined separately (though still based on the CLR Type of the source property).

--- a/src/Kvasir/Translation/Specification/Primary Keys.md
+++ b/src/Kvasir/Translation/Specification/Primary Keys.md
@@ -1,0 +1,40 @@
+﻿# Primary Keys
+
+Each Entity has a **Primary Key**, a collection of one or more Fields that uniquely identifie an instance of the Entity.
+Primary Keys are referenced by Foreign Keys (e.g. for Reference Properties) and may be used as indices in the back-end
+database. The Fields that participate in a Primary Key can be of any Data Type, though they must be non-nullable.
+
+## Entity Types
+
+The Primary Key of an Entity is determined by looking at the nullability, naming, and annotations of the Entity Type's
+properties. In the case of naming, any name-changing operations (e.g. `[Name(N)]` annotations) are applied before the
+Primary Key deduction is performed. Specifically, the following rules are applied in order, stopping as soon as the
+Field's nullability is resolved:
+
+1. Each property that is annotated as `[PrimaryKey]` corresponds to Fields that are part of the Entity's Primary Key
+1. The single Field whose name is `ID` is the Entity's Primary Key
+1. The single Field whose name is `FooID`, where `Foo` is the name of the Entity Type, is the Entity's Primary Key
+1. The single Candidate Key for the Entity is instead the Entity's Primary Key
+1. The single non-nullable Field is the Entity's Primary Key
+
+It is an error if the Primary Key for an Entity cannot be deduced.
+
+Because the Fields that form an Entity's Primary Key must be non-nullable, the Primary Key deduction can influence the
+nullability of Fields. Any Field whose nullability is _not_ based on an annotation becomes non-nullable if it is part of
+an Entity's Primary Key. It is an error for any Field that forms part of an Entity's Primary Key to be nullable because
+its source property is annotated as `[Nullable]` or because its type is an instantiation of the `Nullable<T>` generic.
+
+Some back-end database providers allow Primary Keys to be named, since Primary Keys are a type of constraint.
+By default, the name assigned to a Primary Key for an Entity is implementation defined. If an Entity Type is annotated
+with `[NamedPrimaryKey(N)]`, then the Primary Key for the corresponding Entity will be named exactly `N`.
+
+## Aggregate Types
+
+Aggregate Types do not have a Primary Key, as they do not correspond to database Entities. It is an error for a property
+in an Aggregate Type to be annotated with `[PrimaryKey]`. However, the properties of an Aggregate Type may correspond to
+Fields that contribute to an Entity's Primary Key if the Aggregate Property itself is annotated.
+
+## Synthetic Types
+
+The Primary Key for a Synthetic Type is the type's complete set of Fields. It is an error for a Relation Property to be
+annotated with `[PrimaryKey]`.

--- a/src/Kvasir/Translation/Specification/Reference Properties.md
+++ b/src/Kvasir/Translation/Specification/Reference Properties.md
@@ -1,0 +1,35 @@
+﻿# Reference Properties
+
+A **Reference Property** is one whose CLR Type is a (possibly nullable) Entity Type. Conceptually, a Reference Property
+represents a connection between two Entity Types in which the at least one of the cardinalities is `1` (e.g. one-to-one,
+one-to-many, or many-to-one). Each Reference Property contributes Fields that are based on the Primary Key of the
+referenced Entity Type. Exactly one Field is contributed for each Field in the target's Primary Key, with the Field's
+Data Type being carried over from its source. Other attributes may be modified by annotating the Reference Property
+itself.
+
+## Nullability
+
+Because the Fields contributed by a Reference Property are based on another Entity's Primary Key, they are inherently
+all non-nullable. However, if the Reference Property would be deduced as nullable using the nullability deduction rules
+for Scalar Properties, then the Fields become nullable instead. (Note that the same error conditions for the
+`[Nullable]` and `[NonNullable]` attributes apply as for Scalar Properties.) In such scenarios, the Reference Property
+represents an "optional reference": either all the Fields are `null` (indicating the absence of a reference) or all the
+Fields are non-`null` (indicating the presence of a reference).
+
+## Naming
+
+The Fields to which a Reference Property corresponds are named identically to those of an Aggregate Property, with the
+`[Name(S) { Path = "Q" }]` attribute modifying the naming scheme in the same way.
+
+## Column Ordering
+
+The Fields to which a Reference Property corresponds will always be ordered sequentially within the Table, with the same
+relative order as in the referenced Entity Type's Primary Key. By default, the starting column index for the Fields is
+undefined; however, one can specify a `0`-based column index for the set of Fields by using the `[Column(N)]`
+annotation. A Reference Property that is annotated with `[Column(N)]` will correspond to Fields whose smallest column
+index is exactly `N`. It is an error for a Field to have a negative column index, and it is also an error for two (or
+more) Fields in the same Table to have the same column index.
+
+## Default Values
+
+It is an error for a Reference Property to be annotated with `[Default(obj)]`.

--- a/src/Kvasir/Translation/Specification/Relation Properties.md
+++ b/src/Kvasir/Translation/Specification/Relation Properties.md
@@ -1,0 +1,28 @@
+﻿# Relation Properties
+
+A **Relation Property** is one whose CLR Type is a `class` or `record class` type that implements the `IRelation`
+interface. This is an interface that can _only_ be implemented by types in the Kvasir assembly, meaning that it is
+**not** possible for users to create their own Relation Types. Kvasir currently provides three such types:
+
+* `RelationList<T>` — equivalent to `List<T>`, implementing all the same interfaces and APIs
+* `RelationSet<T>` — equivalent to `Set<T>`, implementing all the same interfaces and APIs
+* `RelationMap<K, V>` — equivalent to `Dictionary<K, V>`, implementing all the same interfaces and APIs
+
+## Synthetic Types
+
+The data for a Relation Property `P` defined in an Entity Type `E` (possibly lifted from an Aggregate Type) is stored in
+a dedicated Relation Table, separate from the data pulled from other properties on `E`. The structure of this Table is
+based on the **Synthetic Type** of the Relation, which is defined as a hypothetical `struct` with two properties:
+
+1. An anonymously named property whose type is `E`
+1. A property named `Item` whose type is the **Connection Type** of the Relation
+
+Because the Synthetic Type is hypothetically a `struct`, any annotations placed on a Relation Property are processed as
+if they were placed on an Aggregate Property whose CLR Type was the Synthetic Type itself. In particular, any valid
+`Path` value must begin with `Item`, as that is the only named property available. (If the Connection Type is a
+primitive type, then `Item` is the _only_ valid `Path` value.)
+
+## Nested Relations
+
+It is an error for the Connection Type of a Relation Property to be a type that implements the `IRelation` interface or
+to be an Aggregate Type that contains a Relation Property.

--- a/src/Kvasir/Translation/Specification/Scalar Properties.md
+++ b/src/Kvasir/Translation/Specification/Scalar Properties.md
@@ -1,0 +1,93 @@
+﻿# Scalar Properties
+
+A **Scalar Property** is one whose CLR Type is a (possibly nullable) built-in primitive, `string`, `System.DateTime`, or
+`System.Guid`. A Scalar Property corresponds to exactly one Field in the database, with the storage mechanism depending
+on both the property's CLR Type and the specific support of the database provider. Ultimately, all properties of any
+categorization (except for Enumeration) decay into Scalar Properties, as Scalar Properties represent the most atomic
+data representation possible.
+
+Scalar Properties come in two flavors: Top-Level and Nested. A **Top-Level Scalar Property** is one defined on an Entity
+Type that corresponds to a Field on the Primary Table of that type. A **Nested Scalar Property** is one that is defined
+either on a non-Entity Type (such as an Aggregate Type) or that corresponds to a Field on the Primary Table of a type
+other than the Entity Type on which it is defined (as is the case when dealing with Relation Properties). By and large,
+this document will consider only the former; discussions of the latter can be found in the documents dedicated to other
+property categorizations.
+
+## Data Type Mapping
+
+The Data Type of a Scalar Property is based on the CLR Type of the property after its Extrinsic Data Conversions is
+performed. If the CLR Type is an instantiation of the `System.Nullable<T>` generic (e.g. `int?`), then the generic
+argument `T` is considered instead. Likewise, the underlying reference type of a nullable reference type (e.g. `string`
+for `string?`) is the determining factor. The specific conversion between CLR Type and Data Type is:
+
+| CLR Type          | Data Type   |
+|:-----------------:|:-----------:|
+| `bool`            | `Boolean`   |
+| `byte`            | `UInt8`     |
+| `char`            | `Character` |
+| `decimal`         | `Decimal`   |
+| `double`          | `Double`    |
+| `float`           | `Single`    |
+| `int`             | `Int32`     |
+| `long`            | `Int64`     |
+| `sbyte`           | `Int8`      |
+| `short`           | `Int16`     |
+| `string`          | `Text`      |
+| `System.DateTime` | `DateTime`  |
+| `System.Guid`     | `Guid`      |
+| `uint`            | `UInt32`    |
+| `ulong`           | `UInt64`    |
+| `ushort`          | `UInt16`    |
+
+## Nullability
+
+The nullability of a Field sourced from a Primitive Property is based on two factors: the nullability of the property's
+own CLR Type (after its Extrinsic Data Conversions are applied) and the nullability annotation applied to the property.
+Specifically, the following rules are applied in order, stopping as soon as the Field's nullability is resolved:
+
+1. If the property is annotated as `[Nullable]`, then the corresponding Field will be nullable
+1. If the property is annotated as `[NonNullable]`, then the corresponding Field will be non-nullable
+1. If the property's CLR Type is an instantiation of the `System.Nullable<T>` generic, then the corresponding Field will
+be nullable
+1. If the property's CLR Type is a value type, then the corresponding Field will be non-nullable
+1. If the Entity Type is defined in a nullable-enabled context and the CLR Type is a non-nullable reference type (e.g.
+`string`), then the corresponding Field will be non-nullable
+1. Else, the corresponding Field will be nullable
+
+Note that a Field's participation in an Entity's Primary Key may supersede the above deduction rules, and in some cases
+may induce additional errors.
+
+## Naming
+
+By default, a Scalar Property named `P` will correspond to a Field whose name is exactly `P`, with all casing and
+punctuation (e.g. for `snake_case` names) preserved. That being said, a Scalar Property annotated with `[Name(S)]` will
+be named `S` instead (again, with casing and punctuation preserved). `S` can contain any characters, but it is an error
+for `S` to be the empty string.
+
+It is an error for two or more Fields in the same Table to have the same name. Absent any annotations, this pattern is
+guaranteed by Kvasir. If annotations are used to change the default name translations, it is the user's responsibility
+to ensure uniqueness of names. The `[Name(S)]` annotation may be used, for example, to switch the names of two Fields
+without running afoul of this requirement.
+
+## Column Ordering
+
+By default, the order of Fields within a Table is undefined. However, one can specify a `0`-based column index for a
+Field by using the `[Column(N)]` annotation. A Scalar Property that is annotated with `[Column(N)]` will correspond to a
+Field with column index exactly `N`. It is an error for a Field to have a negative column index, and it is also an error
+for two (or more) Fields in the same Table to have the same column index.
+
+## Default Values
+
+Fields may have a **Default Value**, which is the datum assigned to the Field when a new instance of the owning Entity
+is created (such as with an `INSERT` SQL statement) and no value for the Field is explicitly specified. By default,
+Fields do not have a Default Value. However, a Scalar Property annotated with `[Default(obj)]` will have a Default Value
+obtained by passing `obj` through the property's Extrinsic Data Conversion.
+
+The type of `obj` must be exactly the CLR Type of the property before its Extrinsic Data Conversion is performed;
+implicit type conversions (e.g. widening of integers) are not supported. The only exception to this rule is for Scalar
+Properties whose pre-conversion CLR Type is either `System.DateTime` or `System.Guid`: because values of these types
+cannot be provided directly to a C# attribute, a `string` is expected (converted into the appropriate type based on the
+Translation Settings).
+
+Note that not having a Default Value is different than having a Default Value of `null`. `null` is permitted as the
+value for `obj` only if the Field is nullable; a Default Value of `null` specified for a non-nullable Field is an error.

--- a/src/Kvasir/Translation/Specification/Tables.md
+++ b/src/Kvasir/Translation/Specification/Tables.md
@@ -1,0 +1,28 @@
+﻿# Tables
+
+## Primary Tables
+
+The **Primary Table** for an Entity is the Table in the back-end database into which the data extracted from each
+non-Relation property is stored. Every Entity Type has exactly one Primary Table whose name is `<E>Table`, where `<E>`
+is the fully namespace-qualified name of the Entity Type (pursuant to commonality elision, see below). If the Entity
+Type is annotated with `[Table(T)]`, then the name of the Primary Table is instead exactly `T`, with no namespace
+qualification and all casing and punctuation (e.g. for `snake_case` names) preserved. Alternatively, if the Entity Type
+is annotated with `[ExcludeNamespaceFromName]`, the name of the Primary Table will be `<X>Table` where `<X>` is simply
+the name of the Entity Type. It is an error for an Entity Type to be annotated with both `[Table(T)]` and
+`[ExcludeNamespaceFromName]`.
+
+If all the Entity Types in an application's object model are in the same namespace, and none of the Entity Types are
+annotated wth `[Table(T)]`, then the common namespace will be _removed_ from the name of the Primary Table.
+
+## Relation Tables
+
+A **Relation Table** is a Table into which the data from a Relation Property is stored. Each Relation Property has
+exactly one Relation Table whose name is `<E>.<P>`, where `<E>` is the name of the owning Entity's Primary Table (wit
+the `Table` suffix stripped, if present) and `<P>` is the name of the Relation Property. Note that both of these pieces
+may be modified by annotations (e.g. `[Table(T)]` or `[Name(S)]`).
+
+## Name Uniqueness
+
+All Tables in the database must have unique names. The default naming conventions for both Primary Tables and Relation
+Table guarantee this, but the use of annotations to alter Tables' names may induce duplications. It is an error for two
+(or more) Tables (Primary Tables and/or Relation Tables) to have the same name.


### PR DESCRIPTION
This commit adds several markdown documentation files that outline the specification for how an application's object model is translated into the Kvasir data model. These docs cover Tables, Scalar Properties, Enumeration Properties, Aggregate Properties, Reference Properties, Relation Properties, Constraints, Data Conversions, and Primary Keys. The purpose of these docs is to guide the implementation of the schema translation, particularly with respect to how annotations/attributes influence the behaviors of the translation engine. These docs do not cover Reconstitution; that documentation will be added at a later date.