### PR TITLE
Annotation Bookkeeping

### DIFF
--- a/src/Kvasir/Annotations/EnumAttributes.cs
+++ b/src/Kvasir/Annotations/EnumAttributes.cs
@@ -11,7 +11,7 @@ namespace Kvasir.Annotations {
     ///   enumeration support. The <see cref="NumericAttribute"/> can be used to override the default storage behavior
     ///   and insist that the storage be a numeric type instead.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = true)]
     public sealed class NumericAttribute : Attribute {
         /// <summary>
         ///   The dot-separated path, relative to the property on which the annotation is placed, to the property to

--- a/src/Kvasir/Annotations/IdentificationAttributes.cs
+++ b/src/Kvasir/Annotations/IdentificationAttributes.cs
@@ -18,11 +18,11 @@ namespace Kvasir.Annotations {
     ///   </para>
     /// </remarks>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class CodeOnlyAttribute : Attribute {
-        /// <summary>
-        ///   The dot-separated path, relative to the property on which the annotation is placed, to the property to
-        ///   which the annotation actually applies.
-        /// </summary>
-        public string Path { internal get; init; } = "";
-    }
+    public sealed class CodeOnlyAttribute : Attribute {}
+
+    /// <summary>
+    ///   An annotation that marks a particular property or class as one that should be included in the data model.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed class IncludeInModelAttribute : Attribute { }
 }

--- a/src/Kvasir/Annotations/PathingAttributes.cs
+++ b/src/Kvasir/Annotations/PathingAttributes.cs
@@ -14,34 +14,4 @@ namespace Kvasir.Annotations {
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public sealed class ExcludeNamespaceFromNameAttribute : Attribute {}
-
-    /// <summary>
-    ///   An annotation that specifies how the properties in the path of a POCO property nested in an Aggregate are
-    ///   combined into a single Field name.
-    /// </summary>
-    /// <remarks>
-    ///   The Kvasir framework will automatically determine the name of backing Fields for POCO properties defined on
-    ///   Aggregates by concatenating the access path to each property with a specific character. The character used by
-    ///   default is dependent on the specific back-end database provider, pursuant to its syntax rules. The
-    ///   <see cref="PathSeparatorAttribute"/> directs Kvasir to use a specific character instead. This directive
-    ///   applies to all Fields dervied from the annotated Aggregate property, except for those whose names are
-    ///   explicitly specified by a <see cref="NameAttribute"/>.
-    /// </remarks>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class PathSeparatorAttribute : Attribute {
-        /// <summary>
-        ///   The separator.
-        /// </summary>
-        public char Separator { internal get; init; }
-
-        /// <summary>
-        ///   Constructs a new instance of the <see cref="PathSeparatorAttribute"/>.
-        /// </summary>
-        /// <param name="separator">
-        ///   The separator.
-        /// </param>
-        public PathSeparatorAttribute(char separator) {
-            Separator = separator;
-        }
-    }
 }

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -439,30 +439,6 @@
               if <paramref name="upperBound"/> is less than <paramref name="lowerBound"/>.
             </exception>
         </member>
-        <member name="T:Kvasir.Annotations.CodeOnlyAttribute">
-            <summary>
-              An annotation that marks a particular property as "code-only."
-            </summary>
-            <remarks>
-              <para>
-                A "code-only" property is one whose value is not stored in the back-end database. The value of such a
-                property is the domain of the application solely; examples include internal state tracking, sensitive user
-                data that is otherwise persisted, or content that is temporally dependent. Because the value of a code-only
-                property never propagates to the database, the property itself does not participate in construction
-                resolution (that is, it must have an implicit default value).
-              </para>
-              <para>
-                A <see cref="T:Kvasir.Annotations.CodeOnlyAttribute"/> that is applied to a property of aggregate type <i>without</i> a path
-                parameterization recursively applies to all nested properties.
-              </para>
-            </remarks>
-        </member>
-        <member name="P:Kvasir.Annotations.CodeOnlyAttribute.Path">
-            <summary>
-              The dot-separated path, relative to the property on which the annotation is placed, to the property to
-              which the annotation actually applies.
-            </summary>
-        </member>
         <member name="T:Kvasir.Annotations.ColumnAttribute">
             <summary>
               An annotation that specifies the column index for the Field backing a particular property.
@@ -694,6 +670,29 @@
               which the annotation actually applies.
             </summary>
         </member>
