### PR TITLE
IsInherited Extension for Methods

### DIFF
--- a/src/Cybele/Extensions/MethodInfo.cs
+++ b/src/Cybele/Extensions/MethodInfo.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Cybele.Extensions {
+    /// <summary>
+    ///   A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
+    ///   of the <see cref="MethodInfo"/> class.
+    /// </summary>
+    public static class MethodExtensions {
+        /// <summary>
+        ///   Determines if a method is inherited.
+        /// </summary>
+        /// <param name="self">
+        ///   The <see cref="MethodInfo"/> instance on which the extension method is inokved.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="self"/> is a method that overrides a <see langword="virtual"/>
+        ///   function inherited from a base class, or if it is a function whose implementation is inherited from a base
+        ///   class, or if it is an implementation of an interface method; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsInherited(this MethodInfo self) {
+            // Methods that are directly inherited (virtual or non-virtual) are accessed via reflection via one type but
+            // are actually declared by another type, so they must be inherited.
+            if (self.DeclaringType != self.ReflectedType) {
+                return true;
+            }
+
+            // Abstract and virtual methods that are overridden in a derived class have a "base definition" where the
+            // method was first declared which is necessarily different than the method itself; this does not work with
+            // interface implementations
+            if (self.GetBaseDefinition() != self) {
+                return true;
+            }
+
+            // As best I can tell, this is the only way to determine if a method is an interface implementation. There
+            // is no attribute or other marking on the MethodInfo, so we have to iterate over the source type's
+            // interfaces and look for the method in the mapping.
+            foreach (var intfc in self.ReflectedType!.GetInterfaces()) {
+                if (self.ReflectedType!.GetInterfaceMap(intfc).TargetMethods.Contains(self)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///   Returns <see langword="false"/>, as constructors by definition are never inherited.
+        /// </summary>
+        /// <paramm name="self">
+        ///   The <see cref="ConstructorInfo"/> instance on which the extension method is invoked.
+        /// </paramm>
+        /// <returns>
+        ///   <see langword="false"/>.
+        /// </returns>
+        public static bool IsInherited(this ConstructorInfo self) {
+            return false;
+        }
+    }
+}

--- a/src/Cybele/Intellisense.xml
+++ b/src/Cybele/Intellisense.xml
@@ -1272,6 +1272,36 @@
                <paramref name="derivedType"/> and <paramref name="ancestorType"/>; otherwise, <see langword="false"/>.
              </returns>
         </member>
+        <member name="T:Cybele.Extensions.MethodExtensions">
+            <summary>
+              A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
+              of the <see cref="T:System.Reflection.MethodInfo"/> class.
+            </summary>
+        </member>
+        <member name="M:Cybele.Extensions.MethodExtensions.IsInherited(System.Reflection.MethodInfo)">
+            <summary>
+              Determines if a method is inherited.
+            </summary>
+            <param name="self">
+              The <see cref="T:System.Reflection.MethodInfo"/> instance on which the extension method is inokved.
+            </param>
+            <returns>
+              <see langword="true"/> if <paramref name="self"/> is a method that overrides a <see langword="virtual"/>
+              function inherited from a base class, or if it is a function whose implementation is inherited from a base
+              class, or if it is an implementation of an interface method; otherwise, <see langword="false"/>.
+            </returns>
+        </member>
+        <member name="M:Cybele.Extensions.MethodExtensions.IsInherited(System.Reflection.ConstructorInfo)">
+            <summary>
+              Returns <see langword="false"/>, as constructors by definition are never inherited.
+            </summary>
+            <paramm name="self">
+              The <see cref="T:System.Reflection.ConstructorInfo"/> instance on which the extension method is invoked.
+            </paramm>
+            <returns>
+              <see langword="false"/>.
+            </returns>
+        </member>
         <member name="T:Cybele.Extensions.Nullability">
             An indication of the nullability of an aspect of a program.
         </member>

--- a/test/UnitTests/Cybele/Extensions/MethodInfo.cs
+++ b/test/UnitTests/Cybele/Extensions/MethodInfo.cs
@@ -1,0 +1,207 @@
+﻿using Cybele.Extensions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+using BF = System.Reflection.BindingFlags;
+
+namespace UT.Cybele.Extensions {
+    [TestClass, TestCategory("MethodInfo: IsInherited")]
+    public sealed class MethodInfo_IsInherited : ExtensionTests {
+        [TestMethod] public void FirstDeclarationNonVirtualMethodIsNotInherited() {
+            // Arrange
+            var method = typeof(Base).GetMethod(nameof(Base.NonVirtualFunction))!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeFalse();
+        }
+
+        [TestMethod] public void InheritedNonVirtualMethodIsInherited() {
+            // Arrange
+            var method = typeof(Derived).GetMethod(nameof(Derived.NonVirtualFunction))!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeTrue();
+        }
+
+        [TestMethod] public void FirstDeclarationAbstractMethodIsNotInherited() {
+            // Arrange
+            var method = typeof(Base).GetMethod(nameof(Base.AbstractFunction))!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeFalse();
+        }
+
+        [TestMethod] public void FirstDeclarationVirtualMethodIsNotInherited() {
+            // Arrange
+            var method = typeof(Base).GetMethod(nameof(Base.VirtualFunction))!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeFalse();
+        }
+
+        [TestMethod] public void OverriddenVirtualMethodIsInherited() {
+            // Arrange
+            var method = typeof(Derived).GetMethod(nameof(Derived.VirtualFunction))!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeTrue();
+        }
+
+        [TestMethod] public void OverriddenAbstractMethodIsInherited() {
+            // Arrange
+            var method = typeof(Derived).GetMethod(nameof(Derived.AbstractFunction))!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeTrue();
+        }
+
+        [TestMethod] public void InheritedVirtualMethodIsInherited() {
+            // Arrange
+            var attrs = BF.Public | BF.NonPublic | BF.Instance | BF.Static | BF.FlattenHierarchy;
+            var methods = typeof(MoreDerived).GetMethods(attrs);
+            var method = methods.Where(m => m.Name.Contains(nameof(Base.NotOverriddenVirtualFunction))).First()!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeTrue();
+        }
+
+        [TestMethod] public void HidingVirtualMethodIsNotInherited() {
+            // Arrange
+            var method = typeof(Derived).GetMethod(nameof(Derived.ToBeHidden))!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeFalse();
+        }
+
+        [TestMethod] public void HiddenVirtualMethodIsInherited() {
+            // Arrange
+            var methods = typeof(Derived).GetMethods();
+            var method = methods.Where(m => m.Name == nameof(Base.ToBeHidden) && m.DeclaringType == typeof(Base)).First()!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeTrue();
+        }
+
+        [TestMethod] public void DeclaredMethodInInterfaceIsNotInherited() {
+            // Arrange
+            var method = typeof(IInterface).GetMethod(nameof(IInterface.ImplicitInterfaceFunction))!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeFalse();
+        }
+
+        [TestMethod] public void ImplicitInterfaceImplementationIsInherited() {
+            // Arrange
+            var method = typeof(Derived).GetMethod(nameof(Derived.ImplicitInterfaceFunction))!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeTrue();
+        }
+
+        [TestMethod] public void ExplicitInterfaceImplementationIsInherited() {
+            // Arrange
+            var attrs = BF.Public | BF.NonPublic | BF.Instance | BF.Static | BF.FlattenHierarchy;
+            var methods = typeof(Derived).GetMethods(attrs);
+            var method = methods.Where(m => m.Name.Contains(nameof(IInterface.ExplicitInterfaceFunction))).First()!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeTrue();
+        }
+
+        [TestMethod] public void InheritedImplicitInterfaceImplementationIsInherited() {
+            // Arrange
+            var method = typeof(MoreDerived).GetMethod(nameof(MoreDerived.ImplicitInterfaceFunction))!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeTrue();
+        }
+
+        [TestMethod] public void InheritedExplicitInterfaceIplementationIsInherited() {
+            // Arrange
+            var attrs = BF.Public | BF.NonPublic | BF.Instance | BF.Static | BF.FlattenHierarchy;
+            var methods = typeof(MoreDerived).GetMethods(attrs);
+            var method = methods.Where(m => m.Name.Contains(nameof(IInterface.ExplicitInterfaceFunction))).First()!;
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeTrue();
+        }
+
+        [TestMethod] public void FirstDeclarationStaticMethodIsNotInherited() {
+            // Arrange
+            var method = typeof(Derived).GetMethod(nameof(Derived.Static))!;
+
+            // Assert
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeFalse();
+        }
+
+        [TestMethod] public void InheritedStaticMethodIsInherited() {
+            // Arrange
+            var attrs = BF.Public | BF.NonPublic | BF.Instance | BF.Static | BF.FlattenHierarchy;
+            var methods = typeof(MoreDerived).GetMethods(attrs);
+            var method = methods.Where(m => m.Name.Contains(nameof(Derived.Static))).First()!;
+
+            // Assert
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeTrue();
+        }
+
+        [TestMethod] public void ConstructIsNotInherited() {
+            // Arrange
+            var method = typeof(Derived).GetConstructors()[0];
+
+            // Act
+            var inherited = method.IsInherited();
+
+            // Assert
+            inherited.Should().BeFalse();
+        }
+    }
+}

--- a/test/UnitTests/Cybele/Extensions/_TestClass.cs
+++ b/test/UnitTests/Cybele/Extensions/_TestClass.cs
@@ -117,16 +117,29 @@ namespace UT.Cybele.Extensions {
         [AttributeUsage(AttributeTargets.All, Inherited = true)] protected class InheritedAttribute : Attribute {}
         [AttributeUsage(AttributeTargets.All, Inherited = false)] protected class UninheritedAttribute : Attribute {}
 
-        [Inherited, Uninherited] protected class Base {
+        protected interface IInterface {
+            void ImplicitInterfaceFunction();
+            void ExplicitInterfaceFunction();
+        }
+        [Inherited, Uninherited] protected abstract class Base {
+            public abstract void AbstractFunction();
             [Inherited, Uninherited] public int NonVirtualProperty => 10;
             [Inherited, Uninherited] public virtual int VirtualProperty => 100;
             [Inherited, Uninherited] public void NonVirtualFunction() {}
             [Inherited, Uninherited] public virtual void VirtualFunction() {}
+            public virtual void NotOverriddenVirtualFunction() {}
+            public virtual void ToBeHidden() {}
         }
-        protected class Derived : Base {
+        protected class Derived : Base, IInterface {
+            public override void AbstractFunction() {}
             public override int VirtualProperty => 200;
             public override void VirtualFunction() {}
+            public void ImplicitInterfaceFunction() {}
+            void IInterface.ExplicitInterfaceFunction() {}
+            public new void ToBeHidden() {}
+            public static void Static() {}
         }
+        protected class MoreDerived : Derived {}
 
 
         protected static readonly Random rand = new Random(02291996);


### PR DESCRIPTION
This commit adds a new extension method for MethodInfo and ConstructorInfo that determines if the method is inherited or not. An inherited method is any one that was not first declared in the type through which it was accessed via reflection; this includes non-virtual methods defined in base classes, overrides of virtual and abstract methods, and all interface implementations (implicit and explicit). Static methods are analyzed in the same way. Constructors are implicitly not inherited.