+        <member name="T:Kvasir.Annotations.CodeOnlyAttribute">
+            <summary>
+              An annotation that marks a particular property as "code-only."
+            </summary>
+            <remarks>
+              <para>
+                A "code-only" property is one whose value is not stored in the back-end database. The value of such a
+                property is the domain of the application solely; examples include internal state tracking, sensitive user
+                data that is otherwise persisted, or content that is temporally dependent. Because the value of a code-only
+                property never propagates to the database, the property itself does not participate in construction
+                resolution (that is, it must have an implicit default value).
+              </para>
+              <para>
+                A <see cref="T:Kvasir.Annotations.CodeOnlyAttribute"/> that is applied to a property of aggregate type <i>without</i> a path
+                parameterization recursively applies to all nested properties.
+              </para>
+            </remarks>
+        </member>
+        <member name="T:Kvasir.Annotations.IncludeInModelAttribute">
+            <summary>
+              An annotation that marks a particular property or class as one that should be included in the data model.
+            </summary>
+        </member>
         <member name="T:Kvasir.Annotations.NameAttribute">
             <summary>
               An annotation that specifies the name of the Field backing a particular property.
@@ -763,33 +762,6 @@
               Kvasir to ignore the POCO's namespace entirely, making a promise that the POCO's name is globally unique among
               types being treated by the framework.
             </remarks>
-        </member>
-        <member name="T:Kvasir.Annotations.PathSeparatorAttribute">
-            <summary>
-              An annotation that specifies how the properties in the path of a POCO property nested in an Aggregate are
-              combined into a single Field name.
-            </summary>
-            <remarks>
-              The Kvasir framework will automatically determine the name of backing Fields for POCO properties defined on
-              Aggregates by concatenating the access path to each property with a specific character. The character used by
-              default is dependent on the specific back-end database provider, pursuant to its syntax rules. The
-              <see cref="T:Kvasir.Annotations.PathSeparatorAttribute"/> directs Kvasir to use a specific character instead. This directive
-              applies to all Fields dervied from the annotated Aggregate property, except for those whose names are
-              explicitly specified by a <see cref="T:Kvasir.Annotations.NameAttribute"/>.
-            </remarks>
-        </member>
-        <member name="P:Kvasir.Annotations.PathSeparatorAttribute.Separator">
-            <summary>
-              The separator.
-            </summary>
-        </member>
-        <member name="M:Kvasir.Annotations.PathSeparatorAttribute.#ctor(System.Char)">
-            <summary>
-              Constructs a new instance of the <see cref="T:Kvasir.Annotations.PathSeparatorAttribute"/>.
-            </summary>
-            <param name="separator">
-              The separator.
-            </param>
         </member>
         <member name="T:Kvasir.Annotations.PrimaryKeyAttribute">
             <summary>

--- a/test/UnitTests/Kvasir/Annotations/NameAttributes.cs
+++ b/test/UnitTests/Kvasir/Annotations/NameAttributes.cs
@@ -118,27 +118,5 @@ namespace UT.Kvasir.Annotations {
             // Assert
             act.Should().ThrowExactly<ArgumentException>().WithAnyMessage();
         }
-
-        [TestMethod] public void PathSeparator() {
-            // Arrange
-            var value = ':';
-
-            // Act
-            var attr = new PathSeparatorAttribute(value);
-
-            // Assert
-            attr.Separator.Should().Be(value);
-        }
-
-        [TestMethod] public void PathSeparator_UniqueId() {
-            // Arrange
-            var attr = new PathSeparatorAttribute(' ');
-
-            // Act
-            var isUnique = ids_.Add(attr.TypeId);
-
-            // Assert
-            isUnique.Should().BeTrue();
-        }
     }
 }

--- a/test/UnitTests/Kvasir/Annotations/TagAttributes.cs
+++ b/test/UnitTests/Kvasir/Annotations/TagAttributes.cs
@@ -152,5 +152,25 @@ namespace UT.Kvasir.Annotations {
             // Assert
             isUnique.Should().BeTrue();
         }
+
+        [TestMethod] public void IncludeInModel_Construct() {
+            // Arrange
+
+            // Act
+            _ = new IncludeInModelAttribute();
+
+            // Assert
+        }
+
+        [TestMethod] public void IncludeInModel_UniqueId() {
+            // Arrange
+            var attr = new IncludeInModelAttribute();
+
+            // Act
+            var isUnique = ids_.Add(attr.TypeId);
+
+            // Assert
+            isUnique.Should().BeTrue();
+        }
     }
 }


### PR DESCRIPTION
This commit makes a couple of small changes to the annotations available in Kvasir, based on the Translation Specification:

   * The PathSeparator annotation has been removed, as it is not going to be supported at this time
   * The IncludeInModel annotation has been added, as it did not previously exist
   * The Numeric annotation for Enumeration-type properties has been updated to allow for multiple, since it accepts a Path property to apply to nested properties