### PR TITLE
Scalar Property Translation

### DIFF
--- a/src/Kvasir/Annotations/DefaultAttribute.cs
+++ b/src/Kvasir/Annotations/DefaultAttribute.cs
@@ -13,7 +13,8 @@ namespace Kvasir.Annotations {
         public string Path { get; init; } = "";
 
         /// <summary>
-        ///   The default value specified by the annotation.
+        ///   The default value specified by the annotation. This value is guaranteed not to be <see langword="null"/>;
+        ///   the sentinel value <see cref="DBNull.Value"/> is used instead.
         /// </summary>
         internal object Value { get; }
 

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -565,7 +565,8 @@
         </member>
         <member name="P:Kvasir.Annotations.DefaultAttribute.Value">
             <summary>
-              The default value specified by the annotation.
+              The default value specified by the annotation. This value is guaranteed not to be <see langword="null"/>;
+              the sentinel value <see cref="F:System.DBNull.Value"/> is used instead.
             </summary>
         </member>
         <member name="M:Kvasir.Annotations.DefaultAttribute.#ctor(System.Object)">
@@ -6107,6 +6108,555 @@
                 --or--
               if <paramref name="sql"/> consists only of whitespace.
             </exception>
+        </member>
+        <member name="T:Kvasir.Translation.Translator">
+            <summary>
+              The component responsible for reflecting over CLR Types and properties to create a data model.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.CandidateKeysContaining(System.Reflection.PropertyInfo)">
+            <summary>
+              Determine the names of the Candidate Keys to which the Field backing a scalar property belongs.
+            </summary>
+            <param name="property">
+              the source <see cref="T:System.Reflection.PropertyInfo">property</see>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if any of the <c>[Unique]</c> annotations applied to <paramref name="property"/> has a non-empty
+              <see cref="P:Kvasir.Annotations.UniqueAttribute.Path">Path</see>.
+                --or--
+              if the value of any of the <c>[Unique]</c> annotations applied to <paramref name="property"/> is invalid
+              or reserved
+                --or--
+              if two or more of the <c>[Unique]</c> annotations applied to <paramref name="property"/> have the same
+              value
+                --or--
+              if two or more of the <c>[Unique]</c> annotations applied to <paramref name="property"/> are anonymous.
+            </exception>
+            <returns>
+              A finite, possibly empty enumerable of the <see cref="T:Kvasir.Schema.KeyName">key names</see> of the Candidate Keys to
+              which <paramref name="property"/> belong.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.MakeCandidateKeysFrom(System.Collections.Generic.IEnumerable{Kvasir.Translation.Translator.FieldDescriptor},System.Collections.Generic.IEnumerable{Kvasir.Schema.IField})">
+            <summary>
+              Create the set of <see cref="T:Kvasir.Schema.CandidateKey">CandidateKeys</see> from a Table's constituent Fields.
+            </summary>
+            <param name="descriptors">
+              The <see cref="T:Kvasir.Translation.Translator.FieldDescriptor">FieldDescriptors</see> from which <paramref name="fields"/> were created.
+            </param>
+            <param name="fields">
+              The actual <see cref="T:Kvasir.Schema.IField">Field</see> objects based on <paramref name="descriptors"/>. The <c>Nth</c>
+              Field was created from the <c>Nth</c> FieldDescriptor.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if any two of the Candidate Keys that would be produced consist of the same set of Fields.
+            </exception>
+            <returns>
+              A finite, possibly empty enumerable of the <see cref="T:Kvasir.Schema.CandidateKey">Candidate Keys</see> defined by the
+              <paramref name="descriptors"/>, populated with elements of <paramref name="fields"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.ColumnOf(System.Reflection.PropertyInfo)">
+            <summary>
+              Determine the <c>0</c>-based column index of the first Field corresponding to a property. This function is
+              safe to use for any kind of property.
+            </summary>
+            <param name="property">
+              The source <see cref="T:System.Reflection.PropertyInfo">property</see>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if the <c>[Column]</c> annotation applied to <paramref name="property"/> has a negative value
+            </exception>
+            <returns>
+              A <c>SOME</c> instance wrapping the <c>0</c>-based column index of the first Field backing
+              <paramref name="property"/> if such a column index is specified; otherwise, a <c>NONE</c> instance.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.ConverterFor(System.Reflection.PropertyInfo)">
+            <summary>
+              Determine the <see cref="T:Cybele.Core.DataConverter"/> with which extrinsic transformations for a Field backing a
+              scalar property are to be performed.
+            </summary>
+            <param name="property">
+              The source <see cref="T:System.Reflection.PropertyInfo">property</see>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if <paramref name="property"/> is annotated with multiple <c>[DataConverter]</c> attributes
+                --or--
+              if the <c>[DataConverter]</c> annotation applied to <paramref name="property"/> has a non-empty
+              <see cref="P:Kvasir.Annotations.DataConverterAttribute.Path">Path</see>
+                --or--
+              if the <c>[DataConverter]</c> annotation applied to <paramref name="property"/> has a non-empty
+              <see cref="P:Kvasir.Annotations.DataConverterAttribute.UserError">user error</see>
+                --or--
+              if the value of the <c>[DataConverter]</c> annotation applied to <paramref name="property"/> has a
+              <see cref="P:Cybele.Core.DataConverter.SourceType">SourceType</see> that is not the same as the CLR type of
+              <paramref name="property"/>, with nullability stripped
+                --or--
+              if the value of <c>[DataConverter]</c> annotation applied to <paramref name="property"/> has a
+              <see cref="P:Cybele.Core.DataConverter.ResultType">ResultType</see> that is not supported.
+            </exception>
+            <returns>
+              The <see cref="T:Cybele.Core.DataConverter"/> to be used for extrinsic transformations for the Field backing
+              <paramref name="property"/>, which may be the
+              <see cref="M:Cybele.Core.DataConverter.Identity(System.Type)">identity conversion</see>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.DefaultValueOf(System.Reflection.PropertyInfo,Kvasir.Schema.IsNullable)">
+            <summary>
+              Get the pre-conversion default value for a Field backing a scalar property.
+            </summary>
+            <param name="property">
+              The source <see cref="T:System.Reflection.PropertyInfo">property</see>.
+            </param>
+            <param name="nullability">
+              The nullability of the Field backing <paramref name="property"/>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if <paramref name="property"/> is annotated with multiple <c>[Default]</c> attributes
+                --or--
+              if the <c>[Default]</c> annotation applied to <paramref name="property"/> has a non-empty
+              <see cref="P:Kvasir.Annotations.DefaultAttribute.Path">Path</see>
+                --or--
+              if <paramref name="nullability"/> is <see cref="F:Kvasir.Schema.IsNullable.No"/> but the value of the <c>[Default]</c>
+              annotation applied to <paramref name="property"/> is <see langword="null"/>
+                --or--
+              if the value of the <c>[Default]</c> annotation applied to <paramref name="property"/> is an array, even
+              if it is a single-element array whose element is the same type as that of <paramref name="property"/>
+                --or--
+              if the value of the <c>[Default]</c> annotation applied to <paramref name="property"/> is not
+              <see langword="null"/>, not an array, and is also not the of the expected type.
+            </exception>
+            <returns>
+              A <c>SOME</c> instance wrapping the unconverted (i.e. raw) default value for the Field backing
+              <paramref name="property"/> if such a default value is specified; otherwise, a <c>NONE</c> instance.
+              The default value for <see cref="T:System.DateTime"/>- and <see cref="T:System.Guid"/>-type properties will be parsed from
+              the original string.
+            </returns>
+        </member>
+        <member name="T:Kvasir.Translation.Translator.FieldDescriptor">
+            <summary>
+              A descriptor of a single back-end database Field.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.FieldDescriptor.#ctor(System.Type,System.String,Kvasir.Schema.FieldName,System.Type,Optional.Option{System.Int32},Kvasir.Schema.IsNullable,Optional.Option{System.Object},System.Boolean,Cybele.Core.DataConverter,System.Collections.Generic.IReadOnlyList{Kvasir.Schema.KeyName})">
+            <summary>
+              A descriptor of a single back-end database Field.
+            </summary>
+        </member>
+        <member name="T:Kvasir.Translation.Translator.TypeDescriptor">
+            <summary>
+              A descriptor of a single in-source CLR Type, translated into two or more Fields.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.TypeDescriptor.#ctor(System.Type,System.Collections.Generic.IReadOnlyList{Kvasir.Translation.Translator.FieldDescriptor})">
+            <summary>
+              A descriptor of a single in-source CLR Type, translated into two or more Fields.
+            </summary>
+        </member>
+        <member name="T:Kvasir.Translation.Translator.PropertyDescriptor">
+            <summary>
+              A descriptor of a single in-source property of a CLR Type, translated into at least one Field.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.PropertyDescriptor.#ctor(System.Collections.Generic.IReadOnlyList{Kvasir.Translation.Translator.FieldDescriptor})">
+            <summary>
+              A descriptor of a single in-source property of a CLR Type, translated into at least one Field.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.NameOf(System.Reflection.PropertyInfo)">
+            <summary>
+              Determine the name of a Field backing a scalar property, using a combination of the propert's native CLR
+              name and user-provided attributes.
+            </summary>
+            <param name="property">
+              The source <see cref="T:System.Reflection.PropertyInfo">property</see>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if <paramref name="property"/> is annotated with multiple <c>[Name]</c> attributes
+                --or--
+              if the <c>[Name]</c> annotation applied to <paramref name="property"/> has a non-empty
+              <see cref="P:Kvasir.Annotations.NameAttribute.Path">Path</see>
+                --or--
+              if the value of the <c>[Name]</c> annotation applied to <paramref name="property"/> is invalid
+                --or--
+              if the value of the <c>[Name]</c> annotation applied to <paramref name="property"/> is the native name of
+              the property.
+            </exception>
+            <returns>
+              The <see cref="T:Kvasir.Schema.FieldName">name</see> of the Field backing <paramref name="property"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.NameOf(System.Type)">
+            <summary>
+              Determine the name of the primary Table backing an Entity type.
+            </summary>
+            <param name="entity">
+              The source <see cref="T:System.Type">Entity type</see>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if <paramref name="entity"/> is annotated with both <c>[Table]</c> or <c>[ExcludeNamespaceFromName]</c>
+                --or--
+              if the value of the <c>[Table]</c> annotation applied to <paramref name="entity"/> is invalid
+                --or--
+              if the value of the <c>[Table]</c> annotation applied to <paramref name="entity"/> is the same as the name
+              of the Table that would have otherwise been ascertained.
+            </exception>
+            <returns>
+              The <see cref="T:Kvasir.Schema.TableName">name</see> of the primary Table backing <paramref name="entity"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.NullabilityOf(System.Reflection.PropertyInfo)">
+            <summary>
+              Determine the nullability imparted by a property, using a combination of the property's native CLR type
+              and user-provided attributes. This function is safe to use for any kind of property.
+            </summary>
+            <param name="property">
+              The source <see cref="T:System.Reflection.PropertyInfo">property</see>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if <paramref name="property"/> is annotated with both <c>[Nullable]</c> and <c>[NonNullable]</c>
+                --or--
+              if <paramref name="property"/> is an inherently nullable property and it is still annotated with
+              <c>[Nullable]</c>
+                --or--
+              if <paramref name="property"/> is an inherently non-nullable property and it is still annotated with
+              <c>[NonNullable]</c>
+            </exception>
+            <returns>
+              <see cref="F:Kvasir.Schema.IsNullable.Yes"/> if <paramref name="property"/> implies nullability for any corresponding
+              Fields; otherwise, <see cref="F:Kvasir.Schema.IsNullable.No"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.IsInPrimaryKey(System.Reflection.PropertyInfo,Kvasir.Schema.IsNullable)">
+            <summary>
+              Determines if a Field backing a scalar property is explicitly proscribed as being part of the Primary Key
+              of the owning Table.
+            </summary>
+            <param name="property">
+              The source <see cref="T:System.Reflection.PropertyInfo">property</see>.
+            </param>
+            <param name="nullability">
+              The nullability of the Field backing <paramref name="property"/>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if <paramref name="property"/> is annotated with multiple <c>[PrimaryKey]</c> attributes
+                --or--
+              if the <c>[PrimaryKey]</c> annotation applied to <paramref name="property"/> has a non-empty
+              <see cref="P:Kvasir.Annotations.PrimaryKeyAttribute.Path">Path</see>
+                --or--
+              if <paramref name="nullability"/> is <see cref="F:Kvasir.Schema.IsNullable.Yes"/> but the <c>[PrimaryKey]</c> annotation
+              is present on <paramref name="property"/>.
+            </exception>
+            <returns>
+              <see langword="true"/> if <paramref name="property"/> is annotated with a <c>[PrimaryKey]</c> attribute;
+              otherwise, <see langword="false"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.CreatePrimaryKeyFor(System.Type,System.Collections.Generic.IEnumerable{Kvasir.Translation.Translator.FieldDescriptor},System.Collections.Generic.IEnumerable{Kvasir.Schema.IField},System.Collections.Generic.IList{Kvasir.Schema.CandidateKey})">
+            <summary>
+              Deduce the <see cref="T:Kvasir.Schema.PrimaryKey">Primary Key</see> for a the Table backing an Entity Type.
+            </summary>
+            <param name="entity">
+              The source Entity Type.
+            </param>
+            <param name="descriptors">
+              The <see cref="T:Kvasir.Translation.Translator.FieldDescriptor">Field Descriptors</see> for <paramref name="entity"/>.
+            </param>
+            <param name="fields">
+              The actual <see cref="T:Kvasir.Schema.IField">Field</see> objects based on <paramref name="descriptors"/>. The <c>Nth</c>
+              Field was created from the <c>Nth</c> FieldDescriptor.
+            </param>
+            <param name="candidates">
+              The <see cref="T:Kvasir.Schema.CandidateKey">Candidate Keys</see> for <paramref name="entity"/>. If a Candidate Key is
+              deduced as the Primary Key, it will be <i>REMOVED</i> from this list.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if <paramref name="entity"/> is annotated with a <c>[NamedPrimaryKey]</c> whose value is invalid
+                --or--
+              if <paramref name="entity"/> is annotated with a <c>[NamedPrimaryKey]</c> and the deduced Primary Key is a
+              named Candidate Key
+                --or--
+              if the Primary Key of <paramref name="entity"/> cannot be deduced.
+            </exception>
+            <returns>
+              The <see cref="T:Kvasir.Schema.PrimaryKey">Primary Key</see> of the Table backing <paramref name="entity"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.TranslateScalar(System.Reflection.PropertyInfo)">
+            <summary>
+              Translate a scalar property into a <see cref="T:Kvasir.Translation.Translator.FieldDescriptor"/>.
+            </summary>
+            <param name="property">
+              The source <see cref="T:System.Reflection.PropertyInfo">property</see>.
+            </param>
+            <returns>
+              The translation of <paramref name="property"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.TranslateEntity(System.Type)">
+            <summary>
+              Translate a single Entity Type.
+            </summary>
+            <param name="clr">
+              The Entity Type.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if <paramref name="clr"/> is not a valid Entity Type
+                --or--
+              if the Translation of <paramref name="clr"/> contains any Tables with exactly 0 or 1 back-end Fields
+                --or--
+              if the name of any Tables in the Translation of <paramref name="clr"/> has a name that is not globally
+              unique
+                --or--
+              if the Translation of <paramref name="clr"/> contains any Table with two or more Field sharing a single
+              name
+                --or--
+              if the Translation of <paramref name="clr"/> contains any Table in which one or more Candidate Keys is a
+              superset (not necessarily proper) of the Table's Primary Key
+                --or--
+              if the Translation of <paramref name="clr"/> contains any Table in which the name of the Primary Key is
+              the same as the name of any of the Table's Candidate Keys.
+            </exception>
+            <returns>
+              The Translation of <paramref name="clr"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.MakeFieldsFrom(System.Collections.Generic.IEnumerable{Kvasir.Translation.Translator.FieldDescriptor})">
+            <summary>
+              Converts one or more <see cref="T:Kvasir.Translation.Translator.FieldDescriptor">FieldDescriptors</see> into their corresponding
+              <see cref="T:Kvasir.Schema.IField">Fields</see>.
+            </summary>
+            <param name="descriptors">
+              The <see cref="T:Kvasir.Translation.Translator.FieldDescriptor">FieldDescriptors</see> describing the schema model.
+            </param>
+            <returns>
+              A finite enumerable of <see cref="T:Kvasir.Schema.IField">Fields</see>, one for each source descriptor in the same order
+              thereof.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.TranslateProperty(System.Reflection.PropertyInfo)">
+            <summary>
+              Translate a single CLR property of a particular.
+            </summary>
+            <param name="property">
+              The <see cref="T:System.Reflection.PropertyInfo">CLR property</see> to translate.
+            </param>
+            <returns>
+              The <see cref="T:Kvasir.Translation.Translator.PropertyDescriptor"/> describing <paramref name="property"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.TranslateType(System.Type)">
+            <summary>
+              Translate a single CLR Type, which may or may not be an Entity Type.
+            </summary>
+            <remarks>
+              Very few assumptions about the semantic of the source Type are made. In particular, this function does not
+              create bona fide schema structures (e.g. Candidate Key, Primary Keys, etc.), nor does it enforce any
+              requirements about Fields (e.g. minimum of two, all unique names, etc.). This makes the function suitable
+              for Translating Entity Types and also for Translating Aggregate Types and Synthetic Types, where the
+              result is one piece of a larger Table whose final form will be impacted by other Translations.
+            </remarks>
+            <param name="clr">
+              The source <see cref="T:System.Type">CLR Type</see>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if the annotations of the Fields in the Translation of <paramref name="clr"/> leave gaps in the assigned
+              or implied column indices.
+            </exception>
+            <returns>
+              The <see cref="T:Kvasir.Translation.Translator.TypeDescriptor"/> of the back-end schema for <paramref name="clr"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.ModelPropertiesOf(System.Type)">
+            <summary>
+              Generate the set of top-level properties of a CLR Type that are part of its back-end data model.
+            </summary>
+            <param name="clr">
+              The source <see cref="T:System.Type">CLR Type</see>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if any property of <paramref name="clr"/> is annotated as both <c>[IncludeInModel]</c> and
+              <c>[CodeOnly</c>
+                --or--
+              if any property of <paramref name="clr"/> that is read-only, an indexer, or is inherited (from either a
+              base class or an interface) is annotated as either <c>[IncludeInModel]</c> or <c>[CodeOnly]</c>
+                --or--
+              if any public, readable, instance property of <paramref name="clr"/> is annotated as
+              <c>[IncludeInModel]</c>
+                --or--
+              if any property that is either non-public, <see langword="static"/> or an indexer is annotated as
+              <c>[CodeOnly]</c>.
+            </exception>
+            <returns>
+              A finite enumerable of <see cref="T:System.Reflection.PropertyInfo">properties</see> that are part of the back-end data model
+              for <paramref name="clr"/>, either in its Principal Table or as a Relation. The order of the properties is
+              undefined but is guaranteed to be the same on consecutive invocations for the exact same CLR Type.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.RecordFields(System.Collections.Generic.IEnumerable{Kvasir.Translation.Translator.FieldDescriptor},Cybele.Collections.StickyList{Kvasir.Translation.Translator.FieldDescriptor})">
+            <summary>
+              Place the Field Descriptors generated during the Translation of a property into a running list tracking
+              the Fields' ultimate columnar positions.
+            </summary>
+            <param name="descriptors">
+              The <see cref="T:Kvasir.Translation.Translator.FieldDescriptor">FieldDescriptors</see>.
+            </param>
+            <param name="into">
+              The running list, using stickiness to indicate a position required by an annotation.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if any of the element of <paramref name="descriptors"/> has a specified column index that is already
+              occupied in <paramref name="into"/> by a "sticky" item.
+            </exception>
+        </member>
+        <member name="P:Kvasir.Translation.Translator.Item(System.Type)">
+            <summary>
+              Translate a CLR Type.
+            </summary>
+            <param name="clr">
+              The source CLR <see cref="T:System.Type"/>.
+            </param>
+            <returns>
+              [GET] The translation associated with <paramref name="clr"/>, creating it if necessary. Note that if
+              <paramref name="clr"/> has any relation-type properties, additional Entity Types may be translated as
+              well.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.#ctor">
+            <summary>
+              Create a new <see cref="T:Kvasir.Translation.Translator"/> with default settings.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.#ctor(Kvasir.Core.Settings)">
+            <summary>
+              Create a new <see cref="T:Kvasir.Translation.Translator"/> with custom settings.
+            </summary>
+            <param name="settings">
+              The custom <see cref="T:Kvasir.Core.Settings">settings</see>
+            </param>
+            <remarks>
+              Note that the <paramref name="settings"/> are not currently used: they exist as a forward-compatible
+              customization point to provide control over Translation behaviors.
+            </remarks>
+        </member>
+        <member name="T:Kvasir.Translation.Translator.PropertyCategory">
+            <summary>
+              A representation of the categories of property.
+            </summary>
+        </member>
+        <member name="F:Kvasir.Translation.Translator.PropertyCategory.Scalar">
+            A scalar property, corresponding to exactly one backing Field
+        </member>
+        <member name="F:Kvasir.Translation.Translator.PropertyCategory.Enumeration">
+            An enumeration property, corresponding to exactly one backing Field with automatic support for an
+            inclusion <c>CHECK</c> constraint
+        </member>
+        <member name="F:Kvasir.Translation.Translator.PropertyCategory.Aggregate">
+            An aggregate property, corresponding to one or more backing Fields
+        </member>
+        <member name="F:Kvasir.Translation.Translator.PropertyCategory.Reference">
+            A reference property, corresponding to a Foreign Key against another Entity
+        </member>
+        <member name="F:Kvasir.Translation.Translator.PropertyCategory.Relation">
+            A relation property, corresponding to another Table altogether
+        </member>
+        <member name="M:Kvasir.Translation.Translator.CategoryOf(System.Reflection.PropertyInfo)">
+            <summary>
+              Determine the categorization of the Field or Fields backing a property.
+            </summary>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if the <see cref="P:System.Reflection.PropertyInfo.PropertyType">property type</see> of <paramref name="property"/> is
+              <see cref="T:System.Object"/>, <see cref="T:System.ValueType"/>, or <see cref="T:System.Enum"/>
+                --or--
+              if the <see cref="P:System.Reflection.PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is an
+              interface
+                --or--
+              if the <see cref="P:System.Reflection.PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is a
+              <see cref="T:System.Delegate">delegate</see>
+                --or--
+              if the <see cref="P:System.Reflection.PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is
+              <c>dynamic</c>
+                --or--
+              if the <see cref="P:System.Reflection.PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is from
+              an assembly other than that in which the <see cref="T:Kvasir.Translation.Translator"/> was constructed
+                --or--
+              if the <see cref="P:System.Reflection.PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is
+              a closed generic class (open generics are syntactically invalid, and closed generic structs are allowed)
+                --or--
+              if the <see cref="P:System.Reflection.PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is
+              <see langword="abstract"/>
+            </exception>
+            <returns>
+              The <see cref="T:Kvasir.Translation.Translator.PropertyCategory">category</see> of the Field or Fields backing
+              <paramref name="property"/>.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.CheckEntityType(System.Type)">
+            <summary>
+              Perform error checking to ensure that a particular Type can be an Entity Type.
+            </summary>
+            <param name="entity">
+              The source <see cref="T:System.Type"/>.
+            </param>
+            <exception cref="T:Kvasir.Exceptions.KvasirException">
+              if <paramref name="entity"/> is a primitive type
+                --or--
+              if <paramref name="entity"/> is an enumeration type
+                --or--
+              if <paramref name="entity"/> is a struct or record struct type
+                --or--
+              if <paramref name="entity"/> is an interface
+                --or--
+              if <paramref name="entity"/> is an open or closed generic type
+                --or--
+              if <paramref name="entity"/> is an <see langword="abstract"/> type
+            </exception>
+        </member>
+        <member name="T:Kvasir.Translation.PrincipalTableDef">
+            <summary>
+              A representation of the data model for a Principal Table (rather than a Relation Table).
+            </summary>
+        </member>
+        <member name="P:Kvasir.Translation.PrincipalTableDef.Table">
+            <summary>
+              The <see cref="T:Kvasir.Schema.ITable">Table</see>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.PrincipalTableDef.#ctor(Kvasir.Schema.ITable)">
+            <summary>
+              Construct a new <see cref="T:Kvasir.Translation.PrincipalTableDef"/>.
+            </summary>
+            <param name="table">
+              The <see cref="P:Kvasir.Translation.PrincipalTableDef.Table">Principal Table</see>.
+            </param>
+        </member>
+        <member name="T:Kvasir.Translation.Translation">
+            <summary>
+              A translation of a single CLR Type.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Translation.Translation.CLRSource">
+            <summary>
+              The source CLR <see cref="T:System.Type"/>.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Translation.Translation.Principal">
+            <summary>
+              The definition of the principal Table of the <see cref="P:Kvasir.Translation.Translation.CLRSource">source Type</see>.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.Translation.#ctor(System.Type,Kvasir.Translation.PrincipalTableDef)">
+            <summary>
+              Construct a new <see cref="T:Kvasir.Translation.Translation"/>.
+            </summary>
+            <param name="clr">
+              The <see cref="P:Kvasir.Translation.Translation.CLRSource">source CLR Type</see>.
+            </param>
+            <param name="principal">
+              The <see cref="P:Kvasir.Translation.Translation.Principal">principal Table definition</see>.
+            </param>
         </member>
     </members>
 </doc>

--- a/src/Kvasir/Translation/CandidateKeys.cs
+++ b/src/Kvasir/Translation/CandidateKeys.cs
@@ -1,0 +1,137 @@
+﻿using Kvasir.Annotations;
+using Kvasir.Exceptions;
+using Kvasir.Schema;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Determine the names of the Candidate Keys to which the Field backing a scalar property belongs.
+        /// </summary>
+        /// <param name="property">
+        ///   the source <see cref="PropertyInfo">property</see>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if any of the <c>[Unique]</c> annotations applied to <paramref name="property"/> has a non-empty
+        ///   <see cref="UniqueAttribute.Path">Path</see>.
+        ///     --or--
+        ///   if the value of any of the <c>[Unique]</c> annotations applied to <paramref name="property"/> is invalid
+        ///   or reserved
+        ///     --or--
+        ///   if two or more of the <c>[Unique]</c> annotations applied to <paramref name="property"/> have the same
+        ///   value
+        ///     --or--
+        ///   if two or more of the <c>[Unique]</c> annotations applied to <paramref name="property"/> are anonymous.
+        /// </exception>
+        /// <returns>
+        ///   A finite, possibly empty enumerable of the <see cref="KeyName">key names</see> of the Candidate Keys to
+        ///   which <paramref name="property"/> belong.
+        /// </returns>
+        private static IEnumerable<KeyName> CandidateKeysContaining(PropertyInfo property) {
+            bool anonymousSeen = false;
+            var namesSeen = new HashSet<string>();
+            foreach (var annotation in property.GetCustomAttributes<UniqueAttribute>()) {
+                // It is an error for the [Unique] attribute of a scalar property to have a non-empty <Path> value
+                if (annotation.Path != "") {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        $"path \"{annotation.Path}\" of [Unique] annotation does not exist"
+                    );
+                }
+
+                // It is an error for the value of a [Unique] annotation to be invalid as the name of a Key; currently,
+                // the only restrictions on this is that the name must have non-zero length and cannot begin with @@@
+                // (the latter is reserved, and there is no back-end awareness)
+                if (annotation.Name == "") {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        $"[Unique] name argument \"{annotation.Name}\" is not a valid Candidate Key name"
+                    );
+                }
+                if (!annotation.IsAnonymous && annotation.Name.StartsWith(UniqueAttribute.ANONYMOUS_PREFIX)) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        $"[Unique] name argument \"{annotation.Name}\" begins with reserved character sequence " +
+                        UniqueAttribute.ANONYMOUS_PREFIX
+                    );
+                }
+
+                // It is an error for the value of two or more [Unique] annotations applied to the same scalar property
+                // to have the same name; note that this doesn't cover repeated anonymous [Unique] annotations
+                if (!namesSeen.Add(annotation.Name)) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        $"two or more [Unique] annotations have the same name ('{annotation.Name}')"
+                    );
+                }
+
+                // It is an error for a single property to be annotated with multiple [Unique] attributes that do not
+                // specify a name (i.e. are "anonymous")
+                if (anonymousSeen && annotation.IsAnonymous) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        "two or more [Unique] annotations are anonymous (i.e. no name is provided)"
+                    );
+                }
+                anonymousSeen |= annotation.IsAnonymous;
+
+                // No errors detected
+                yield return new KeyName(annotation.Name);
+            }
+        }
+
+        /// <summary>
+        ///   Create the set of <see cref="CandidateKey">CandidateKeys</see> from a Table's constituent Fields.
+        /// </summary>
+        /// <param name="descriptors">
+        ///   The <see cref="FieldDescriptor">FieldDescriptors</see> from which <paramref name="fields"/> were created.
+        /// </param>
+        /// <param name="fields">
+        ///   The actual <see cref="IField">Field</see> objects based on <paramref name="descriptors"/>. The <c>Nth</c>
+        ///   Field was created from the <c>Nth</c> FieldDescriptor.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if any two of the Candidate Keys that would be produced consist of the same set of Fields.
+        /// </exception>
+        /// <returns>
+        ///   A finite, possibly empty enumerable of the <see cref="CandidateKey">Candidate Keys</see> defined by the
+        ///   <paramref name="descriptors"/>, populated with elements of <paramref name="fields"/>.
+        /// </returns>
+        private static IEnumerable<CandidateKey> MakeCandidateKeysFrom(IEnumerable<FieldDescriptor> descriptors,
+            FieldSeq fields) {
+
+            var keys = new Dictionary<KeyName, IList<IField>>();
+            foreach (var (descriptor, field) in descriptors.Zip(fields)) {
+                foreach (var candidate in descriptor.KeyMemberships) {
+                    keys.TryAdd(candidate, new List<IField>());
+                    Debug.Assert(!keys[candidate].Contains(field));
+                    keys[candidate].Add(field);
+                }
+            }
+
+            var reprs = new Dictionary<string, KeyName>();
+            foreach (var (name, members) in keys) {
+                // Using a string character here is technically dangerous, as the vertical bar is not a reserved
+                // character and therefore could appear naturally in a Field name via [Name], but this is unlikely and
+                // the alternative (using a collection with a custom aggregating hash function) is overkill
+                //
+                // No need to sort the Fields because the orders will be consistent with the iteration from the above
+                // loop, so e.g. exactly one of (A, B, C) and (A, C, B) is possible
+                var repr = string.Join('|', members.Select(f => f.Name));
+                if (reprs.TryGetValue(repr, out KeyName? existing)) {
+                    throw new KvasirException(
+                        $"Error translating type {descriptors.First().SourceType.Name}: " +
+                        $"Candidate Key '{name}' and '{existing}' are comprised of the same Fields " +
+                        $"({repr.Replace("|", ", ")})"
+                    );
+                }
+
+                reprs[repr] = name;
+                yield return new CandidateKey(name, members);
+            }
+        }
+    }
+}

--- a/src/Kvasir/Translation/ColumnOrdering.cs
+++ b/src/Kvasir/Translation/ColumnOrdering.cs
@@ -1,0 +1,42 @@
+﻿using Kvasir.Annotations;
+using Kvasir.Exceptions;
+using Optional;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Determine the <c>0</c>-based column index of the first Field corresponding to a property. This function is
+        ///   safe to use for any kind of property.
+        /// </summary>
+        /// <param name="property">
+        ///   The source <see cref="PropertyInfo">property</see>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if the <c>[Column]</c> annotation applied to <paramref name="property"/> has a negative value
+        /// </exception>
+        /// <returns>
+        ///   A <c>SOME</c> instance wrapping the <c>0</c>-based column index of the first Field backing
+        ///   <paramref name="property"/> if such a column index is specified; otherwise, a <c>NONE</c> instance.
+        /// </returns>
+        private static Option<int> ColumnOf(PropertyInfo property) {
+            var annotation = property.GetCustomAttribute<ColumnAttribute>();
+
+            // If there is no [Column] annotation, then there is no explicit column index
+            if (annotation is null) {
+                return Option.None<int>();
+            }
+
+            // It is an error for the [Column] index to be negative
+            if (annotation.Column < 0) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"[Column] index {annotation.Column} is negative"
+                );
+            }
+
+            // No errors detected
+            return Option.Some(annotation.Column);
+        }
+    }
+}

--- a/src/Kvasir/Translation/DataConverters.cs
+++ b/src/Kvasir/Translation/DataConverters.cs
@@ -1,0 +1,100 @@
+﻿using Cybele.Core;
+using Cybele.Extensions;
+using Kvasir.Annotations;
+using Kvasir.Exceptions;
+using Kvasir.Schema;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Determine the <see cref="DataConverter"/> with which extrinsic transformations for a Field backing a
+        ///   scalar property are to be performed.
+        /// </summary>
+        /// <param name="property">
+        ///   The source <see cref="PropertyInfo">property</see>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if <paramref name="property"/> is annotated with multiple <c>[DataConverter]</c> attributes
+        ///     --or--
+        ///   if the <c>[DataConverter]</c> annotation applied to <paramref name="property"/> has a non-empty
+        ///   <see cref="DataConverterAttribute.Path">Path</see>
+        ///     --or--
+        ///   if the <c>[DataConverter]</c> annotation applied to <paramref name="property"/> has a non-empty
+        ///   <see cref="DataConverterAttribute.UserError">user error</see>
+        ///     --or--
+        ///   if the value of the <c>[DataConverter]</c> annotation applied to <paramref name="property"/> has a
+        ///   <see cref="DataConverter.SourceType">SourceType</see> that is not the same as the CLR type of
+        ///   <paramref name="property"/>, with nullability stripped
+        ///     --or--
+        ///   if the value of <c>[DataConverter]</c> annotation applied to <paramref name="property"/> has a
+        ///   <see cref="DataConverter.ResultType">ResultType</see> that is not supported.
+        /// </exception>
+        /// <returns>
+        ///   The <see cref="DataConverter"/> to be used for extrinsic transformations for the Field backing
+        ///   <paramref name="property"/>, which may be the
+        ///   <see cref="DataConverter.Identity">identity conversion</see>.
+        /// </returns>
+        private static DataConverter ConverterFor(PropertyInfo property) {
+            // It is an error for a property to be annotated with multiple [Name] attributes
+            var annotations = property.GetCustomAttributes<DataConverterAttribute>();
+            if (annotations.Count() > 1) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    "multiple [DataConverter] annotations encountered"
+                );
+            }
+            var annotation = annotations.FirstOrDefault();
+
+            // If there is no [DataConverter] annotation, then an identity conversion is used
+            if (annotation is null) {
+                return DataConverter.Identity(property.PropertyType);
+            }
+
+            // It is an error for the [DataConverter] attribute of a scalar property to have a non-empty <Path> value
+            if (annotation.Path != "") {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"path \"{annotation.Path}\" of [DataConverter] annotation does not exist"
+                );
+            }
+
+            // It is an error for the [DataConverter] attribute of a scalar property to have a populated <UserError>
+            if (annotation.UserError is not null) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"data provided to [DataConverter] is invalid ({annotation.UserError})"
+                );
+            }
+
+            // The IDataConverter interface required by the [DataConverter] attribute requires that classes implement
+            // both the Convert and Revert APIs, producing a bidirectional converter
+            var converter = annotation.DataConverter;
+            Debug.Assert(converter.IsBidirectional);
+
+            // It is an error for the <SourceType> of the value of a [DataConverter] annotation to be different than the
+            // property's CLR type, modulo nullability for primitives and structs; by using IsInstanceOf, we are able
+            // to support the desirable argument variance
+            if (!property.PropertyType.IsInstanceOf(converter.SourceType)) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"[DataConverter] annotation operates on {converter.SourceType.Name} for " +
+                    $"Field of type {property.PropertyType.Name}"
+                );
+            }
+
+            // It is an error for the <ResultType> of the value of a [DataConveter] annotation to be an unsupported type
+            if (!DBType.IsSupported(converter.ResultType)) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"result type {converter.ResultType.Name} of [DataConverter] annotation is not supported"
+                );
+            }
+
+            // No errors detected
+            return converter;
+        }
+    }
+}

--- a/src/Kvasir/Translation/Defaults.cs
+++ b/src/Kvasir/Translation/Defaults.cs
@@ -1,0 +1,135 @@
+﻿using Cybele.Extensions;
+using Kvasir.Annotations;
+using Kvasir.Exceptions;
+using Kvasir.Schema;
+using Optional;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Get the pre-conversion default value for a Field backing a scalar property.
+        /// </summary>
+        /// <param name="property">
+        ///   The source <see cref="PropertyInfo">property</see>.
+        /// </param>
+        /// <param name="nullability">
+        ///   The nullability of the Field backing <paramref name="property"/>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if <paramref name="property"/> is annotated with multiple <c>[Default]</c> attributes
+        ///     --or--
+        ///   if the <c>[Default]</c> annotation applied to <paramref name="property"/> has a non-empty
+        ///   <see cref="DefaultAttribute.Path">Path</see>
+        ///     --or--
+        ///   if <paramref name="nullability"/> is <see cref="IsNullable.No"/> but the value of the <c>[Default]</c>
+        ///   annotation applied to <paramref name="property"/> is <see langword="null"/>
+        ///     --or--
+        ///   if the value of the <c>[Default]</c> annotation applied to <paramref name="property"/> is an array, even
+        ///   if it is a single-element array whose element is the same type as that of <paramref name="property"/>
+        ///     --or--
+        ///   if the value of the <c>[Default]</c> annotation applied to <paramref name="property"/> is not
+        ///   <see langword="null"/>, not an array, and is also not the of the expected type.
+        /// </exception>
+        /// <returns>
+        ///   A <c>SOME</c> instance wrapping the unconverted (i.e. raw) default value for the Field backing
+        ///   <paramref name="property"/> if such a default value is specified; otherwise, a <c>NONE</c> instance.
+        ///   The default value for <see cref="DateTime"/>- and <see cref="Guid"/>-type properties will be parsed from
+        ///   the original string.
+        /// </returns>
+        private static Option<object?> DefaultValueOf(PropertyInfo property, IsNullable nullability) {
+            // It is an error for a property to be annotated with multiple [Default] attributes
+            var annotations = property.GetCustomAttributes<DefaultAttribute>();
+            if (annotations.Count() > 1) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    "multiple [Default] annotations encountered"
+                );
+            }
+            var annotation = annotations.FirstOrDefault();
+
+            // If there is no [Default] annotation, then there is no default value
+            if (annotation is null) {
+                return Option.None<object?>();
+            }
+
+            // It is an error for the [Default] attribute of a scalar property to have a non-empty <Path> value
+            if (annotation.Path != "") {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"path \"{annotation.Path}\" of [Default] annotation does not exist"
+                );
+            }
+
+            // It is an error for the [Default] value of a non-nullable Field to be 'null'
+            if (annotation.Value == DBNull.Value && nullability == IsNullable.No) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    "[Default] value of 'null' is not valid for a non-nullable Field"
+                );
+            }
+
+            // If the value of the [Default] annotation is 'null', then the rest of the checks are unnecessary
+            if (annotation.Value == DBNull.Value) {
+                return Option.Some<object?>(null);
+            }
+
+            // It is an error for the [Default] value of a Field to be an array
+            if (annotation.Value.GetType().IsArray) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    "[Default] value cannot be an array"
+                );
+            }
+
+            // It is an error for the [Default] value of a Field to be different than its pre-conversion CLR type; for
+            // Fields whose pre-conversion CLR type is 'DateTime' or 'Guid', the [Default] value must be a 'string'
+            // (that will later be parsed)
+            var argStrWrapper =
+                annotation.Value.GetType() == typeof(string) ? "\"" :
+                annotation.Value.GetType() == typeof(char) ? "'" : "";
+            if (property.PropertyType == typeof(DateTime) || property.PropertyType == typeof(Guid)) {
+                if (annotation.Value.GetType() != typeof(string)) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        $"[Default] value of {argStrWrapper}{annotation.Value}{argStrWrapper} " +
+                        $"(of type {annotation.Value.GetType().Name}) " +
+                        $"is not valid for a Field of type {property.PropertyType.Name} " +
+                        "(a string is required, which will then be parsed)"
+                    );
+                }
+            }
+            else if (!annotation.Value.GetType().IsInstanceOf(property.PropertyType)) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"[Default] value of {argStrWrapper}{annotation.Value}{argStrWrapper} " +
+                    $"(of type {annotation.Value.GetType().Name}) " +
+                    $"is not valid for a Field of type {property.PropertyType.Name}"
+                );
+            }
+
+            // Parse value if necessary
+            if (property.PropertyType == typeof(DateTime)) {
+                if (!DateTime.TryParse((string)annotation.Value, out DateTime result)) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        $"could not parse [Default] value \"{annotation.Value}\" into {nameof(DateTime)}"
+                    );
+                }
+                return Option.Some<object?>(result);
+            }
+            if (property.PropertyType == typeof(Guid)) {
+                if (!Guid.TryParse((string)annotation.Value, out Guid result)) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        $"could not parse [Default] value \"{annotation.Value}\" into {nameof(Guid)}"
+                    );
+                }
+                return Option.Some<object?>(result);
+            }
+            return Option.Some<object?>(annotation.Value);
+        }
+    }
+}

--- a/src/Kvasir/Translation/Descriptors.cs
+++ b/src/Kvasir/Translation/Descriptors.cs
@@ -1,0 +1,40 @@
+﻿using Cybele.Core;
+using Kvasir.Schema;
+using Optional;
+using System;
+using System.Collections.Generic;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   A descriptor of a single back-end database Field.
+        /// </summary>
+        private record struct FieldDescriptor(
+            Type SourceType,
+            string AccessPath,
+            FieldName Name,
+            Type CLRType,
+            Option<int> Column,
+            IsNullable Nullability,
+            Option<object?> RawDefault,
+            bool IsInPrimaryKey,
+            DataConverter Converter,
+            IReadOnlyList<KeyName> KeyMemberships
+        );
+
+        /// <summary>
+        ///   A descriptor of a single in-source CLR Type, translated into two or more Fields.
+        /// </summary>
+        private record struct TypeDescriptor(
+            Type CLRType,
+            IReadOnlyList<FieldDescriptor> Fields
+        );
+
+        /// <summary>
+        ///   A descriptor of a single in-source property of a CLR Type, translated into at least one Field.
+        /// </summary>
+        private record struct PropertyDescriptor(
+            IReadOnlyList<FieldDescriptor> Fields
+        );
+    }
+}

--- a/src/Kvasir/Translation/Naming.cs
+++ b/src/Kvasir/Translation/Naming.cs
@@ -1,0 +1,135 @@
+﻿using Cybele.Extensions;
+using Kvasir.Annotations;
+using Kvasir.Exceptions;
+using Kvasir.Schema;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Determine the name of a Field backing a scalar property, using a combination of the propert's native CLR
+        ///   name and user-provided attributes.
+        /// </summary>
+        /// <param name="property">
+        ///   The source <see cref="PropertyInfo">property</see>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if <paramref name="property"/> is annotated with multiple <c>[Name]</c> attributes
+        ///     --or--
+        ///   if the <c>[Name]</c> annotation applied to <paramref name="property"/> has a non-empty
+        ///   <see cref="NameAttribute.Path">Path</see>
+        ///     --or--
+        ///   if the value of the <c>[Name]</c> annotation applied to <paramref name="property"/> is invalid
+        ///     --or--
+        ///   if the value of the <c>[Name]</c> annotation applied to <paramref name="property"/> is the native name of
+        ///   the property.
+        /// </exception>
+        /// <returns>
+        ///   The <see cref="FieldName">name</see> of the Field backing <paramref name="property"/>.
+        /// </returns>
+        private static FieldName NameOf(PropertyInfo property) {
+            // It is an error for a property to be annotated with multiple [Name] attributes
+            var annotations = property.GetCustomAttributes<NameAttribute>();
+            if (annotations.Count() > 1) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    "multiple [Name] annotations encountered"
+                );
+            }
+            var annotation = annotations.FirstOrDefault();
+
+            // If there is no [Name] annotation, then the property's native name is used
+            if (annotation is null) {
+                return new FieldName(property.Name);
+            }
+
+            // It is an error for the [Name] attribute of a scalar property to have a non-empty <Path> value
+            if (annotation.Path != "") {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"path \"{annotation.Path}\" of [Name] annotation does not exist"
+                );
+            }
+
+            // It is an error for the value of a [Name] annotation to be invalid as the name of a Field; currently, the
+            // only restriction on this is that the name must have non-zero length (there is no back-end awareness)
+            if (annotation.Name == "") {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"[Name] \"{annotation.Name}\" is not a valid Field name"
+                );
+            }
+
+            // It is an error for the value of the [Name] annotation to be the property's native name
+            if (annotation.Name == property.Name) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"[Name] annotation is redundant (Field would have been named '{annotation.Name}' anyway)"
+                );
+            }
+
+            // No errors detected
+            return new FieldName(annotation.Name);
+        }
+
+        /// <summary>
+        ///   Determine the name of the primary Table backing an Entity type.
+        /// </summary>
+        /// <param name="entity">
+        ///   The source <see cref="Type">Entity type</see>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if <paramref name="entity"/> is annotated with both <c>[Table]</c> or <c>[ExcludeNamespaceFromName]</c>
+        ///     --or--
+        ///   if the value of the <c>[Table]</c> annotation applied to <paramref name="entity"/> is invalid
+        ///     --or--
+        ///   if the value of the <c>[Table]</c> annotation applied to <paramref name="entity"/> is the same as the name
+        ///   of the Table that would have otherwise been ascertained.
+        /// </exception>
+        /// <returns>
+        ///   The <see cref="TableName">name</see> of the primary Table backing <paramref name="entity"/>.
+        /// </returns>
+        private static TableName NameOf(Type entity) {
+            var annotation = entity.GetCustomAttribute<TableAttribute>();
+            var excludeNamespace = entity.HasAttribute<ExcludeNamespaceFromNameAttribute>();
+
+            // It is an error for a type to be annotated with both [Table] and [ExcludeNamespaceFromName]
+            if (annotation is not null && excludeNamespace) {
+                throw new KvasirException(
+                    $"Error translating Entity Type {entity.Name}: " +
+                    "type is annotated as with both [ExcludeNamespaceFromName] and [Table]"
+                );
+            }
+
+            // If there is no [Table] annotation, the the type's native namespace-qualified name is used; the namespace
+            // is dropped if an [ExcludeNamespaceFromName] annotation is present (though nestedness identifiers will
+            // still be present)
+            if (annotation is null) {
+                return new TableName((excludeNamespace ? entity.Name : entity.FullName!) + "Table");
+            }
+
+            // It is an error for the value of a [Table] annotation to be invalid as the name of a Table; currently, the
+            // only restriction on this is that the name must have non-zero length (there is no back-end awareness)
+            if (annotation.Name == "") {
+                throw new KvasirException(
+                    $"Error translating Entity Type {entity.Name}: " +
+                    $"[Table] name \"{annotation.Name}\" is not a valid Table name"
+                );
+            }
+
+            // It is an error for the value of a [Table] annotation to be the same as what the Entity Type's primary
+            // table would have been in the absence of the annotation
+            if (annotation.Name == entity.FullName! + "Table") {
+                throw new KvasirException(
+                    $"Error translating Entity Type {entity.Name}: " +
+                    $"[Table] annotation is redundant (Table would have been named '{annotation.Name}' anyway)"
+                );
+            }
+
+            // No errors detected
+            return new TableName(annotation.Name);
+        }
+    }
+}

--- a/src/Kvasir/Translation/Nullability.cs
+++ b/src/Kvasir/Translation/Nullability.cs
@@ -1,0 +1,66 @@
+﻿using Cybele.Extensions;
+using Kvasir.Annotations;
+using Kvasir.Exceptions;
+using Kvasir.Schema;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Determine the nullability imparted by a property, using a combination of the property's native CLR type
+        ///   and user-provided attributes. This function is safe to use for any kind of property.
+        /// </summary>
+        /// <param name="property">
+        ///   The source <see cref="PropertyInfo">property</see>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if <paramref name="property"/> is annotated with both <c>[Nullable]</c> and <c>[NonNullable]</c>
+        ///     --or--
+        ///   if <paramref name="property"/> is an inherently nullable property and it is still annotated with
+        ///   <c>[Nullable]</c>
+        ///     --or--
+        ///   if <paramref name="property"/> is an inherently non-nullable property and it is still annotated with
+        ///   <c>[NonNullable]</c>
+        /// </exception>
+        /// <returns>
+        ///   <see cref="IsNullable.Yes"/> if <paramref name="property"/> implies nullability for any corresponding
+        ///   Fields; otherwise, <see cref="IsNullable.No"/>.
+        /// </returns>
+        private static IsNullable NullabilityOf(PropertyInfo property) {
+            var forceNullable = property.HasAttribute<NullableAttribute>();
+            var forceNonNullable = property.HasAttribute<NonNullableAttribute>();
+            var deduction = property.GetNullability();
+
+            // It is an error for a property to be annotated as both [Nullable] and [NonNullable]
+            if (forceNullable && forceNonNullable) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    "property is annotated as with both [Nullable] and [NonNullable]"
+                );
+            }
+
+            // It is an error for a property that would otherwise be deduced as nullable to be annotated as [Nullable]
+            if (forceNullable && deduction == Nullability.Nullable) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    "[Nullable] annotation is redundant (Field is already nullable)"
+                );
+            }
+
+            // It is an error for a property that would otherwise be deduced as non-nullable to be annotated as
+            // [NonNullable]
+            if (forceNonNullable && deduction == Nullability.NonNullable) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    "[NonNullable] annotation is redundant (Field is already non-nullable)"
+                );
+            }
+
+            // No errors detected
+            if (forceNullable || (deduction == Nullability.Nullable && !forceNonNullable)) {
+                return IsNullable.Yes;
+            }
+            return IsNullable.No;
+        }
+    }
+}

--- a/src/Kvasir/Translation/PrimaryKeys.cs
+++ b/src/Kvasir/Translation/PrimaryKeys.cs
@@ -1,0 +1,186 @@
+﻿using Cybele.Extensions;
+using Kvasir.Annotations;
+using Kvasir.Exceptions;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Determines if a Field backing a scalar property is explicitly proscribed as being part of the Primary Key
+        ///   of the owning Table.
+        /// </summary>
+        /// <param name="property">
+        ///   The source <see cref="PropertyInfo">property</see>.
+        /// </param>
+        /// <param name="nullability">
+        ///   The nullability of the Field backing <paramref name="property"/>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if <paramref name="property"/> is annotated with multiple <c>[PrimaryKey]</c> attributes
+        ///     --or--
+        ///   if the <c>[PrimaryKey]</c> annotation applied to <paramref name="property"/> has a non-empty
+        ///   <see cref="PrimaryKeyAttribute.Path">Path</see>
+        ///     --or--
+        ///   if <paramref name="nullability"/> is <see cref="IsNullable.Yes"/> but the <c>[PrimaryKey]</c> annotation
+        ///   is present on <paramref name="property"/>.
+        /// </exception>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="property"/> is annotated with a <c>[PrimaryKey]</c> attribute;
+        ///   otherwise, <see langword="false"/>.
+        /// </returns>
+        private static bool IsInPrimaryKey(PropertyInfo property, IsNullable nullability) {
+            // It is an error for a property to be annotated with multiple [PrimaryKey] attributes
+            var annotations = property.GetCustomAttributes<PrimaryKeyAttribute>();
+            if (annotations.Count() > 1) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    "multiple [PrimaryKey] annotations encountered"
+                );
+            }
+            var annotation = annotations.FirstOrDefault();
+
+            // It is an error for the [PrimaryKey] attribute of a scalar property to have a non-empty <Path> value
+            if (annotation is not null && annotation.Path != "") {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"path \"{annotation.Path}\" of [PrimaryKey] annotation does not exist"
+                );
+            }
+
+            // It is an error for a nullable Field to be annotated as being part of the [PrimaryKey]
+            if (annotation is not null && nullability == IsNullable.Yes) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    "nullable Field cannot be annotated as [PrimaryKey]"
+                );
+            }
+
+            // No errors detected
+            return annotation is not null;
+        }
+
+        /// <summary>
+        ///   Deduce the <see cref="PrimaryKey">Primary Key</see> for a the Table backing an Entity Type.
+        /// </summary>
+        /// <param name="entity">
+        ///   The source Entity Type.
+        /// </param>
+        /// <param name="descriptors">
+        ///   The <see cref="FieldDescriptor">Field Descriptors</see> for <paramref name="entity"/>.
+        /// </param>
+        /// <param name="fields">
+        ///   The actual <see cref="IField">Field</see> objects based on <paramref name="descriptors"/>. The <c>Nth</c>
+        ///   Field was created from the <c>Nth</c> FieldDescriptor.
+        /// </param>
+        /// <param name="candidates">
+        ///   The <see cref="CandidateKey">Candidate Keys</see> for <paramref name="entity"/>. If a Candidate Key is
+        ///   deduced as the Primary Key, it will be <i>REMOVED</i> from this list.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if <paramref name="entity"/> is annotated with a <c>[NamedPrimaryKey]</c> whose value is invalid
+        ///     --or--
+        ///   if <paramref name="entity"/> is annotated with a <c>[NamedPrimaryKey]</c> and the deduced Primary Key is a
+        ///   named Candidate Key
+        ///     --or--
+        ///   if the Primary Key of <paramref name="entity"/> cannot be deduced.
+        /// </exception>
+        /// <returns>
+        ///   The <see cref="PrimaryKey">Primary Key</see> of the Table backing <paramref name="entity"/>.
+        /// </returns>
+        private static PrimaryKey CreatePrimaryKeyFor(Type entity, IEnumerable<FieldDescriptor> descriptors,
+            FieldSeq fields, IList<CandidateKey> candidates) {
+
+            var annotated = new List<IField>();
+            IField? namedID = null;
+            IField? namedTableID = null;
+            IField? nonNullable = null;
+            var nonNullableCount = 0;
+            var name = entity.GetCustomAttribute<NamedPrimaryKeyAttribute>()?.Name;
+
+            // It is an error for the value of a [NamedPrimaryKey] annotation to be invalid as the name of a Key;
+            // currently, the only restrictions on this is that the name must have non-zero length (there is no back-end
+            // awareness)
+            if (name == "") {
+                throw new KvasirException(
+                    $"Error translating type {entity.Name}: " +
+                    $"[NamedPrimaryKey] name argument \"{name}\" is not a valid Primary Key name"
+                );
+            }
+
+            // #1) Any Fields that are annotated as [PrimaryKey]
+            // #2) The single non-nullable Field named "ID"
+            // #3) The single non-nullable Field named "<EntityType>ID"
+            // #4) The single Candidate Key that consists of only non-nullable Fields
+            // #5) The single non-nullable Field
+            // #6) deduction fails with error
+            foreach (var (descriptor, field) in descriptors.Zip(fields)) {
+                if (descriptor.IsInPrimaryKey) {
+                    Debug.Assert(descriptor.Nullability == IsNullable.No);
+                    annotated.Add(field);
+                }
+                else if (field.Nullability == IsNullable.No && descriptor.Name.ToString() == "ID") {
+                    namedID = field;
+                }
+                else if (field.Nullability == IsNullable.No && descriptor.Name.ToString() == $"{entity.Name}ID") {
+                    namedTableID = field;
+                }
+                else if (field.Nullability == IsNullable.No) {
+                    ++nonNullableCount;
+                    nonNullable = field;
+                }
+            }
+
+            if (!annotated.IsEmpty()) {
+                return name is null ? new PrimaryKey(annotated) : new PrimaryKey(new KeyName(name), annotated);
+            }
+            if (namedID is not null || namedTableID is not null) {
+                var key = Enumerable.Repeat(namedID ?? namedTableID, 1);
+                return name is null ? new PrimaryKey(key!) : new PrimaryKey(new KeyName(name), key!);
+            }
+
+            var viableCandidates = candidates.Where(ck => ck.Fields.All(f => f.Nullability == IsNullable.No));
+            if (viableCandidates.Count() == 1) {
+                var deduction = viableCandidates.First();
+                bool isAnonymous = deduction.Name.Exists(n => n.ToString().StartsWith(UniqueAttribute.ANONYMOUS_PREFIX));
+                
+                // It is an error for the value of a [NamedPrimaryKey] to be different than that of the Candidate Key
+                // deduced as the Primary Key, unless the Candidate Key is anonymous
+                if (name is not null && !isAnonymous && deduction.Name.Exists(n => n.ToString() != name)) {
+                    throw new KvasirException(
+                        $"Error translating type {entity.Name}: " +
+                        $"a Candidate Key with name \"{deduction.Name.Unwrap()}\" was deduced as the Primary Key, " +
+                        $"but the [NamedPrimaryKey] of \"{name}\" is conflicting"
+                    );
+                }
+
+                // It is an error for the value of a [NamedPrimaryKey] to be different the same as that of the Candidate
+                // Key deduced as the Primary Key, as the former annotation is then redundant
+                if (deduction.Name.Exists(n => n.ToString() == name)) {
+                    throw new KvasirException(
+                        $"Error translating type {entity.Name}: " +
+                        $"a Candidate Key with name \"{deduction.Name.Unwrap()}\" was deduced as the Primary Key, " +
+                        "rendering the [NamedPrimaryKey] annotation redundant"
+                    );
+                }
+
+                // No errors detected; need to remove the deduced Candidate Key to avoid inducing a subset/superset
+                // error downstream
+                candidates.Remove(deduction);
+                return new PrimaryKey(name is null ? deduction.Name.Unwrap() : new KeyName(name), deduction.Fields);
+            }
+
+            if (nonNullable is not null && nonNullableCount == 1) {
+                var key = Enumerable.Repeat(nonNullable, 1);
+                return name is null ? new PrimaryKey(key) : new PrimaryKey(new KeyName(name), key);
+            }
+
+            // It is an error for the deduction of a Table's Primary Key to fail
+            throw new KvasirException($"Error translating type {entity.Name}: unable to deduce Primary Key");
+        }
+    }
+}

--- a/src/Kvasir/Translation/Scalar.cs
+++ b/src/Kvasir/Translation/Scalar.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Translate a scalar property into a <see cref="FieldDescriptor"/>.
+        /// </summary>
+        /// <param name="property">
+        ///   The source <see cref="PropertyInfo">property</see>.
+        /// </param>
+        /// <returns>
+        ///   The translation of <paramref name="property"/>.
+        /// </returns>
+        private static FieldDescriptor TranslateScalar(PropertyInfo property) {
+            var nullability = NullabilityOf(property);
+            return new FieldDescriptor(
+                SourceType: property.ReflectedType!,
+                AccessPath: property.Name,
+                Name: NameOf(property),
+                Nullability: nullability,
+                Column: ColumnOf(property),
+                CLRType: property.PropertyType,
+                Converter: ConverterFor(property),
+                RawDefault: DefaultValueOf(property, nullability),
+                IsInPrimaryKey: IsInPrimaryKey(property, nullability),
+                KeyMemberships: CandidateKeysContaining(property).ToList()
+            );
+        }
+    }
+}

--- a/src/Kvasir/Translation/Specification/Data Conversions.md
+++ b/src/Kvasir/Translation/Specification/Data Conversions.md
@@ -15,9 +15,9 @@ Data Type of the corresponding Fields. It is an error for a property to be annot
 When applied to a Scalar Property, it is an error for the `Path` of a `[DataConverter(T)]` annotation to be anything
 other than the empty string. Futhermore, the `SourceType` of `T` must be exactly the native type of the property;
 implicit type conversions (e.g. widening of integers) are not supported. The CLR Type of the Scalar Property is then
-the `ResultType` of `T`. It is an error for a Scalar Property to be directly annotated with more than one
-`[DataConverter(T)]` attributes; to achieve a complex, multi-step conversion, simply construct a suitable converter type
-`T`.
+the `ResultType` of `T`, but the nullability is unaffected. It is an error for a Scalar Property to be directly
+annotated with more than one `[DataConverter(T)]` attributes; to achieve a complex, multi-step conversion, simply
+construct a suitable converter type `T`.
 
 A Scalar Property that is not annotated with `[DataConverter(T)]` has no Extrinsic Data Conversion: its CLR Type is the
 property's own native type.

--- a/src/Kvasir/Translation/Specification/General Identification.md
+++ b/src/Kvasir/Translation/Specification/General Identification.md
@@ -54,9 +54,15 @@ category are describes in separate documents of the spec, but the categories the
 
 It is an error for a property that is included in the Data Model to have a CLR Type that does not fall into one of these
 categories (e.g. a `delegate`, `System.Enum`, `dynamic`, etc.). Due to other rules regarding generic Entity Types and
-inheritance, it is also the case that the CLR Type of a property included in the Data Model cannot be generic. Nullable
-types are fully supported (both `System.Nullable<T>` instantations and nullable reference types); the category of a
-property with such a CLR Type is that of its non-nullable equivalent.
+inheritance, it is also the case that the CLR Type of a property included in the Data Model cannot be generic reference
+type; closed generic value types (i.e. structs) are legal (and they may be from the C# standard library). Nullable types
+are fully supported (both `System.Nullable<T>` instantations and nullable reference types); the category of a property
+with such a CLR Type is that of its non-nullable equivalent.
+
+Note that a Data Converter cannot be used to include a property in the Data Model if that property's type does not fit
+one of the above five categories. If you wish to store data of an otherwise unsupported type in the back-end database,
+you must provide an façade property that fronts the ineligible property and performs the data conversion automatically
+on `get` operations.
 
 Properties need not be writeable to be included in the Data Model: a property's `set` method can have `public`
 visibility, non-`public` visibility, or be absent altogether. That being said, the presence and/or absence of a `set`

--- a/src/Kvasir/Translation/Specification/Primary Keys.md
+++ b/src/Kvasir/Translation/Specification/Primary Keys.md
@@ -12,17 +12,13 @@ Primary Key deduction is performed. Specifically, the following rules are applie
 Field's nullability is resolved:
 
 1. Each property that is annotated as `[PrimaryKey]` corresponds to Fields that are part of the Entity's Primary Key
-1. The single Field whose name is `ID` is the Entity's Primary Key
-1. The single Field whose name is `FooID`, where `Foo` is the name of the Entity Type, is the Entity's Primary Key
-1. The single Candidate Key for the Entity is instead the Entity's Primary Key
+1. The single non-nullable Field whose name is `ID` is the Entity's Primary Key
+1. The single non-nullable Field whose name is `FooID`, where `Foo` is the name of the Entity Type, is the Entity's Primary Key
+1. The single Candidate Key for the Entity consisting of only non-nullable Fields is instead the Entity's Primary Key
 1. The single non-nullable Field is the Entity's Primary Key
 
-It is an error if the Primary Key for an Entity cannot be deduced.
-
-Because the Fields that form an Entity's Primary Key must be non-nullable, the Primary Key deduction can influence the
-nullability of Fields. Any Field whose nullability is _not_ based on an annotation becomes non-nullable if it is part of
-an Entity's Primary Key. It is an error for any Field that forms part of an Entity's Primary Key to be nullable because
-its source property is annotated as `[Nullable]` or because its type is an instantiation of the `Nullable<T>` generic.
+It is an error if the Primary Key for an Entity cannot be deduced. It is also an error for a Field that is nullable
+(either by deduction or by the presence of a `[Nullable]` annotation) to be annotated with `[PrimaryKey]`.
 
 Some back-end database providers allow Primary Keys to be named, since Primary Keys are a type of constraint.
 By default, the name assigned to a Primary Key for an Entity is implementation defined. If an Entity Type is annotated

--- a/src/Kvasir/Translation/TableDefs.cs
+++ b/src/Kvasir/Translation/TableDefs.cs
@@ -1,0 +1,35 @@
+﻿using Kvasir.Schema;
+using System.Diagnostics;
+
+namespace Kvasir.Translation {
+    /// <summary>
+    ///   A representation of the data model for a Principal Table (rather than a Relation Table).
+    /// </summary>
+    internal sealed record class PrincipalTableDef {
+        /// <summary>
+        ///   The <see cref="ITable">Table</see>.
+        /// </summary>
+        public ITable Table { get; }
+
+        /// <summary>
+        ///   Construct a new <see cref="PrincipalTableDef"/>.
+        /// </summary>
+        /// <param name="table">
+        ///   The <see cref="Table">Principal Table</see>.
+        /// </param>
+        public PrincipalTableDef(ITable table) {
+            Debug.Assert(table is not null);
+            Table = table;
+        }
+
+        /* Because PrincipalTableDef is a record type, the following methods are synthesized automatically by the compiler:
+         *   > public PrincipalTableDef(PrincipalTableDef rhs)
+         *   > public bool Equals(PrincipalTableDef? rhs)
+         *   > public sealed override bool Equals(object? rhs)
+         *   > public sealed override int GetHashCode()
+         *   > public sealed override string ToString()
+         *   > public static bool operator==(PrincipalTableDef? lhs, PrincipalTableDef? rhs)
+         *   > public static bool oeprator!=(PrincipalTableDef? lhs, PrincipalTableDef? rhs)
+         */
+    }
+}

--- a/src/Kvasir/Translation/TranslateEntity.cs
+++ b/src/Kvasir/Translation/TranslateEntity.cs
@@ -1,0 +1,135 @@
+﻿using Cybele.Extensions;
+using Kvasir.Exceptions;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Translate a single Entity Type.
+        /// </summary>
+        /// <param name="clr">
+        ///   The Entity Type.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if <paramref name="clr"/> is not a valid Entity Type
+        ///     --or--
+        ///   if the Translation of <paramref name="clr"/> contains any Tables with exactly 0 or 1 back-end Fields
+        ///     --or--
+        ///   if the name of any Tables in the Translation of <paramref name="clr"/> has a name that is not globally
+        ///   unique
+        ///     --or--
+        ///   if the Translation of <paramref name="clr"/> contains any Table with two or more Field sharing a single
+        ///   name
+        ///     --or--
+        ///   if the Translation of <paramref name="clr"/> contains any Table in which one or more Candidate Keys is a
+        ///   superset (not necessarily proper) of the Table's Primary Key
+        ///     --or--
+        ///   if the Translation of <paramref name="clr"/> contains any Table in which the name of the Primary Key is
+        ///   the same as the name of any of the Table's Candidate Keys.
+        /// </exception>
+        /// <returns>
+        ///   The Translation of <paramref name="clr"/>.
+        /// </returns>
+        private Translation TranslateEntity(Type clr) {
+            // If we've already translated the Type once, then simply return the memoized TypeDescriptor; the upstream
+            // caller may modify the result based on property-level annotations
+            if (entityCache_.TryGetValue(clr, out Translation? result)) {
+                return result;
+            }
+
+            // Make sure that the Type can actually be used as an Entity Type
+            CheckEntityType(clr);
+
+            // Get the TypeDescriptor for the Type; this will perform all of the property-level error checking and put
+            // the FieldDescriptors in the correct order
+            var descriptor = TranslateType(clr);
+
+            // It is an error for an Entity to have fewer than two Fields
+            if (descriptor.Fields.Count < 2) {
+                throw new KvasirException(
+                    $"{clr.Name} cannot be an Entity Type: " +
+                    $"at least 2 Fields are required (only {descriptor.Fields.Count} Fields found)"
+                );
+            }
+
+            // It is an error for the name of a Table match that of another Table
+            var tableName = NameOf(clr);
+            if (!tableNames_.Add(tableName)) {
+                throw new KvasirException(
+                    $"Error translating Entity Type {clr.Name}: " +
+                    $"Primary Table name \"{tableName}\" is already in use"
+                );
+            }
+
+            // It is an error for a Table to contain two or more Fields with the same name
+            var fields = new List<IField>(MakeFieldsFrom(descriptor.Fields)).ToList();
+            var fieldNames = new HashSet<FieldName>();
+            foreach (var field in fields) {
+                if (!fieldNames.Add(field.Name)) {
+                    throw new KvasirException(
+                        $"Error translating Entity Type {clr.Name}: duplicate Field name \"{field.Name}\" encountered"
+                    );
+                }
+            }
+
+            // Create the Candidate Keys, then deduce the Primary Key
+            var candidateKeys = MakeCandidateKeysFrom(descriptor.Fields, fields).ToList();
+            var primaryKey = CreatePrimaryKeyFor(clr, descriptor.Fields, fields, candidateKeys);
+
+            // It is an error for the Primary Key of a Table to be a superset of any of the Table's Candidate Keys
+            var pkSet = new HashSet<FieldName>(primaryKey.Fields.Select(f => f.Name));
+            foreach (var candidate in candidateKeys) {
+                var ckSet = new HashSet<FieldName>(candidate.Fields.Select(f => f.Name));
+                if (ckSet.IsSupersetOf(pkSet)) {
+                    throw new KvasirException(
+                        $"Error translating Entity Type {clr.Name}: " +
+                        $"Candidate Key \"{candidate.Name.Unwrap()}\" ({string.Join(", ", ckSet)}) " +
+                        $"is a superset of the Primary Key ({string.Join(", ", pkSet)})"
+                    );
+                }
+            }
+
+            // It is an error for the name of the Primary Key of a Table to be the same as the name of any of the
+            // Table's Candidate Keys
+            if (primaryKey.Name.HasValue && candidateKeys.Any(ck => ck.Name == primaryKey.Name)) {
+                throw new KvasirException(
+                    $"Error translating Entity Type {clr.Name}: " +
+                    $"[NamedPrimaryKey] \"{primaryKey.Name.Unwrap()}\" clashes with name of unrelated Candidate Key"
+                );
+            }
+
+            // These are not currently supported at the Translation Layer, but they are present in the Schema Layer
+            var foreignKeys = new List<ForeignKey>();
+            var checks = new List<CheckConstraint>();
+
+            // No errors detected
+            var table = new Table(tableName, fields, primaryKey, candidateKeys, foreignKeys, checks);
+            var def = new PrincipalTableDef(table);
+            var translation = new Translation(clr, def);
+            entityCache_.Add(clr, translation);
+            return translation;
+        }
+
+        /// <summary>
+        ///   Converts one or more <see cref="FieldDescriptor">FieldDescriptors</see> into their corresponding
+        ///   <see cref="IField">Fields</see>.
+        /// </summary>
+        /// <param name="descriptors">
+        ///   The <see cref="FieldDescriptor">FieldDescriptors</see> describing the schema model.
+        /// </param>
+        /// <returns>
+        ///   A finite enumerable of <see cref="IField">Fields</see>, one for each source descriptor in the same order
+        ///   thereof.
+        /// </returns>
+        private static FieldSeq MakeFieldsFrom(IEnumerable<FieldDescriptor> descriptors) {
+            foreach (var descriptor in descriptors) {
+                var dbType = DBType.Lookup(descriptor.Converter.ResultType);
+                var defaultValue = descriptor.RawDefault.Map(obj => DBValue.Create(descriptor.Converter.Convert(obj)));
+                yield return new BasicField(descriptor.Name, dbType, descriptor.Nullability, defaultValue);
+            }
+        }
+    }
+}

--- a/src/Kvasir/Translation/TranslateProperty.cs
+++ b/src/Kvasir/Translation/TranslateProperty.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Translate a single CLR property of a particular.
+        /// </summary>
+        /// <param name="property">
+        ///   The <see cref="PropertyInfo">CLR property</see> to translate.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="PropertyDescriptor"/> describing <paramref name="property"/>.
+        /// </returns>
+        private PropertyDescriptor TranslateProperty(PropertyInfo property) {
+            var category = CategoryOf(property);
+
+            if (category == PropertyCategory.Scalar) {
+                var fields = new List<FieldDescriptor>() { TranslateScalar(property) };
+                return new PropertyDescriptor(Fields: fields);
+            }
+            else {
+                throw new NotSupportedException("Only scalar properties can be translated at this time");
+            }
+        }
+    }
+}

--- a/src/Kvasir/Translation/TranslateType.cs
+++ b/src/Kvasir/Translation/TranslateType.cs
@@ -1,0 +1,218 @@
+﻿using Cybele.Collections;
+using Cybele.Extensions;
+using Kvasir.Annotations;
+using Kvasir.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Translate a single CLR Type, which may or may not be an Entity Type.
+        /// </summary>
+        /// <remarks>
+        ///   Very few assumptions about the semantic of the source Type are made. In particular, this function does not
+        ///   create bona fide schema structures (e.g. Candidate Key, Primary Keys, etc.), nor does it enforce any
+        ///   requirements about Fields (e.g. minimum of two, all unique names, etc.). This makes the function suitable
+        ///   for Translating Entity Types and also for Translating Aggregate Types and Synthetic Types, where the
+        ///   result is one piece of a larger Table whose final form will be impacted by other Translations.
+        /// </remarks>
+        /// <param name="clr">
+        ///   The source <see cref="Type">CLR Type</see>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if the annotations of the Fields in the Translation of <paramref name="clr"/> leave gaps in the assigned
+        ///   or implied column indices.
+        /// </exception>
+        /// <returns>
+        ///   The <see cref="TypeDescriptor"/> of the back-end schema for <paramref name="clr"/>.
+        /// </returns>
+        private TypeDescriptor TranslateType(Type clr) {
+            Debug.Assert(clr != typeof(object));
+            Debug.Assert(clr != typeof(string));
+            Debug.Assert(clr != typeof(DateTime));
+            Debug.Assert(clr != typeof(Guid));
+            Debug.Assert(!clr.IsAbstract);
+            Debug.Assert(!clr.IsEnum);
+            Debug.Assert(!clr.IsGenericType);
+            Debug.Assert(!clr.IsGenericTypeDefinition);
+            Debug.Assert(!clr.IsInterface);
+            Debug.Assert(!clr.IsPrimitive);
+            Debug.Assert(!clr.IsInstanceOf(typeof(Delegate)));
+
+            // If we've already translated the Type once, then simply return the memoized TypeDescriptor; the upstream
+            // caller may modify the result based on property-level annotations
+            if (typeCache_.TryGetValue(clr, out TypeDescriptor result)) {
+                return result;
+            }
+
+            var fields = new StickyList<FieldDescriptor>();
+            var relations = new List<TypeDescriptor>();
+            foreach (var property in ModelPropertiesOf(clr)) {
+                var translation = TranslateProperty(property);
+                RecordFields(translation.Fields, fields);
+            }
+
+            // It is an error for any type (Entity Type, Aggregate Type, Synthetic Type, etc.) to have gaps in its
+            // ordered Fields
+            if (fields.HasGaps) {
+                var gaps = Enumerable.Range(0, fields.LargestIndex).Select(idx => !fields.IsOccupied(idx));
+                throw new KvasirException(
+                    $"Error translating type {clr.Name}: " +
+                    "explicitly specified [Column] indices are non-consecutive, leaving gaps"
+                );
+            }
+
+            var checks = new List<Check.ComplexAttribute>();
+            var descriptor = new TypeDescriptor(CLRType: clr, Fields: fields);
+            typeCache_.Add(clr, descriptor);
+            return descriptor;
+        }
+
+        /// <summary>
+        ///   Generate the set of top-level properties of a CLR Type that are part of its back-end data model.
+        /// </summary>
+        /// <param name="clr">
+        ///   The source <see cref="Type">CLR Type</see>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if any property of <paramref name="clr"/> is annotated as both <c>[IncludeInModel]</c> and
+        ///   <c>[CodeOnly</c>
+        ///     --or--
+        ///   if any property of <paramref name="clr"/> that is read-only, an indexer, or is inherited (from either a
+        ///   base class or an interface) is annotated as either <c>[IncludeInModel]</c> or <c>[CodeOnly]</c>
+        ///     --or--
+        ///   if any public, readable, instance property of <paramref name="clr"/> is annotated as
+        ///   <c>[IncludeInModel]</c>
+        ///     --or--
+        ///   if any property that is either non-public, <see langword="static"/> or an indexer is annotated as
+        ///   <c>[CodeOnly]</c>.
+        /// </exception>
+        /// <returns>
+        ///   A finite enumerable of <see cref="PropertyInfo">properties</see> that are part of the back-end data model
+        ///   for <paramref name="clr"/>, either in its Principal Table or as a Relation. The order of the properties is
+        ///   undefined but is guaranteed to be the same on consecutive invocations for the exact same CLR Type.
+        /// </returns>
+        private static IEnumerable<PropertyInfo> ModelPropertiesOf(Type clr) {
+            var flags =
+                BindingFlags.Public | BindingFlags.NonPublic |      // include both public and non-public properties
+                BindingFlags.Static | BindingFlags.Instance;        // include both static and instance properties
+
+            foreach (var property in clr.GetProperties(flags).OrderBy(p => p.Name)) {
+                var userInclude = property.HasAttribute<IncludeInModelAttribute>();
+                var userExclude = property.HasAttribute<CodeOnlyAttribute>();
+
+                var getter = property.GetMethod;
+                var indexer = property.GetIndexParameters().Length > 0;
+                var inherited = getter is not null && (property.DeclaringType != clr || getter.IsInherited());
+                var systemInclude = getter is not null && !indexer && !inherited && getter.IsPublic && !getter.IsStatic;
+                var systemExclude = !systemInclude;
+
+                // It is an error for a property to be annotated as both [IncludeInModel] and [CodeOnly]
+                if (userInclude && userExclude) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        "property is annotated with both [IncludeInModel] and [CodeOnly]"
+                    );
+                }
+
+                // It is an error for a property that is annotated as [IncludeInModel] to be write-only
+                if (userInclude && getter is null) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        "a write-only property cannot be annotated as [IncludeInModel]"
+                    );
+                }
+
+                // It is an error for a property that is annotated as [IncludeInModel] to be an indexer
+                if (userInclude && indexer) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        "an indexer property cannot be annotated as [IncludeInModel]"
+                    );
+                }
+
+                // It is an error for a property that is annotated as [IncludeInModel] to have been inherited from
+                // either a base class or an interface
+                if (userInclude && inherited) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        "an inherited property cannot be annotated as [IncludeInModel] " +
+                        "(the property was inherited - declared by a base class or an interface)"
+                    );
+                }
+
+                // It is an error for a readable property that is annotated as [IncludeInModel] to be both a public
+                // property and an instance property, as the annotation is then redundant
+                if (userInclude && systemInclude) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        "[IncludeInModel] annotation is redundant (property is public and non-static)"
+                    );
+                }
+
+                // It is an error for a property that is annotated as [CodeOnly] to be inherited from either a base
+                // class or an interface, as the annotation is then redundant
+                if (userExclude && inherited) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        "[CodeOnly] annotation is redundant " +
+                        "(the property was inherited - declared by a base class or an interface)"
+                    );
+                }
+
+                // It is an error for a property that is annotated as [CodeOnly] to be read-only, non-public, static, or
+                // an indexer, as the annotation is then redundant
+                if (userExclude && systemExclude) {
+                    throw new KvasirException(
+                        $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                        "[CodeOnly] annotation is redundant (property is write-only, an indexer, non-public, or static)"
+                    );
+                }
+
+                // No errors detected, and the property is either annotated as [IncludeInModel] or is a property that is
+                // included by default and is not annotated as [CodeOnly]
+                if (userInclude || (systemInclude && !userExclude)) {
+                    yield return property;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Place the Field Descriptors generated during the Translation of a property into a running list tracking
+        ///   the Fields' ultimate columnar positions.
+        /// </summary>
+        /// <param name="descriptors">
+        ///   The <see cref="FieldDescriptor">FieldDescriptors</see>.
+        /// </param>
+        /// <param name="into">
+        ///   The running list, using stickiness to indicate a position required by an annotation.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if any of the element of <paramref name="descriptors"/> has a specified column index that is already
+        ///   occupied in <paramref name="into"/> by a "sticky" item.
+        /// </exception>
+        private static void RecordFields(IEnumerable<FieldDescriptor> descriptors, StickyList<FieldDescriptor> into) {
+            foreach (var descriptor in descriptors) {
+                if (!descriptor.Column.HasValue) {
+                    into.Add(descriptor);
+                    continue;
+                }
+                var column = descriptor.Column.Unwrap();
+
+                // It is an error for two or more Fields to be explicitly assigned the same column index
+                Debug.Assert(column >= 0);
+                if (column <= into.LargestIndex && into.IsOccupied(column) && into.IsSticky(column)) {
+                    throw new KvasirException(
+                        $"Error translating property {descriptor.AccessPath} of type {descriptor.SourceType.Name}: " +
+                        $"[Column] index {column} is already occupied"
+                    );
+                }
+                into.Insert(column, descriptor);
+            }
+        }
+    }
+}

--- a/src/Kvasir/Translation/Translation.cs
+++ b/src/Kvasir/Translation/Translation.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Kvasir.Translation {
+    /// <summary>
+    ///   A translation of a single CLR Type.
+    /// </summary>
+    internal sealed record class Translation {
+        /// <summary>
+        ///   The source CLR <see cref="Type"/>.
+        /// </summary>
+        public Type CLRSource { get; }
+
+        /// <summary>
+        ///   The definition of the principal Table of the <see cref="CLRSource">source Type</see>.
+        /// </summary>
+        public PrincipalTableDef Principal { get; }
+
+        /// <summary>
+        ///   Construct a new <see cref="Translation"/>.
+        /// </summary>
+        /// <param name="clr">
+        ///   The <see cref="CLRSource">source CLR Type</see>.
+        /// </param>
+        /// <param name="principal">
+        ///   The <see cref="Principal">principal Table definition</see>.
+        /// </param>
+        public Translation(Type clr, PrincipalTableDef principal) {
+            Debug.Assert(clr is not null);
+            Debug.Assert(principal is not null);
+
+            CLRSource = clr;
+            Principal = principal;
+        }
+
+        /* Because Translation is a record type, the following methods are synthesized automatically by the compiler:
+         *   > public Translation(Translation rhs)
+         *   > public bool Equals(Translation? rhs)
+         *   > public sealed override bool Equals(object? rhs)
+         *   > public sealed override int GetHashCode()
+         *   > public sealed override string ToString()
+         *   > public static bool operator==(Translation? lhs, Translation? rhs)
+         *   > public static bool oeprator!=(Translation? lhs, Translation? rhs)
+         */
+    }
+}

--- a/src/Kvasir/Translation/Translator.cs
+++ b/src/Kvasir/Translation/Translator.cs
@@ -1,0 +1,59 @@
+﻿using Kvasir.Core;
+using Kvasir.Schema;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    /// <summary>
+    ///   The component responsible for reflecting over CLR Types and properties to create a data model.
+    /// </summary>
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   Translate a CLR Type.
+        /// </summary>
+        /// <param name="clr">
+        ///   The source CLR <see cref="Type"/>.
+        /// </param>
+        /// <returns>
+        ///   [GET] The translation associated with <paramref name="clr"/>, creating it if necessary. Note that if
+        ///   <paramref name="clr"/> has any relation-type properties, additional Entity Types may be translated as
+        ///   well.
+        /// </returns>
+        public Translation this[Type clr] => TranslateEntity(clr);
+
+        /// <summary>
+        ///   Create a new <see cref="Translator"/> with default settings.
+        /// </summary>
+        public Translator()
+            : this(Settings.Default) {
+
+            callingAssembly_ = Assembly.GetCallingAssembly();
+        }
+
+        /// <summary>
+        ///   Create a new <see cref="Translator"/> with custom settings.
+        /// </summary>
+        /// <param name="settings">
+        ///   The custom <see cref="Settings">settings</see>
+        /// </param>
+        /// <remarks>
+        ///   Note that the <paramref name="settings"/> are not currently used: they exist as a forward-compatible
+        ///   customization point to provide control over Translation behaviors.
+        /// </remarks>
+        public Translator(Settings settings) {
+            settings_ = settings;
+            callingAssembly_ = Assembly.GetCallingAssembly();
+            typeCache_ = new Dictionary<Type, TypeDescriptor>();
+            entityCache_ = new Dictionary<Type, Translation>();
+            tableNames_ = new HashSet<TableName>();
+        }
+
+
+        private readonly Settings settings_;
+        private readonly Assembly callingAssembly_;
+        private readonly Dictionary<Type, TypeDescriptor> typeCache_;
+        private readonly Dictionary<Type, Translation> entityCache_;
+        private readonly HashSet<TableName> tableNames_;
+    }
+}

--- a/src/Kvasir/Translation/TypeChecking.cs
+++ b/src/Kvasir/Translation/TypeChecking.cs
@@ -1,0 +1,217 @@
+﻿using Cybele.Extensions;
+using Kvasir.Exceptions;
+using Kvasir.Relations;
+using Kvasir.Schema;
+using System;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    internal sealed partial class Translator {
+        /// <summary>
+        ///   A representation of the categories of property.
+        /// </summary>
+        private enum PropertyCategory {
+            /// A scalar property, corresponding to exactly one backing Field
+            Scalar,
+
+            /// An enumeration property, corresponding to exactly one backing Field with automatic support for an
+            /// inclusion <c>CHECK</c> constraint
+            Enumeration,
+
+            /// An aggregate property, corresponding to one or more backing Fields
+            Aggregate,
+
+            /// A reference property, corresponding to a Foreign Key against another Entity
+            Reference,
+
+            /// A relation property, corresponding to another Table altogether
+            Relation
+        }
+
+        /// <summary>
+        ///   Determine the categorization of the Field or Fields backing a property.
+        /// </summary>
+        /// <exception cref="KvasirException">
+        ///   if the <see cref="PropertyInfo.PropertyType">property type</see> of <paramref name="property"/> is
+        ///   <see cref="object"/>, <see cref="ValueType"/>, or <see cref="Enum"/>
+        ///     --or--
+        ///   if the <see cref="PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is an
+        ///   interface
+        ///     --or--
+        ///   if the <see cref="PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is a
+        ///   <see cref="Delegate">delegate</see>
+        ///     --or--
+        ///   if the <see cref="PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is
+        ///   <c>dynamic</c>
+        ///     --or--
+        ///   if the <see cref="PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is from
+        ///   an assembly other than that in which the <see cref="Translator"/> was constructed
+        ///     --or--
+        ///   if the <see cref="PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is
+        ///   a closed generic class (open generics are syntactically invalid, and closed generic structs are allowed)
+        ///     --or--
+        ///   if the <see cref="PropertyInfo.PropertyType"> property type</see> of<paramref name= "property" /> is
+        ///   <see langword="abstract"/>
+        /// </exception>
+        /// <returns>
+        ///   The <see cref="PropertyCategory">category</see> of the Field or Fields backing
+        ///   <paramref name="property"/>.
+        /// </returns>
+        private PropertyCategory CategoryOf(PropertyInfo property) {
+            // It is an error for a property's type to be 'object' or 'dynamic'
+            if (property.PropertyType == typeof(object)) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"property has invalid type {property.PropertyType.Name} (or could be dynamic)"
+                );
+            }
+
+            // It is an error for a property's type to be 'System.ValueType'
+            if (property.PropertyType == typeof(ValueType)) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"property has invalid type {property.PropertyType.Name}"
+                );
+            }
+
+            // It is an error for a property's type to be 'System.Enum'
+            if (property.PropertyType == typeof(Enum)) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"property has invalid type {property.PropertyType.Name}"
+                );
+            }
+
+            // It is an error for a property's type to come from an external assembly
+            if (!DBType.IsSupported(property.PropertyType) && property.PropertyType.Assembly != callingAssembly_) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"property has invalid type {property.PropertyType.Name} " +
+                    $"(not from assembly '{callingAssembly_.FullName}')"
+                );
+            }
+
+            // It is an error for a property's type to be an Interface
+            if (property.PropertyType.IsInterface) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"property has invalid type {property.PropertyType.Name} (an interface)"
+                );
+            }
+
+            // It is an error for a property's type to be a Delegate
+            if (property.PropertyType.IsInstanceOf(typeof(Delegate))) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"property has invalid type {property.PropertyType.Name} (a delegate)"
+                );
+            }
+
+            // It is an error for a property's type to be an abstract class
+            if (property.PropertyType.IsClass && property.PropertyType.IsAbstract) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"property has invalid type {property.PropertyType.Name} (an abstract class or record class)"
+                );
+            }
+
+            // It is an error for a property's type to be a closed generic class
+            if (property.PropertyType.IsClass && property.PropertyType.IsGenericType) {
+                throw new KvasirException(
+                    $"Error translating property {property.Name} of type {property.ReflectedType!.Name}: " +
+                    $"property has invalid type {property.PropertyType.Name} (a closed generic class or record class)"
+                );
+            }
+
+            // No errors detected
+            if (property.PropertyType.IsEnum) {
+                return PropertyCategory.Enumeration;
+            }
+            else if (property.PropertyType.IsInstanceOf(typeof(IRelation))) {
+                return PropertyCategory.Relation;
+            }
+            else if (DBType.IsSupported(property.PropertyType)) {
+                return PropertyCategory.Scalar;
+            }
+            else if (property.PropertyType.IsClass) {
+                #if DEBUG
+                CheckEntityType(property.PropertyType);
+                #endif
+                return PropertyCategory.Reference;
+            }
+            else {
+                return PropertyCategory.Aggregate;
+            }
+        }
+
+        /// <summary>
+        ///   Perform error checking to ensure that a particular Type can be an Entity Type.
+        /// </summary>
+        /// <param name="entity">
+        ///   The source <see cref="Type"/>.
+        /// </param>
+        /// <exception cref="KvasirException">
+        ///   if <paramref name="entity"/> is a primitive type
+        ///     --or--
+        ///   if <paramref name="entity"/> is an enumeration type
+        ///     --or--
+        ///   if <paramref name="entity"/> is a struct or record struct type
+        ///     --or--
+        ///   if <paramref name="entity"/> is an interface
+        ///     --or--
+        ///   if <paramref name="entity"/> is an open or closed generic type
+        ///     --or--
+        ///   if <paramref name="entity"/> is an <see langword="abstract"/> type
+        /// </exception>
+        private static void CheckEntityType(Type entity) {
+            // It is an error for an Entity's type to be a primitive
+            if (entity.IsPrimitive) {
+                throw new KvasirException(
+                    $"{entity.Name} cannot be an Entity Type: type is a primitive"
+                );
+            }
+
+            // It is an error for an Entity's type to be an enumeration
+            if (entity.IsEnum) {
+                throw new KvasirException(
+                    $"{entity.Name} cannot be an Entity Type: type is an enumeration"
+                );
+            }
+
+            // It is an error for an Entity's type to be a struct or a record struct
+            if (entity.IsValueType) {
+                throw new KvasirException(
+                    $"{entity.Name} cannot be an Entity Type: type is a struct or a record struct"
+                );
+            }
+
+            // It is an error for an Entity's type to be an Interface
+            if (entity.IsInterface) {
+                throw new KvasirException(
+                    $"{entity.Name} cannot be an Entity Type: type is an interface"
+                );
+            }
+
+            // It is an error for an Entity's type to be an open generic
+            if (entity.IsGenericTypeDefinition) {
+                throw new KvasirException(
+                    $"{entity.Name} cannot be an Entity Type: type is an open generic"
+                );
+            }
+
+            // It is an error for an Entity's type to be a closed generic
+            if (entity.IsGenericType) {
+                throw new KvasirException(
+                    $"{entity.Name} cannot be an Entity Type: type is a closed generic"
+                );
+            }
+
+            // It is an error for an Entity's type to be abstract
+            if (entity.IsAbstract) {
+                throw new KvasirException(
+                    $"{entity.Name} cannot be an Entity Type: type is an abstract class or record class"
+                );
+            }
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/CandidateKeys.cs
+++ b/test/UnitTests/Kvasir/Translation/CandidateKeys.cs
@@ -1,0 +1,171 @@
+﻿using FluentAssertions;
+using Kvasir.Exceptions;
+using Kvasir.Translation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using static UT.Kvasir.Translation.TestComponents;
+
+namespace UT.Kvasir.Translation {
+    [TestClass, TestCategory("Candidate Keys")]
+    public class CandidateKeyTests {
+        [TestMethod] public void MultipleUnnamedCandidateKeys() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Inmate);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveCandidateKey("SSN").And
+                .HaveCandidateKey("FullName").And
+                .NoOtherCandidateKeys();
+        }
+
+        [TestMethod] public void NamedCandidateKey() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BowlGame);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveCandidateKey("PrimarySponsor", "SecondarySponsor").WithName("Sponsorship").And
+                .NoOtherCandidateKeys();
+        }
+
+        [TestMethod] public void SingleFieldInMultipleCandidateKeys() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(KingOfEngland);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveCandidateKey("RegnalName", "RegnalNumber").WithName("Uno").And
+                .HaveCandidateKey("RegnalName", "RoyalHouse").WithName("Another").And
+                .HaveCandidateKey("RegnalNumber", "RoyalHouse").WithName("Third").And
+                .NoOtherCandidateKeys();
+        }
+
+        [TestMethod] public void DuplicateNamedCandidateKeys_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Check);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*Candidate Key*")                         // categorization
+                .WithMessage("*comprised*same*Fields*")                 // rationale
+                .WithMessage("*N2*N1*");                                // details
+        }
+
+        [TestMethod] public void DuplicateAnonymousCandidateKeys_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Pigment);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Pigment.ChemicalFormula)}*")    // source property
+                .WithMessage("*[Unique]*")                              // annotation
+                .WithMessage("*two or more*");                          // rationale
+        }
+
+        [TestMethod] public void FieldInSameCandidateKeyMultipleTimes_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Desert);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Desert.Length)}*")              // source property
+                .WithMessage("*[Unique]*")                              // annotation
+                .WithMessage("*two or more*")                           // rationale
+                .WithMessage("*Size*");                                 // details
+        }
+
+        [TestMethod] public void InvalidCandidateKeyName_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Allomancy);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Allomancy.MistingTerm)}*")      // source property
+                .WithMessage("*[Unique]*")                              // annotation
+                .WithMessage("*not a valid Candidate Key name*")        // rationale
+                .WithMessage("*\"\"*");                                 // details
+        }
+
+        [TestMethod] public void ReservedCandidateKeyName_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Lens);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Lens.IndexOfRefraction)}*")     // source property
+                .WithMessage("*[Unique]*")                              // annotation
+                .WithMessage("*reserved character sequence @@@*")       // rationale
+                .WithMessage("*@@@Key*");                               // details
+        }
+
+        [TestMethod] public void PathOnUniqueAnnotationForScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Sonnet);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Sonnet.Line1)}*")               // source property
+                .WithMessage("*[Unique]*")                              // annotation
+                .WithMessage("*path*does not exist*")                   // rationale
+                .WithMessage("*\"---\"*");                              // details
+        }
+
+        [TestMethod] public void CandidateKeyIsSupersetOfPrimaryKey_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(WorldHeritageSite);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                                // source type
+                .WithMessage("*Candidate Key*is a superset of*Primary Key*")    // rationale
+                .WithMessage("*\"X\"*");                                        // details
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/DataConverters.cs
+++ b/test/UnitTests/Kvasir/Translation/DataConverters.cs
@@ -1,0 +1,225 @@
+﻿using FluentAssertions;
+using Kvasir.Core;
+using Kvasir.Exceptions;
+using Kvasir.Schema;
+using Kvasir.Translation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+using static UT.Kvasir.Translation.TestComponents;
+
+namespace UT.Kvasir.Translation {
+    [TestClass, TestCategory("Data Converters")]
+    public class DataConverterTests {
+        [TestMethod] public void DataCoverterDoesNotChangeDataType() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Cenote);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Name", DBType.Text, IsNullable.No).And
+                .HaveField("MaxDepth", DBType.Single, IsNullable.No).And
+                .HaveField("IsKarst", DBType.Boolean, IsNullable.No).And
+                .HaveField("Latitude", DBType.Decimal, IsNullable.No).And
+                .HaveField("Longitude", DBType.Decimal, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void DataConverterChangesDataType() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Comet);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("AstronomicalIdentifier", DBType.Guid, IsNullable.No).And
+                .HaveField("Aphelion", DBType.Double, IsNullable.No).And
+                .HaveField("Perihelion", DBType.Int32, IsNullable.No).And
+                .HaveField("Eccentricity", DBType.Int32, IsNullable.No).And
+                .HaveField("MassKg", DBType.UInt64, IsNullable.No).And
+                .HaveField("Albedo", DBType.Double, IsNullable.No).And
+                .HaveField("OrbitalPeriod", DBType.Single, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void DataConverterResultTypeIsNonNullableWhileSourceIsNullable() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(RoyalHouse);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("HouseName", DBType.Text, IsNullable.No).And
+                .HaveField("Founded", DBType.DateTime, IsNullable.No).And
+                .HaveField("CurrentHead", DBType.Text, IsNullable.Yes).And
+                .HaveField("TotalMonarchs", DBType.Int32, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void DataCoverterResultTypeIsNullableWhileSourceIsNonNullable() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Planeswalker);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Name", DBType.Text, IsNullable.No).And
+                .HaveField("MannaCost", DBType.Int8, IsNullable.No).And
+                .HaveField("InitialLoyalty", DBType.Int8, IsNullable.No).And
+                .HaveField("Ability1", DBType.Text, IsNullable.No).And
+                .HaveField("Ability2", DBType.Text, IsNullable.No).And
+                .HaveField("Ability3", DBType.Text, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void DataCoverterSourceTypeIsNullableOnNonNullableField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(GolfHole);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("CourseID", DBType.Int32, IsNullable.No).And
+                .HaveField("HoleNumber", DBType.UInt8, IsNullable.No).And
+                .HaveField("Par", DBType.UInt8, IsNullable.No).And
+                .HaveField("DistanceToFlag", DBType.UInt16, IsNullable.No).And
+                .HaveField("NumSandTraps", DBType.UInt8, IsNullable.No).And
+                .HaveField("ContainsWaterHazard", DBType.Boolean, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void DataCoverterSourceTypeUnrelatedToFieldType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Jedi);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Jedi.MiddleName)}*")            // source property
+                .WithMessage("*[DataConverter]*")                       // annotation
+                .WithMessage($"*Field of type {nameof(String)}*")       // rationale
+                .WithMessage($"*operates on {nameof(Boolean)}*");       // details
+        }
+
+        [TestMethod] public void DataConverterSourceTypeCovertibleWithFieldType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ConstitutionalAmendment);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                                // source type
+                .WithMessage($"*{nameof(ConstitutionalAmendment.Number)}*")     // source property
+                .WithMessage("*[DataConverter]*")                               // annotation
+                .WithMessage($"*Field of type {typeof(int).Name}*")             // rationale
+                .WithMessage($"*operates on {typeof(long).Name}*");             // details
+        }
+
+        [TestMethod] public void DataConverterResultTypeNotSupported_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SNLEpisode);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(SNLEpisode.AirDate)}*")         // source property
+                .WithMessage("*[DataConverter]*")                       // annotation
+                .WithMessage("*result type*is not supported*")          // rationale
+                .WithMessage($"*{nameof(ArgumentException)}*");         // details
+        }
+
+        [TestMethod] public void DataConverterIsNotDataConverter_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(MetraRoute);
+
+            // Act
+            var act = () => translator[source];
+            
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                                   // source type
+                .WithMessage($"*{nameof(MetraRoute.Line)}*")                       // source property
+                .WithMessage("*[DataConverter]*")                                  // annotation
+                .WithMessage($"*does not implement*{nameof(IDataConverter)}*")     // rationale
+                .WithMessage($"*{typeof(int).Name}*");                             // details
+        }
+
+        [TestMethod] public void IdentityDataConverter() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(FieldGoal);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("When", DBType.DateTime, IsNullable.No).And
+                .HaveField("Made", DBType.Boolean, IsNullable.No).And
+                .HaveField("Doinks", DBType.Int32, IsNullable.No).And
+                .HaveField("Kicker", DBType.Text, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void MultipleDataConverters_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BowlingFrame);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(BowlingFrame.FirstThrowPins)}*")    // source property
+                .WithMessage("*[DataConverter]*")                           // annotation
+                .WithMessage("*multiple*");                                 // rationale
+        }
+
+        [TestMethod] public void PathOnDataConverterAnnotationForScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(DraftPick);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(DraftPick.Overall)}*")          // source property
+                .WithMessage("*[DataConverter]*")                       // annotation
+                .WithMessage("*path*does not exist*")                   // rationale
+                .WithMessage("*\"---\"*");                              // details
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/DefaultValues.cs
+++ b/test/UnitTests/Kvasir/Translation/DefaultValues.cs
@@ -1,0 +1,304 @@
+﻿using FluentAssertions;
+using Kvasir.Exceptions;
+using Kvasir.Translation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Optional;
+using System;
+
+using static UT.Kvasir.Translation.TestComponents;
+
+namespace UT.Kvasir.Translation {
+    [TestClass, TestCategory("Default Values")]
+    public class DefaultValueTests {
+        [TestMethod] public void ValidNonNullScalarDefaults() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BloodType);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("ABO", Option.Some("O")).And
+                .HaveField("RHPositive", Option.Some(true)).And
+                .HaveField("ApproxPrevalence", Option.Some(0.5f)).And
+                .HaveField("NumSubgroups", Option.Some(1)).And
+                .HaveField("AnnualDonationsL", Option.None<object>()).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void ValidNonNullDateTimeDefault() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Umpire);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("UniqueUmpireNumber", Option.None<object>()).And
+                .HaveField("Debut", Option.Some(new DateTime(1970, 1, 1))).And
+                .HaveField("UniformNumber", Option.None<object>()).And
+                .HaveField("Name", Option.None<object>()).And
+                .HaveField("Ejections", Option.None<object>()).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void ValidNonNullGuidDefault() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Saint);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("SainthoodIdentifier", Option.Some(new Guid("81a130d2-502f-4cf1-a376-63edeb000e9f"))).And
+                .HaveField("Name", Option.None<object>()).And
+                .HaveField("CanonizationDate", Option.None<object>()).And
+                .HaveField("FeastMonth", Option.None<object>()).And
+                .HaveField("FeastDay", Option.None<object>()).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void NullDefaultForNullableField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Pepper);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Genus", Option.None<object>()).And
+                .HaveField("Species", Option.None<object>()).And
+                .HaveField("CommonName", Option.Some<object>(DBNull.Value)).And
+                .HaveField("ScovilleRating", Option.None<object>()).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void InvalidUnconvertibleScalarDefault_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Battleship);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(Battleship.Length)}*")              // source property
+                .WithMessage("*[Default]*")                                 // annotation
+                .WithMessage($"*Field of type {nameof(UInt16)}*")           // rationale
+                .WithMessage($"*\"100 feet\" (of type {nameof(String)})*"); // details
+        }
+
+        [TestMethod] public void InvalidConvertibleScalarDefault_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(County);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(County.Population)}*")              // source property
+                .WithMessage("*[Default]*")                                 // annotation
+                .WithMessage($"*Field of type {nameof(UInt64)}*")           // rationale
+                .WithMessage($"*5000000 (of type {nameof(Int32)})*");       // details
+        }
+
+        [TestMethod] public void OtherwiseValidSingleElementArrayDefault_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BilliardBall);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(BilliardBall.Number)}*")        // source property
+                .WithMessage("*[Default]*")                             // annotation
+                .WithMessage("*array*");                                // rationale
+        }
+
+        [TestMethod] public void InvalidlyFormattedDateTimeDefault_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Tournament);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(Tournament.Kickoff)}*")             // source property
+                .WithMessage("*[Default]*")                                 // annotation
+                .WithMessage($"*could not parse*into {nameof(DateTime)}*")  // rationale
+                .WithMessage("*\"20030714\"*");                             // details
+        }
+
+        [TestMethod] public void InvalidRangeDateTimeDefault_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Sculpture);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(Sculpture.CreationDate)}*")         // source property
+                .WithMessage("*[Default]*")                                 // annotation
+                .WithMessage($"*could not parse*into {nameof(DateTime)}*")  // rationale
+                .WithMessage("*\"1344-18-18\"*");                           // details
+        }
+
+        [TestMethod] public void NonStringDateTimeDefault_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(RomanEmperor);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(RomanEmperor.ReignEnd)}*")          // source property
+                .WithMessage("*[Default]*")                                 // annotation
+                .WithMessage($"*Field of type {nameof(DateTime)}*")         // rationale
+                .WithMessage($"*true (of type {nameof(Boolean)})*")         // details
+                .WithMessage("*a string is required*");                     // explanation
+        }
+
+        [TestMethod] public void InvalidlyFormattedGuidDefault_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Gene);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                                // source type
+                .WithMessage($"*{nameof(Gene.UUID)}*")                          // source property
+                .WithMessage("*[Default]*")                                     // annotation
+                .WithMessage($"*could not parse*into {nameof(Guid)}*")          // rationale
+                .WithMessage("*\"ee98f44827b248a2bb9fc5ef342e7ab2!!!\"*");      // details
+        }
+
+        [TestMethod] public void NonStringGuidDefault_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(HogwartsHouse);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(HogwartsHouse.TermIndex)}*")        // source property
+                .WithMessage("*[Default]*")                                 // annotation
+                .WithMessage($"*Field of type {nameof(Guid)}*")             // rationale
+                .WithMessage($"*'^' (of type {nameof(Char)})*")             // details
+                .WithMessage("*a string is required*");                     // explanation
+        }
+
+        [TestMethod] public void NullDefaultForNonNullableField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(RadioStation);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(RadioStation.CallSign)}*")      // source property
+                .WithMessage("*null*for*non-nullable Field*");          // rationale
+        }
+
+        [TestMethod] public void ValidDefaultValueForOriginalTypeNotConvertedType() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(CrosswordClue);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("PuzzleID", Option.None<object>()).And
+                .HaveField("AcrossOrDown", Option.Some(65)).And
+                .HaveField("Number", Option.None<object>()).And
+                .HaveField("NumLetters", Option.None<object>()).And
+                .HaveField("ClueText", Option.None<object>()).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void ValidDefaultForConvertedTypeNotOriginalType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Coupon);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(Coupon.IsBOGO)}*")                  // source property
+                .WithMessage("*[Default]*")                                 // annotation
+                .WithMessage($"*Field of type {nameof(Boolean)}*")          // rationale
+                .WithMessage($"*0 (of type {nameof(Int32)})*");             // details
+        }
+
+        [TestMethod] public void MultipleDefaultsForSingleField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SkeeBall);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(SkeeBall.L1Value)}*")               // source property
+                .WithMessage("*[Default]*")                                 // annotation
+                .WithMessage("*multiple*");                                 // rationale
+        }
+
+        [TestMethod] public void PathOnDefaultAnnotationForScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(NativeAmericanTribe);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(NativeAmericanTribe.Exonym)}*") // source property
+                .WithMessage("*[Default]*")                             // annotation
+                .WithMessage("*path*does not exist*")                   // rationale
+                .WithMessage("*\"---\"*");                              // details
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/Identification.cs
+++ b/test/UnitTests/Kvasir/Translation/Identification.cs
@@ -1,0 +1,1005 @@
+﻿using FluentAssertions;
+using Kvasir.Exceptions;
+using Kvasir.Schema;
+using Kvasir.Translation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+using static UT.Kvasir.Translation.TestComponents;
+
+namespace UT.Kvasir.Translation {
+    [TestClass, TestCategory("Identification")]
+    public class IdentificationTests {
+        [TestMethod] public void NonNullableScalars() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Smorgasbord);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.CLRSource.Should().Be(source);
+            translation.Principal.Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestComponents+SmorgasbordTable").And
+                .HaveField("Byte", DBType.UInt8, IsNullable.No).And
+                .HaveField("Char", DBType.Character, IsNullable.No).And
+                .HaveField("DateTime", DBType.DateTime, IsNullable.No).And
+                .HaveField("Decimal", DBType.Decimal, IsNullable.No).And
+                .HaveField("Double", DBType.Double, IsNullable.No).And
+                .HaveField("Float", DBType.Single, IsNullable.No).And
+                .HaveField("Guid", DBType.Guid, IsNullable.No).And
+                .HaveField("Int", DBType.Int32, IsNullable.No).And
+                .HaveField("Long", DBType.Int64, IsNullable.No).And
+                .HaveField("SByte", DBType.Int8, IsNullable.No).And
+                .HaveField("Short", DBType.Int16, IsNullable.No).And
+                .HaveField("String", DBType.Text, IsNullable.No).And
+                .HaveField("UInt", DBType.UInt32, IsNullable.No).And
+                .HaveField("ULong", DBType.UInt64, IsNullable.No).And
+                .HaveField("UShort", DBType.UInt16, IsNullable.No);
+        }
+
+        [TestMethod] public void NullableScalars() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Plethora);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.CLRSource.Should().Be(source);
+            translation.Principal.Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestComponents+PlethoraTable").And
+                .HaveField("Byte", DBType.UInt8, IsNullable.Yes).And
+                .HaveField("Char", DBType.Character, IsNullable.Yes).And
+                .HaveField("DateTime", DBType.DateTime, IsNullable.Yes).And
+                .HaveField("Decimal", DBType.Decimal, IsNullable.Yes).And
+                .HaveField("Double", DBType.Double, IsNullable.Yes).And
+                .HaveField("Float", DBType.Single, IsNullable.Yes).And
+                .HaveField("Guid", DBType.Guid, IsNullable.Yes).And
+                .HaveField("Int", DBType.Int32, IsNullable.Yes).And
+                .HaveField("Long", DBType.Int64, IsNullable.Yes).And
+                .HaveField("SByte", DBType.Int8, IsNullable.Yes).And
+                .HaveField("Short", DBType.Int16, IsNullable.Yes).And
+                .HaveField("String", DBType.Text, IsNullable.Yes).And
+                .HaveField("UInt", DBType.UInt32, IsNullable.Yes).And
+                .HaveField("ULong", DBType.UInt64, IsNullable.Yes).And
+                .HaveField("UShort", DBType.UInt16, IsNullable.Yes);
+        }
+
+        [TestMethod] public void RecordClassEntityType() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Color);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.CLRSource.Should().Be(source);
+            translation.Principal.Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestComponents+ColorTable").And
+                .HaveField("Red", DBType.UInt8, IsNullable.No).And
+                .HaveField("Green", DBType.UInt8, IsNullable.No).And
+                .HaveField("Blue", DBType.UInt8, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void PartialEntityType() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PresidentialElection);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.CLRSource.Should().Be(source);
+            translation.Principal.Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestComponents+PresidentialElectionTable").And
+                .HaveField("Year", DBType.UInt16, IsNullable.No).And
+                .HaveField("DemocraticCandidate", DBType.Text, IsNullable.No).And
+                .HaveField("DemocraticPVs", DBType.UInt64, IsNullable.No).And
+                .HaveField("DemocraticEVs", DBType.UInt16, IsNullable.No).And
+                .HaveField("RepublicanCandidate", DBType.Text, IsNullable.No).And
+                .HaveField("RepublicanPVs", DBType.UInt64, IsNullable.No).And
+                .HaveField("RepublicanEVs", DBType.UInt16, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void NonPublicEntityType() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(TestComponents).GetNestedType("GitCommit", System.Reflection.BindingFlags.NonPublic)!;
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.CLRSource.Should().Be(source);
+            translation.Principal.Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestComponents+GitCommitTable").And
+                .HaveField("Hash", DBType.Text, IsNullable.No).And
+                .HaveField("Author", DBType.Text, IsNullable.No).And
+                .HaveField("Message", DBType.Text, IsNullable.No).And
+                .HaveField("Timestamp", DBType.DateTime, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void StructEntityType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Carbohydrate);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*cannot be an Entity Type*")              // rationale
+                .WithMessage("*struct or*record struct*");              // explanation
+        }
+
+        [TestMethod] public void RecordStructEntityType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(AminoAcid);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*cannot be an Entity Type*")              // rationale
+                .WithMessage("*struct or*record struct*");              // explanation
+        }
+
+        [TestMethod] public void AbstractEntityType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SuperBowl);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*cannot be an Entity Type*")              // rationale
+                .WithMessage("*abstract*");                             // explanation
+        }
+
+        [TestMethod] public void OpenGenericEntityType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Speedometer<>);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*cannot be an Entity Type*")              // rationale
+                .WithMessage("*open generic*");                         // explanation
+        }
+        
+        [TestMethod] public void ClosedGenericEntityType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Speedometer<int>);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*cannot be an Entity Type*")              // rationale
+                .WithMessage("*closed generic*");                       // explanation
+        }
+
+        [TestMethod] public void InterfaceEntityType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ILiquor);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*cannot be an Entity Type*")              // rationale
+                .WithMessage("*interface*");                            // explanation
+        }
+
+        [TestMethod] public void EnumEntityType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Season);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*cannot be an Entity Type*")              // rationale
+                .WithMessage("*enumeration*");                          // explanation
+        }
+
+        [TestMethod] public void PrimitiveEntityType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ushort);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*cannot be an Entity Type*")              // rationale
+                .WithMessage("*primitive*");                            // explanation
+        }
+
+        [TestMethod] public void EntityTypeWithZeroProperties_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Nothing);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*cannot be an Entity Type*")              // rationale
+                .WithMessage("*0 Fields*")                              // details
+                .WithMessage("*at least 2 Fields*");                    // explanation
+        }
+
+        [TestMethod] public void EntityTypeWithOneProperty_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Integer);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*cannot be an Entity Type*")              // rationale
+                .WithMessage("*1 Field*")                               // details
+                .WithMessage("*at least 2 Fields*");                    // explanation
+        }
+
+        [TestMethod] public void NonPublicPropertiesExcluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Animal);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .NotHaveField("Kingdom").And
+                .NotHaveField("Phylum").And
+                .NotHaveField("Class").And
+                .NotHaveField("Order").And
+                .NotHaveField("Family").And
+                .HaveField("Genus", DBType.Text, IsNullable.No).And
+                .HaveField("Species", DBType.Text, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void NonReadablePropertiesExcluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ScrabbleTile);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .NotHaveField("NumAvailable").And
+                .HaveField("Letter", DBType.Character, IsNullable.No).And
+                .HaveField("Value", DBType.UInt8, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void PublicPropertiesWithNonPublicAccessorsExcluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ChemicalElement);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .NotHaveField("AtomicNumber").And
+                .NotHaveField("AtomicWeight").And
+                .NotHaveField("Name").And
+                .NotHaveField("MeltingPoint").And
+                .NotHaveField("BoilingPoint").And
+                .HaveField("Symbol", DBType.Text, IsNullable.No).And
+                .HaveField("NumAllotropes", DBType.Int8, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void StaticPropertiesExcluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Circle);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .NotHaveField("PI").And
+                .HaveField("CenterX", DBType.Int32, IsNullable.No).And
+                .HaveField("CenterY", DBType.Int32, IsNullable.No).And
+                .HaveField("Radius", DBType.UInt64, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void IndexerPropertiesExcluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BattingOrder);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("GameID", DBType.Guid, IsNullable.No).And
+                .HaveField("Team", DBType.Text, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void CodeOnlyCausesPropertyToBeExcluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(QuadraticEquation);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .NotHaveField("Expression").And
+                .HaveField("QuadraticCoefficient", DBType.Int64, IsNullable.No).And
+                .HaveField("LinearCoefficient", DBType.Int64, IsNullable.No).And
+                .HaveField("Constant", DBType.Int64, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void VirtualPropertyDeclarationIncluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(GreekGod);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Name", DBType.Text, IsNullable.No).And
+                .HaveField("RomanEquivalent", DBType.Text, IsNullable.Yes).And
+                .HaveField("NumChildren", DBType.UInt32, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void InterfacePropertiesExcluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Movie);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .NotHaveField("English").And
+                .NotHaveField("French").And
+                .NotHaveField("Spanish").And
+                .HaveField("ID", DBType.Guid, IsNullable.No).And
+                .HaveField("Release", DBType.DateTime, IsNullable.No).And
+                .HaveField("Runtime", DBType.UInt8, IsNullable.No).And
+                .HaveField("Director", DBType.Text, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void InheritedPropertiesExcluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Holiday);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .NotHaveField("Day").And
+                .NotHaveField("Month").And
+                .NotHaveField("Year").And
+                .HaveField("Date", DBType.DateTime, IsNullable.No).And
+                .HaveField("Name", DBType.Text, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void OverridingPropertiesExcluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(POBox);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .NotHaveField("Number").And
+                .NotHaveField("Street").And
+                .NotHaveField("City").And
+                .NotHaveField("Country").And
+                .NotHaveField("Apartment").And
+                .HaveField("POBoxNumber", DBType.UInt32, IsNullable.No).And
+                .HaveField("KnownAs", DBType.Text, IsNullable.Yes).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void HidingPropertiesIncluded() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(FighterJet);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .NotHaveField("Company").And
+                .NotHaveField("Model").And
+                .NotHaveField("InUse").And
+                .HaveField("Type", DBType.Text, IsNullable.No).And
+                .HaveField("Nickname", DBType.Text, IsNullable.No).And
+                .HaveField("FirstFlight", DBType.DateTime, IsNullable.No).And
+                .HaveField("Capacity", DBType.UInt8, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void IndexerIncludedInModel_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Language);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*[IncludeInModel]*")                      // annotation
+                .WithMessage("*indexer*");                              // rationale
+        }
+
+        [TestMethod] public void NonReadablePropertyIncludedInModel_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(HebrewPrayer);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(HebrewPrayer.OnShabbat)}*")     // source property
+                .WithMessage("*[IncludeInModel]*")                      // annotation
+                .WithMessage("*write-only*");                           // rationale
+        }
+
+        [TestMethod] public void StaticPropertiesIncludedInModel() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ChessPiece);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Name", DBType.Text, IsNullable.No).And
+                .HaveField("Icon", DBType.Character, IsNullable.No).And
+                .HaveField("Value", DBType.UInt8, IsNullable.No).And
+                .HaveField("FIDE", DBType.Text, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void NonPublicPropertiesIncludedInModel() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Song);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Title", DBType.Text, IsNullable.No).And
+                .HaveField("Artist", DBType.Text, IsNullable.No).And
+                .HaveField("Album", DBType.Text, IsNullable.Yes).And
+                .HaveField("Length", DBType.UInt16, IsNullable.No).And
+                .HaveField("ReleaseYear", DBType.UInt16, IsNullable.No).And
+                .HaveField("Rating", DBType.Double, IsNullable.No).And
+                .HaveField("Grammys", DBType.UInt8, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void PublicPropertiesWithNonPublicAccessorsIncludedInModel() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Country);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Exonym", DBType.Text, IsNullable.No).And
+                .HaveField("Endonym", DBType.Text, IsNullable.No).And
+                .HaveField("IndependenceDay", DBType.DateTime, IsNullable.No).And
+                .HaveField("Population", DBType.UInt64, IsNullable.No).And
+                .HaveField("LandArea", DBType.UInt64, IsNullable.No).And
+                .HaveField("Coastline", DBType.UInt64, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void InterfacePropertyIncludedInModel_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Book);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Book.Title)}*")                 // source property
+                .WithMessage("*[IncludeInModel]*")                      // annotation
+                .WithMessage("*inherited*")                             // rationale
+                .WithMessage("*interface*");                            // details
+        }
+
+        [TestMethod] public void OverridingPropertyIncludedInModel_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Drum);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Drum.LowestKey)}*")             // source property
+                .WithMessage("*[IncludeInModel]*")                      // annotation
+                .WithMessage("*inherited*")                             // rationale
+                .WithMessage("*base class*");                          // details
+        }
+
+        [TestMethod] public void InterfacePropertyMarkedCodeOnly_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(IPAddress);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(IPAddress.RFC)}*")              // source property
+                .WithMessage("*[CodeOnly]*")                            // annotation
+                .WithMessage("*redundant*inherited*")                   // rationale
+                .WithMessage("*interface*");                            // details
+        }
+
+        [TestMethod] public void OverridingPropertyMarkedCodeOnly_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Submarine);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Submarine.NumWheels)}*")        // source property
+                .WithMessage("*[CodeOnly]*")                            // annotation
+                .WithMessage("*redundant*inherited*")                   // rationale
+                .WithMessage("*base class*");                           // details
+        }
+
+        [TestMethod] public void NonReadablePropertyMarkedCodeOnly_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(CourtCase);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(CourtCase.Year)}*")             // source property
+                .WithMessage("*[CodeOnly]*")                            // annotation
+                .WithMessage("*redundant*write-only*");                 // rationale
+        }
+
+        [TestMethod] public void NonPublicPropertyMarkedCodeOnly_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Lake);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*Depth*")                                 // source property
+                .WithMessage("*[CodeOnly]*")                            // annotation
+                .WithMessage("*redundant*non-public*");                 // rationale
+        }
+
+        [TestMethod] public void PublicPropertyWithNonPublicAccessorMarkedCodeOnly_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Mountain);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Mountain.Height)}*")            // source property
+                .WithMessage("*[CodeOnly]*")                            // annotation
+                .WithMessage("*redundant*non-public*");                 // rationale
+        }
+
+        [TestMethod] public void StaticPropertyMarkedCodeOnly_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Tossup);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Tossup.MinLength)}*")           // source property
+                .WithMessage("*[CodeOnly]*")                            // annotation
+                .WithMessage("*redundant*static*");                     // rationale
+        }
+
+        [TestMethod] public void IndexerMarkedCodeOnly_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(University);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*[CodeOnly]*")                            // annotation
+                .WithMessage("*redundant*indexer*");                    // rationale
+        }
+
+        [TestMethod] public void PropertyBothIncludedInModelAndCodeOnly_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(CreditCard);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(CreditCard.CVV)}*")             // source property
+                .WithMessage("*[IncludeInModel]*[CodeOnly]*")           // annotation
+                .WithMessage("*both*");                                 // rationale
+        }
+
+        [TestMethod] public void PropertyWithClrTypeDelegate_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Hurricane);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Hurricane.Form)}*")             // source property
+                .WithMessage("*has invalid type*")                      // rationale
+                .WithMessage($"*{nameof(Action)}*")                     // details
+                .WithMessage("*delegate*");                             // explanation
+        }
+
+        [TestMethod] public void PropertyWithClrTypeDynamic_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(MonopolyProperty);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(MonopolyProperty.HotelCost)}*") // source property
+                .WithMessage("*has invalid type*")                      // rationale
+                .WithMessage("*dynamic*");                              // explanation
+        }
+
+        [TestMethod] public void PropertyWithClrTypeObject_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(URL);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(URL.NetLoc)}*")                 // source property
+                .WithMessage("*has invalid type*")                      // rationale
+                .WithMessage($"*{nameof(Object)}*");                    // details
+        }
+
+        [TestMethod] public void PropertyWithClrTypeSystemEnum_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Enumeration);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Enumeration.ZeroValue)}*")      // source property
+                .WithMessage("*has invalid type*")                      // rationale
+                .WithMessage($"*{nameof(Enum)}*");                      // details
+        }
+
+        [TestMethod] public void PropertyWithClrTypeSystemValueType_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(YouTubeVideo);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(YouTubeVideo.CommentCount)}*")  // source property
+                .WithMessage("*has invalid type*")                      // rationale
+                .WithMessage($"*{nameof(ValueType)}*");                 // details
+        }
+
+        [TestMethod] public void PropertyWithClrTypeExternalAssemblyClass_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Coin);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Coin.CounterfeitResult)}*")     // source property
+                .WithMessage("*has invalid type*")                      // rationale
+                .WithMessage($"*{nameof(Exception)}*")                  // details
+                .WithMessage("*not from assembly*");                    // explanation
+        }
+
+        [TestMethod] public void PropertyWithClrTypeInterface_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Painting);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Painting.Artist)}*")            // source property
+                .WithMessage("*has invalid type*")                      // rationale
+                .WithMessage($"*{nameof(IArtist)}*")                    // details
+                .WithMessage("*interface*");                            // explanation
+        }
+
+        [TestMethod] public void PropertyWithClosedGenericUserClass_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SlackChannel);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(SlackChannel.NumMessages)}*")   // source property
+                .WithMessage("*has invalid type*")                      // rationale
+                .WithMessage($"*{nameof(MessageCount<ushort>)}*")       // details
+                .WithMessage("*closed generic class*");                 // explanation
+        }
+
+        [TestMethod] public void PropertyWithAbstractClass_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BotanicalGarden);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                                // source type
+                .WithMessage($"*{nameof(BotanicalGarden.OfficialFlower)}*")     // source property
+                .WithMessage("*has invalid type*")                              // rationale
+                .WithMessage($"*{nameof(Flower)}*")                             // details
+                .WithMessage("*abstract*");                                     // explanation
+        }
+
+        [TestMethod] public void PropertiesWithDisallowedTypesMarkedCodeOnly() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(DNDCharacter);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .NotHaveField("RollDice").And
+                .NotHaveField("Class").And
+                .NotHaveField("Race").And
+                .NotHaveField("HP").And
+                .NotHaveField("AttackEconomy").And
+                .NotHaveField("Armor").And
+                .HaveField("Name", DBType.Text, IsNullable.No).And
+                .HaveField("Charisma", DBType.UInt8, IsNullable.No).And
+                .HaveField("Constitution", DBType.UInt8, IsNullable.No).And
+                .HaveField("Dexterity", DBType.UInt8, IsNullable.No).And
+                .HaveField("Intelligence", DBType.UInt8, IsNullable.No).And
+                .HaveField("Strength", DBType.UInt8, IsNullable.No).And
+                .HaveField("Wisdom", DBType.UInt8, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void NonNullableScalarMarkedNullable() {
+            var translator = new Translator();
+            var source = typeof(Timestamp);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("UnixSinceEpoch", DBType.UInt64, IsNullable.No).And
+                .HaveField("Hour", DBType.UInt16, IsNullable.No).And
+                .HaveField("Minute", DBType.UInt16, IsNullable.No).And
+                .HaveField("Second", DBType.UInt16, IsNullable.No).And
+                .HaveField("Millisecond", DBType.UInt16, IsNullable.Yes).And
+                .HaveField("Microsecond", DBType.UInt16, IsNullable.Yes).And
+                .HaveField("Nanosecond", DBType.UInt16, IsNullable.Yes).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void NullableScalarMarkedNonNullable() {
+            var translator = new Translator();
+            var source = typeof(Bone);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("TA2", DBType.UInt32, IsNullable.No).And
+                .HaveField("Name", DBType.Text, IsNullable.No).And
+                .HaveField("LatinName", DBType.Text, IsNullable.Yes).And
+                .HaveField("MeSH", DBType.Text, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void NullableScalarMarkedNullable_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(CivMilitaryUnit);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(CivMilitaryUnit.Promotion)}*")  // source property
+                .WithMessage("*[Nullable]*")                            // annotation
+                .WithMessage("*redundant*");                            // rationale
+        }
+
+        [TestMethod] public void NonNullableScalarMarkedNonNullable_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Patent);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Patent.PublicationDate)}*")     // source property
+                .WithMessage("*[NonNullable]*")                         // annotation
+                .WithMessage("*redundant*");                            // rationale
+        }
+
+        [TestMethod] public void PropertyMarkedBothNullableAndNonNullable_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(RetailProduct);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(RetailProduct.SalePrice)}*")    // source property
+                .WithMessage("*[Nullable]*[NonNullable]*")              // annotation
+                .WithMessage("*both*");                                 // rationale
+        }
+
+        [TestMethod] public void PublicInstancePropertyAnnotatedIncludeInModel_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Haiku);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Haiku.Line2)}*")                // source property
+                .WithMessage("*[IncludeInModel]*")                      // annotation
+                .WithMessage("*public*non-static*");                    // rationale
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/Naming.cs
+++ b/test/UnitTests/Kvasir/Translation/Naming.cs
@@ -1,0 +1,234 @@
+﻿using FluentAssertions;
+using Kvasir.Exceptions;
+using Kvasir.Schema;
+using Kvasir.Translation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using static UT.Kvasir.Translation.TestComponents;
+
+namespace UT.Kvasir.Translation {
+    [TestClass, TestCategory("Naming")]
+    public class NamingTests {
+        [TestMethod] public void OddlyShapedFieldNames() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Surah);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.CLRSource.Should().Be(source);
+            translation.Principal.Table.Should()
+                .HaveField("_EnglishName", DBType.Text, IsNullable.No).And
+                .HaveField("__ArabicName", DBType.Text, IsNullable.No).And
+                .HaveField("juz_start", DBType.Decimal, IsNullable.No).And
+                .HaveField("juzEnd", DBType.Decimal, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void RenamePrimaryTable() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PlayingCard);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HaveName("DeckOfCards");
+        }
+
+        [TestMethod] public void NamespaceExcludedFromPrimaryTableName() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Pokemon);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HaveName("PokemonTable");
+        }
+
+        [TestMethod] public void DuplicatePrimaryTableName_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source1 = typeof(Flight);
+            var source2 = typeof(Battle);
+
+            // Act
+            _ = translator[source1];
+            var act = () => translator[source2];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source2.Name}*")                       // source type
+                .WithMessage("*Table name*is already in use*")          // rationale
+                .WithMessage("*\"Miscellaneous\"*");                    // details
+        }
+
+        [TestMethod] public void TableAnnotationDoesntChangeName_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Bookmark);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*[Table]*")                               // annotation
+                .WithMessage("*redundant*");                            // rationale
+        }
+
+        [TestMethod] public void InvalidPrimaryTableName_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(LogIn);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*[Table]*")                               // annotation
+                .WithMessage("*not a valid Table name*")                // rationale
+                .WithMessage("*\"\"*");                                 // details
+        }
+
+        [TestMethod] public void BothTableAndNamespaceExcludeAnnotations_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Encryption);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*[ExcludeNamespaceFromName]*[Table]*")    // annotation
+                .WithMessage("*both*");                                 // rationale
+        }
+
+        [TestMethod] public void RenameFields() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(River);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Name", DBType.Text, IsNullable.No).And
+                .HaveField("SourceElevation", DBType.UInt16, IsNullable.No).And
+                .HaveField("Length", DBType.UInt16, IsNullable.No).And
+                .HaveField("MouthLatitude", DBType.Decimal, IsNullable.No).And
+                .HaveField("MouthLongitude", DBType.Decimal, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void SwitchNamesOfFields() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Episode);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Number", DBType.UInt8, IsNullable.No).And
+                .HaveField("Season", DBType.Int16, IsNullable.No).And
+                .HaveField("Length", DBType.Single, IsNullable.No).And
+                .HaveField("Part", DBType.Int32, IsNullable.Yes).And
+                .HaveField("Title", DBType.Text, IsNullable.No).And
+                .NoOtherFields();
+        }
+
+        [TestMethod] public void DuplicateFieldName_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Ticket2RideRoute);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                                // source type
+                .WithMessage("*duplicate Field name*")                          // rationale
+                .WithMessage("*\"Destination\"*");                              // details
+        }
+
+        [TestMethod] public void SinglePropertyGivenMultipleNames_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BankAccount);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(BankAccount.RoutingNumber)}*")      // source property
+                .WithMessage("*[Name]*")                                    // annotation
+                .WithMessage("*multiple*");                                 // rationale
+        }
+
+        [TestMethod] public void NameAnnotationDoesntChangeName_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Opera);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(Opera.PremiereDate)}*")             // source property
+                .WithMessage("*[Name]*")                                    // annotation
+                .WithMessage("*redundant*");                                // rationale
+        }
+
+        [TestMethod] public void InvalidFieldName_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Volcano);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Volcano.IsActive)}*")           // source property
+                .WithMessage("*[Name]*")                                // annotation
+                .WithMessage("*not a valid Field name*")                // rationale
+                .WithMessage("*\"\"*");                                 // details
+        }
+
+        [TestMethod] public void PathOnFieldNameAnnotationForScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Legume);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Legume.Energy)}*")              // source property
+                .WithMessage("*[Name]*")                                // annotation
+                .WithMessage("*path*does not exist*")                   // rationale
+                .WithMessage("*\"---\"*");                              // details
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/Ordering.cs
+++ b/test/UnitTests/Kvasir/Translation/Ordering.cs
@@ -1,0 +1,88 @@
+﻿using FluentAssertions;
+using Kvasir.Exceptions;
+using Kvasir.Translation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using static UT.Kvasir.Translation.TestComponents;
+
+namespace UT.Kvasir.Translation {
+    [TestClass, TestCategory("Column Ordering")]
+    public class OrderingTests {
+        [TestMethod] public void AllFieldsManuallyOrdered() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Fraction);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("IsNegative", 0).And
+                .HaveField("Denominator", 1).And
+                .HaveField("Numerator", 2);
+        }
+
+        [TestMethod] public void SomeFieldsManuallyOrdered() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Parashah);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("EndChapter", 2).And
+                .HaveField("EndVerse", 3);
+        }
+
+        [TestMethod] public void DuplicateColumnIndices_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Pizza);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Pizza.Veggie2)}*")              // source property
+                .WithMessage("*[Column]*")                              // annotation
+                .WithMessage("*index*is already occupied*");            // rationale
+        }
+
+        [TestMethod] public void GapsInColumnIndices_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PhoneNumber);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*[Column]*")                              // annotation
+                .WithMessage("*indices are non-consecutive*");          // rationale
+        }
+
+        [TestMethod] public void NegativeColumnIndex_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(NationalPark);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(NationalPark.Established)}*")   // source property
+                .WithMessage("*[Column]*")                              // annotation
+                .WithMessage("*index*is negative*")                     // rationale
+                .WithMessage("*-196*");                                 // details
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/PrimaryKeys.cs
+++ b/test/UnitTests/Kvasir/Translation/PrimaryKeys.cs
@@ -1,0 +1,383 @@
+﻿using FluentAssertions;
+using Kvasir.Exceptions;
+using Kvasir.Translation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using static UT.Kvasir.Translation.TestComponents;
+
+namespace UT.Kvasir.Translation {
+    [TestClass, TestCategory("Primary Keys")]
+    public class PrimaryKeyTests {
+        [TestMethod] public void AnnotatedPrimaryKeySingleField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(XKCDComic);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("URL").WithoutName();
+        }
+
+        [TestMethod] public void AnnotatedPrimaryKeyMultipleFields() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Month);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("Calendar", "Index").WithoutName();
+        }
+
+        [TestMethod] public void AnnotatedPrimaryKeyAllFields() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Character);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("Glyph", "CodePoint", "IsASCII").WithoutName();
+        }
+
+        [TestMethod] public void DeducedPrimaryKeyNamedID() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Actor);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("ID").WithoutName();
+        }
+
+        [TestMethod] public void DeducedPrimaryKeyRenamedToID() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PokerHand);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("ID").WithoutName();
+        }
+
+        [TestMethod] public void DeducedPrimaryKeyNamedEntityID() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(IntegerSequence);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("IntegerSequenceID").WithoutName();
+        }
+
+        [TestMethod] public void DeducedPrimaryKeyRenamedToEntityID() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Stadium);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("StadiumID").WithoutName();
+        }
+
+        [TestMethod] public void DeducedPrimaryKeyArbitrateBetweenEntityIDandTableID() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Function);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("FunctionID").WithoutName();
+        }
+
+        [TestMethod] public void DeducedPrimaryKeySingleCandidateSingleNonNullableField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Star);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("ARICNS");
+            translation.Principal.Table.CandidateKeys.Should().BeEmpty();
+        }
+
+        [TestMethod] public void DeducedPrimaryKeySingleCandidateMultipleNonNullableFields() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Expiration);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HavePrimaryKey("FeedCode", "Underlying")
+                .WithName("PK");
+            translation.Principal.Table.CandidateKeys.Should().BeEmpty();
+        }
+
+        [TestMethod] public void DeducedPrimaryKeyMultipleCandidateKeysOnlyOneAllNonNullable() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Vitamin);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HavePrimaryKey("Carbon", "Hydrogen", "Cobalt", "Nitrogen", "Oxygen", "Phosphorus")
+                .WithName("Formula");
+            translation.Principal.Table.CandidateKeys.Count.Should().Be(1);
+        }
+
+        [TestMethod] public void DeducedPrimaryKeySingleNonNullableField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Earthquake);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("SeismicIdentificationNumber").WithoutName();
+        }
+
+        [TestMethod] public void DeducedPrimaryKeySingleAnnotatedNonNullableField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(GeologicEpoch);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("StartingMYA").WithoutName();
+        }
+
+        [TestMethod] public void NonDeduciblePrimaryKey_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(FederalLaw);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*unable to deduce Primary Key*");         // rationale
+        }
+
+        [TestMethod] public void NullableFieldAnnotatedPrimaryKey_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(NorseWorld);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(NorseWorld.EddaMentions)}*")    // source property
+                .WithMessage("*[PrimaryKey]*")                          // annotation
+                .WithMessage("*nullable*");                             // rationale
+        }
+
+        [TestMethod] public void DeducedPrimaryKeySkipNullableFieldNamedID() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Rollercoaster);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("RollercoasterID").WithoutName();
+        }
+
+        [TestMethod] public void DeducedPrimaryKeySkipNullableFieldNamedEntityID() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Doctor);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HavePrimaryKey("Regeneration", "Portrayal")
+                .WithName("DoctorWho");
+        }
+
+        [TestMethod] public void DeducedPrimaryKeySkipCandidateKeyWithNullableField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Polyhedron);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should().HavePrimaryKey("Name").WithoutName();
+        }
+
+        [TestMethod] public void NamedPrimaryKey() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(HebrewLetter);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HavePrimaryKey("Letter")
+                .WithName("LetterPK");
+        }
+
+        [TestMethod] public void NamedPrimaryKeyOverridesUnnamedCandidateKeyName() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(DatabaseField);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HavePrimaryKey("QualifiedName")
+                .WithName("PrimaryKey");
+            translation.Principal.Table.CandidateKeys.Should().BeEmpty();
+        }
+
+        [TestMethod] public void InvalidPrimaryKeyName_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Bay);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*[NamedPrimaryKey]*")                     // annotation
+                .WithMessage("*not a valid Primary Key name*")          // rationale
+                .WithMessage("*\"\"*");                                 // details
+        }
+
+        [TestMethod] public void NamedPrimaryKeyConflictsWithNameOfCandidateKeyPK_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(JigsawPuzzle);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                                        // source type
+                .WithMessage("*[NamedPrimaryKey]*")                                     // annotation
+                .WithMessage("*Candidate Key*deduced as*Primary Key*conflicting*")      // rationale
+                .WithMessage("*\"GlobalIdentifier\"*\"Something\"*");                   // details
+        }
+
+        [TestMethod] public void NamedPrimaryKeyRedundantWithNameOfCandidateKeyPK_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(TimeZone);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                                        // source type
+                .WithMessage("*[NamedPrimaryKey]*")                                     // annotation
+                .WithMessage("*Candidate Key*deduced as*Primary Key*redundant*")        // rationale
+                .WithMessage("*\"PK\"*");                                               // details
+        }
+
+        [TestMethod] public void NamedPrimaryKeyInUseByCandidateKeyNotPK_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Currency);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage("*[NamedPrimaryKey]*")                     // annotation
+                .WithMessage("*clashes*name of*Candidate Key*")         // rationale
+                .WithMessage("*\"Key13\"*");                            // details
+        }
+
+        [TestMethod] public void AnnotatedSolePrimaryKeyFieldAlsoUnnamedCandidateKey_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Waterfall);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                                            // source type
+                .WithMessage("*Candidate Key*is a superset of*Primary Key*")                // rationale
+                .WithMessage($"*{nameof(Waterfall.InternationalUnifiedWaterfallNumber)}*"); // details
+        }
+
+        [TestMethod] public void MultiplePrimaryKeyAnnotations_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Airport);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                            // source type
+                .WithMessage($"*{nameof(Airport.IATA)}*")                   // source property
+                .WithMessage("*[PrimaryKey]*")                              // annotation
+                .WithMessage("*multiple*");                                 // rationale
+        }
+
+        [TestMethod] public void PathOnPrimaryKeyAnnotationForScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Highway);
+
+            // Act
+            var act = () => translator[source];
+
+            // Assert
+            act.Should().Throw<KvasirException>()
+                .WithMessage($"*{source.Name}*")                        // source type
+                .WithMessage($"*{nameof(Highway.Number)}*")             // source property
+                .WithMessage("*[PrimaryKey]*")                          // annotation
+                .WithMessage("*path*does not exist*")                   // rationale
+                .WithMessage("*\"---\"*");                              // details
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/_Converters.cs
+++ b/test/UnitTests/Kvasir/Translation/_Converters.cs
@@ -1,0 +1,43 @@
+﻿using Kvasir.Core;
+using System;
+
+namespace UT.Kvasir.Translation {
+    internal static partial class TestComponents {
+        public class BoolToInt : IDataConverter<bool, int> {
+            public int Convert(bool source) { return source ? 1 : 0; }
+            public bool Revert(int result) { return result != 0; }
+        }
+        public class ByteModulo16 : IDataConverter<byte?, byte?> {
+            public byte? Convert(byte? source) { return source is null ? null : (byte)(source % 16); }
+            public byte? Revert(byte? result) { return result; }
+        }
+        public class CharToInt : IDataConverter<char, int> {
+            public int Convert(char source) { return source; }
+            public char Revert(int result) { return (char)result; }
+        }
+        public class DateToError : IDataConverter<DateTime, ArgumentException> {
+            public ArgumentException Convert(DateTime source) { return new ArgumentException(source.ToString()); }
+            public DateTime Revert(ArgumentException result) { return DateTime.Parse(result.Message); }
+        }
+        public class DeNullify<T> : IDataConverter<T?, T> where T : notnull {
+            public T Convert(T? source) { return source!; }
+            public T? Revert(T result) { return result; }
+        }
+        public class Identity<T> : IDataConverter<T, T> {
+            public T Convert(T source) { return source; }
+            public T Revert(T result) { return result; }
+        }
+        public class InvertBoolean : IDataConverter<bool, bool> {
+            public bool Convert(bool source) { return !source; }
+            public bool Revert(bool result) { return !result; }
+        }
+        public class Nullify<T> : IDataConverter<T, T?> where T : notnull {
+            public T? Convert(T source) { return source; }
+            public T Revert(T? source) { return source ?? default!; }
+        }
+        public class RoundDownDouble : IDataConverter<double, int> {
+            public int Convert(double source) { return (int)source; }
+            public double Revert(int result) { return result + 0.5; }
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -1,0 +1,1365 @@
+﻿using Kvasir.Annotations;
+using System;
+
+namespace UT.Kvasir.Translation {
+    internal static partial class TestComponents {
+        /////// --- Scalar DataTypes
+
+            // Test Scenario: Non-Nullable Scalars
+            public class Smorgasbord {
+                public byte Byte { get; set; }
+                public char Char { get; set; }
+                public DateTime DateTime { get; set; }
+                public decimal Decimal { get; set; }
+                public double Double { get; set; }
+                public float Float { get; set; }
+                public Guid Guid { get; set; }
+                [PrimaryKey] public int Int { get; set; }
+                public long Long { get; set; }
+                public sbyte SByte { get; set; }
+                public short Short { get; set; }
+                public string String { get; set; } = "";
+                public uint UInt { get; set; }
+                public ulong ULong { get; set; }
+                public ushort UShort { get; set; }
+            }
+
+            // Test Scenario: Nullable Scalars
+            public class Plethora {
+                public byte? Byte { get; set; }
+                public char? Char { get; set; }
+                public DateTime? DateTime { get; set; }
+                public decimal? Decimal { get; set; }
+                public double? Double { get; set; }
+                public float? Float { get; set; }
+                public Guid? Guid { get; set; }
+                public int? Int { get; set; }
+                public long? Long { get; set; }
+                public sbyte? SByte { get; set; }
+                public short? Short { get; set; }
+                public string? String { get; set; } = "";
+                public uint? UInt { get; set; }
+                public ulong? ULong { get; set; }
+                public ushort? UShort { get; set; }
+                [PrimaryKey] public int PrimaryKey { get; set; }
+            }
+
+        /////// --- Various Shapes of Entity Type
+
+            // Test Scenario: Record Class Entity Type
+            public record class Color {
+                [PrimaryKey] public byte Red { get; set; }
+                [PrimaryKey] public byte Green { get; set; }
+                [PrimaryKey] public byte Blue { get; set; }
+            }
+
+            // Test Scenario: Partial Entity Type
+            public partial class PresidentialElection {
+                [PrimaryKey] public ushort Year { get; set; }
+                public string DemocraticCandidate { get; set; } = "";
+                public ulong DemocraticPVs { get; set; }
+                public ushort DemocraticEVs { get; set; }
+            }
+            public partial class PresidentialElection {
+                public string RepublicanCandidate { get; set; } = "";
+                public ulong RepublicanPVs { get; set; }
+                public ushort RepublicanEVs { get; set; }
+            }
+
+            // Test Scenario: Non-Public Entity Type
+            private class GitCommit {
+                [PrimaryKey] public string Hash { get; set; } = "";
+                public string Author { get; set; } = "";
+                public string Message { get; set; } = "";
+                public DateTime Timestamp { get; set; }
+            }
+
+            // Test Scenario: Struct Entity Type {error}
+            public struct Carbohydrate {
+                [PrimaryKey] public uint Carbon { get; set; }
+                [PrimaryKey] public uint Hydrogen { get; set; }
+                [PrimaryKey] public uint Oxygen { get; set; }
+            }
+
+            // Test Scenario: Record Struct Entity Type {error}
+            public record struct AminoAcid {
+                [PrimaryKey] public char Symbol { get; set; }
+                public uint Carbon { get; set; }
+                public uint Hydrogen { get; set; }
+                public uint Nitrogen { get; set; }
+                public uint Oxygen { get; set; }
+                public uint Sulfur { get; set; }
+            }
+
+            // Test Scenario: Abstract Entity Type {error}
+            public abstract class SuperBowl {
+                [PrimaryKey] public ushort Year { get; set; }
+                public string HomeTeam { get; set; } = "";
+                public string AwayTeam { get; set; } = "";
+                public byte HomeScore { get; set; }
+                public byte AwayScore { get; set; }
+                public bool HomeWins { get; set; }
+            }
+
+            // Test Scenario: Generic Entity Type {error}
+            public class Speedometer<TUnit> {
+                [PrimaryKey] public long MinSpeed { get; set; }
+                [PrimaryKey] public long MaxSpeed { get; set; }
+                public string Brand { get; set; } = "";
+            }
+
+            // Test Scenario: Interface Entity Type {error}
+            public interface ILiquor {
+                [PrimaryKey] public string Name { get; set; }
+                public ushort Proof { get; set; }
+                public float AlcoholByVolume { get; set; }
+            }
+
+            // Test Scenario: Enumeration Entity Type {error}
+            public enum Season {
+                Winter,
+                Spring,
+                Summer,
+                Fall,
+                Autumn = Fall,
+            }
+
+            // Test Scenario: Entity Type with Zero Properties {error}
+            public class Nothing {}
+
+            // Test Scenario: Entity type with Exactly One Property {error}
+            public class Integer {
+                [PrimaryKey] public int Value { get; set; }
+            }
+
+        /////// --- Property Inclusion/Exclusion
+
+            // Test Scenario: Non-Public Property is Excluded
+            public class Animal {
+                private string Kingdom { get; set; } = "";
+                protected string Phylum { get; set; } = "";
+                internal string Class { get; set; } = "";
+                protected internal string Order { get; set; } = "";
+                private protected string Family { get; set; } = "";
+                [PrimaryKey] public string Genus { get; set; } = "";
+                [PrimaryKey] public string Species { get; set; } = "";
+            }
+
+            // Test Scenario: Non-Readable Property is Excluded
+            public class ScrabbleTile {
+                [PrimaryKey] public char Letter { get; set; }
+                public byte Value { get; set; }
+                public ushort NumAvailable { set {} }
+            }
+
+            // Test Scenario: Property with Non-Public Accessor is Excluded
+            public class ChemicalElement {
+                [PrimaryKey] public string Symbol { get; set; } = "";
+                public byte AtomicNumber { private get; set; }
+                public decimal AtomicWeight { protected get; set; }
+                public string Name { internal get; set; } = "";
+                public ushort? MeltingPoint { protected internal get; set; }
+                public ushort? BoilingPoint { private protected get; set; }
+                public sbyte NumAllotropes { get; set; }
+            }
+
+            // Test Scenario: Static Property is Excluded
+            public class Circle {
+                [PrimaryKey] public int CenterX { get; set; }
+                [PrimaryKey] public int CenterY { get; set; }
+                [PrimaryKey] public ulong Radius { get; set; }
+                public static double PI { get; }
+            }
+
+            // Test Scenario: Indexer is Excluded
+            public class BattingOrder {
+                [PrimaryKey] public Guid GameID { get; set; }
+                public string Team { get; set; } = "";
+                public string this[int position] { get { return ""; } set {} }
+            }
+
+            // Test Scenario: [CodeOnly] Property that would Otherwise be Included
+            public class QuadraticEquation {
+                [CodeOnly] public string Expression { get; set; } = "";
+                [PrimaryKey] public long QuadraticCoefficient { get; set; }
+                [PrimaryKey] public long LinearCoefficient { get; set; }
+                [PrimaryKey] public long Constant { get; set; }
+            }
+
+            // Test Scenario: First-Definition Virtual Property
+            public class GreekGod {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public string? RomanEquivalent { get; set; }
+                public virtual uint NumChildren { get; set; }
+            }
+
+            // Test Scenario: Property Declared by an Interface is Excluded
+            public interface IMultilingual {
+                string English { get; set; }
+                string French { get; set; }
+                string Spanish { get; set; }
+            }
+            public class Movie : IMultilingual {
+                [PrimaryKey] public Guid ID { get; set; }
+                public string English { get; set; } = "";
+                public string French { get; set; } = "";
+                public string Spanish { get; set; } = "";
+                public DateTime Release { get; set; }
+                public byte Runtime { get; set; }
+                public string Director { get; set; } = "";
+            }
+
+            // Test Scenario: Property Inherited from a Base Class is Excluded
+            public abstract class Date {
+                public byte Day { get; set; }
+                public byte Month { get; set; }
+                public short Year { get; set; }
+            }
+            public class Holiday : Date {
+                [PrimaryKey] public DateTime Date { get; set; }
+                [PrimaryKey] public string Name { get; set; } = "";
+            }
+
+            // Test Scenario: Overriding Property is Excluded
+            public abstract class Address {
+                public virtual long Number { get; set; }
+                public virtual string Street { get; set; } = "";
+                public virtual string City { get; set; } = "";
+                public virtual string Country { get; set; } = "";
+                public virtual byte? Apartment { get; set; }
+            }
+            public class POBox : Address {
+                public override long Number { get; set; }
+                public override string Street { get; set; } = "";
+                public override string City { get; set; } = "";
+                public override string Country { get; set; } = "";
+                public override byte? Apartment { get; set; }
+                [PrimaryKey] public uint POBoxNumber { get; set; }
+                public string? KnownAs { get; set; }
+            }
+
+            // Test Scenario: Hiding Property
+            public abstract class Airplane {
+                public string Company { get; set; } = "";
+                public long Model { get; set; }
+                public DateTime FirstFlight { get; set; }
+                public ushort Capacity { get; set; }
+                public bool InUse { get; set; }
+            }
+            public class FighterJet : Airplane {
+                [PrimaryKey] public string Type { get; set; } = "";
+                public string Nickname { get; set; } = "";
+                public new DateTime FirstFlight { get; set; }
+                public new byte Capacity { get; set; }
+            }
+
+            // Test Scenario: Indexer Annotated as [IncludeInModel] {error}
+            public class Language {
+                public string Exonym { get; set; } = "";
+                [PrimaryKey] public string Endonym { get; set; } = "";
+                public ulong Speakers { get; set; }
+                public string ISOCode { get; set; } = "";
+                public ushort Letters { get; set; }
+                [IncludeInModel] public string this[string word] { get { return ""; } set {} }
+            }
+
+            // Test Scenario: Non-Readable Property Annotated as [IncludeInModel] {error}
+            public class HebrewPrayer {
+                [PrimaryKey] public string Name { get; set; } = "";
+                [IncludeInModel] public bool OnShabbat { set {} }
+                public string Text { get; set; } = "";
+            }
+
+            // Test Scenario: Static Property Annotated as [IncludeInModel]
+            public class ChessPiece {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public char Icon { get; set; }
+                public byte Value { get; set; }
+                [IncludeInModel] public static string FIDE { get; set; } = "FIDE";
+            }
+
+            // Test Scenario: Non-Public Property Annotated as [IncludeInModel]
+            public class Song {
+                [PrimaryKey] public string Title { get; set; } = "";
+                [PrimaryKey] public string Artist { get; set; } = "";
+                [IncludeInModel] private string? Album { get; set; } = "";
+                [IncludeInModel] protected ushort Length { get; set; }
+                [IncludeInModel] internal ushort ReleaseYear { get; set; }
+                [IncludeInModel] protected internal double Rating { get; set; }
+                [IncludeInModel] private protected byte Grammys { get; set; }
+            }
+
+            // Test Scenario: Property w/ Non-Public Accessor Annotated as [IncludeInModel]
+            public class Country {
+                [PrimaryKey] public string Exonym { get; set; } = "";
+                [IncludeInModel] public string Endonym { private get; set; } = "";
+                [IncludeInModel] public DateTime IndependenceDay { protected get; set; }
+                [IncludeInModel] public ulong Population { internal get; set; }
+                [IncludeInModel] public ulong LandArea { protected internal get; set; }
+                [IncludeInModel] public ulong Coastline { private protected get; set; }
+            }
+
+            // Test Scenario: Property Declared by an Interface Annotated as [IncludeInModel] by Implementation {error}
+            public interface ILiterature {
+                string Title { get; set; }
+                uint PageCount { get; set; }
+                uint WordCount { get; set; }
+            }
+            public class Book : ILiterature {
+                [PrimaryKey] public ulong ISBN { get; set; }
+                [IncludeInModel] public string Title { get; set; } = "";
+                public uint PageCount { get; set; }
+                public uint WordCount { get; set; }
+            }
+
+            // Test Scenario: Overriding Property Annotated as [IncludeInModel] {error}
+            public abstract class Instrument {
+                public string HornbostelSachs { get; set; } = "";
+                public virtual string? HighestKey { get; set; }
+                public virtual string? LowestKey { get; set; }
+            }
+            public class Drum : Instrument {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public bool UseDrumsticks { get; set; }
+                [IncludeInModel] public override string? LowestKey { get; set; }
+            }
+
+            // Test Scenario: Property Declared by an Interface Annotated as [CodeOnly] by Implementation {error}
+            public interface IWebProtocol {
+                int RFC { get; set; }
+            }
+            public class IPAddress : IWebProtocol {
+                [PrimaryKey] public ulong Value { get; set; }
+                [PrimaryKey] public ulong Version { get; set; }
+                [CodeOnly] public int RFC { get; set; }
+            }
+
+            // Test Scenario: Overriding Property Annotated as [CodeOnly] {error}
+            public abstract class Vehicle {
+                public bool CanFly { get; set; }
+                public bool IsAquatic { get; set; }
+                public virtual int NumWheels { get; set; }
+            }
+            public class Submarine : Vehicle {
+                [PrimaryKey] public Guid Identifier { get; set; }
+                public string Class { get; set; } = "";
+                [CodeOnly] public override int NumWheels { get; set; }
+                public DateTime Commissioned { get; set; }
+                public bool IsActive { get; set; }
+                public ushort CrewMembers { get; set; }
+                public ulong Weight { get; set; }
+        }
+
+            // Test Scenario: Non-Readable Property Annotated as [CodeOnly] {error}
+            public class CourtCase {
+                [PrimaryKey] public ushort Volume { get; set; }
+                [PrimaryKey] public uint CasePage { get; set; }
+                [CodeOnly] public ulong Year { set {} }
+                public string Plaintiff { get; set; } = "";
+                public string Defendant { get; set; } = "";
+            }
+
+            // Test Scenario: Non-Public Property Annotated as [CodeOnly] {error}
+            public class Lake {
+                [PrimaryKey] public decimal Latitude { get; set; }
+                [PrimaryKey] public decimal Longitude { get; set; }
+                public ulong SurfaceArea { get; set; }
+                [CodeOnly] private ulong Depth { get; set; }
+            }
+
+            // Test Scenario: Property w/ Non-Public Accessor Annotated as [CodeOnly] {error}
+            public class Mountain {
+                [PrimaryKey] public string Name { get; set; } = "";
+                [CodeOnly] public long Height { protected get; set; }
+                public decimal Latitude { get; set; }
+                public decimal Longitude { get; set; }
+                public bool SevenSummits { get; set; }
+            }
+
+            // Test Scenario: Static Property Annotated as [CodeOnly] {error}
+            public class Tossup {
+                [PrimaryKey] public uint ID { get; set; }
+                public string LocationCode { get; set; } = "";
+                public string SubjectCode { get; set; } = "";
+                public string TimeCode { get; set; } = "";
+                public string Body { get; set; } = "";
+                [CodeOnly] public static byte MinLength { get; set; }
+                public static byte MaxLength { get; set; }
+            }
+
+            // Test Scenario: Indexer Annotated as [CodeOnly] {error}
+            public class University {
+                [PrimaryKey] public string System { get; set; } = "";
+                [PrimaryKey] public string Campus { get; set; } = "";
+                public ulong UndergradEnrollment { get; set; }
+                public ulong GraduateEnrollment { get; set; }
+                public ulong Endowment { get; set; }
+                [CodeOnly] public int this[int index] { get { return -1; } set {} }
+            }
+
+            // Test Scenario: Property Annotated as Both [CodeOnly] and [IncludeInModel] {error}
+            public class CreditCard {
+                [PrimaryKey] public string Number { get; set; } = "";
+                public DateTime Expiration { get; set; }
+                [IncludeInModel, CodeOnly] public byte CVV { get; set; }
+            }
+
+            // Test Scenario: Public, Instance Property Annotated as [IncludeInModel] {error}
+            public class Haiku {
+                [PrimaryKey] public string Title { get; set; } = "";
+                public string Author { get; set; } = "";
+                public string Line1 { get; set; } = "";
+                [IncludeInModel] public string Line2 { get; set; } = "";
+                public string Line3 { get; set; } = "";
+            }
+
+        /////// --- Invalid Property Types
+
+            // Test Scenario: Property with a Delegate CLR Type {error}
+            public delegate void HurricaneAction();
+            public class Hurricane {
+                [PrimaryKey] public short Year { get; set; }
+                [PrimaryKey] public byte Number { get; set; }
+                public ulong TopWindSpeed { get; set; }
+                public ulong Damage { get; set; }
+                public uint Casualties { get; set; }
+                public HurricaneAction Form { get; set; } = () => {};
+            }
+
+            // Test Scenario: Property with a Dynamic CLR Type {error}
+            public class MonopolyProperty {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public byte Rent { get; set; }
+                public byte Mortgage { get; set; }
+                public dynamic HotelCost { get; set; } = 100.0;
+            }
+
+            // Test Scenario: Property with CLR Type of object {error}
+            public class URL {
+                public string Scheme { get; set; } = "";
+                public object? NetLoc { get; set; }
+                [PrimaryKey] public string Path { get; set; } = "";
+                public string Params { get; set; } = "";
+                public string? Query { get; set; }
+                public string? Fragment { get; set; }
+                public string? Username { get; set; }
+                public string? Password { get; set; }
+                public string? Hostname { get; set; }
+                public ushort Port { get; set; }
+            }
+
+            // Test Scenario: Property with a CLR Type of System.Enum {error}
+            public class Enumeration {
+                [PrimaryKey] public string Namespace { get; set; } = "";
+                [PrimaryKey] public string Typename { get; set; } = "";
+                public Enum? ZeroValue { get; set; }
+                public uint EnumeratorCount { get; set; }
+            }
+
+            // Test Scenario: Property with a CLR Type of System.ValueType {error}
+            public class YouTubeVideo {
+                [PrimaryKey] public string URL { get; set; } = "";
+                public uint Length { get; set; }
+                public ulong Likes { get; set; }
+                public string Channel { get; set; } = "";
+                public ValueType CommentCount { get; set; } = 0;
+            }
+
+            // Test Scenario: Property with a CLR Type that is a Standard Library Class {error}
+            public class Coin {
+                [PrimaryKey] public byte Value { get; set; }
+                public float Diameter { get; set; }
+                [PrimaryKey] public bool InCirculation { get; set; }
+                public Exception CounterfeitResult { get; set; } = new ApplicationException("COUNTERFEIT!");
+            }
+
+            // Test Scenario: Property with a CLR Type that is a User-Defined Interface {error}
+            public interface IArtist {}
+            public class Painting {
+                [PrimaryKey] public Guid NGAID { get; set; }
+                public decimal Height { get; set; }
+                public decimal Width { get; set; }
+                public IArtist? Artist { get; set; }
+                public short Year { get; set; }
+            }
+
+            // Test Scenario: Property with a Closed Generic User-Defined Class {error}
+            public class MessageCount<T> {}
+            public class SlackChannel {
+                [PrimaryKey] public Guid ID { get; set; }
+                public string ChannelName { get; set; } = "";
+                public long Members { get; set; }
+                public bool IsPrivate { get; set; }
+                public MessageCount<short>? NumMessages { get; set; }
+            }
+
+            // Test Scenario: Property with an Abstract User-Defined Class {error}
+            public abstract class Flower {}
+            public class BotanicalGarden {
+                [PrimaryKey] public int ID { get; set; }
+                public DateTime Opening { get; set; }
+                public ulong VisitorsPerYear { get; set; }
+                public Flower? OfficialFlower { get; set; }
+            }
+
+            // Test Scenario: [CodeOnly] on Properties with Otherwise Invalid CLR Types
+            public interface IArmor {}
+            public class CustomBackground<T> {}
+            public class DNDCharacter {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public byte Charisma { get; set; }
+                public byte Constitution { get; set; }
+                public byte Dexterity { get; set; }
+                public byte Intelligence { get; set; }
+                public byte Strength { get; set; }
+                public byte Wisdom { get; set; }
+                [CodeOnly] public Func<byte, byte, bool, byte>? RollDice { get; set; }
+                [CodeOnly] public dynamic Class { get; set; } = -1;
+                [CodeOnly] public object? SubClass { get; set; }
+                [CodeOnly] public Enum Race { get; set; } = GCCollectionMode.Optimized;
+                [CodeOnly] public ValueType HP { get; set; } = 0;
+                [CodeOnly] public Tuple<int, int> AttackEconomy { get; set; } = new Tuple<int, int>(1, 1);
+                [CodeOnly] public IArmor? Armor { get; set; }
+                [CodeOnly] public CustomBackground<DNDCharacter>? Background { get; set; }
+            }
+
+        /////// --- Nullability Annotations
+
+            // Test Scenario: Non-Nullable Scalar Annotated as [Nullable]
+            public class Timestamp {
+                [PrimaryKey] public ulong UnixSinceEpoch { get; set; }
+                public ushort Hour { get; set; }
+                public ushort Minute { get; set; }
+                public ushort Second { get; set; }
+                [Nullable] public ushort Millisecond { get; set; }
+                [Nullable] public ushort Microsecond { get; set; }
+                [Nullable] public ushort Nanosecond { get; set; }
+            }
+
+            // Test Scenario: Nullable Scalar Annotated as [NonNullable]
+            public class Bone {
+                [PrimaryKey] public uint TA2 { get; set; }
+                [NonNullable] public string? Name { get; set; }
+                public string? LatinName { get; set; } = "";
+                public string MeSH { get; set; } = "";
+            }
+
+            // Test Scenario: Redundant [Nullable] Annotation {error}
+            public class CivMilitaryUnit {
+                [PrimaryKey] public string Identifier { get; set; } = "";
+                [Nullable] public string? Promotion { get; set; } = "";
+                public byte MeleeStrength { get; set; }
+                public byte? RangedStrength { get; set; }
+                public bool IsUnique { get; set; }
+            }
+
+            // Test Scenario: Redundant [NonNullable] Annotation {error}
+            public class Patent {
+                [PrimaryKey] public ulong DocumentID { get; set; }
+                [NonNullable] public DateTime PublicationDate { get; set; }
+                public string? Description { get; set; }
+                public ulong ApplicationNumber { get; set; }
+            }
+
+            // Test Scenario: Both [Nullable] & [NonNullable] Annotation {error}
+            public class RetailProduct {
+                [PrimaryKey] public Guid ID { get; set; }
+                public string Name { get; set; } = "";
+                public string Description { get; set; } = "";
+                public decimal BasePrice { get; set; }
+                [Nullable, NonNullable] public decimal SalePrice { get; set; }
+                public ulong StockCount { get; set; }
+                public uint CategoryID { get; set; }
+            }
+
+        /////// --- Table Renaming
+
+            // Test Scenario: Entity Type Annotated with [Table]
+            [Table("DeckOfCards")] public class PlayingCard {
+                [PrimaryKey] public byte Suit { get; set; }
+                [PrimaryKey] public byte Value { get; set; }
+            }
+
+            // Test Scenario: Entity Type Annotated with [ExcludeNamespaceFromName]
+            [ExcludeNamespaceFromName] public class Pokemon {
+                [PrimaryKey] public ushort PokedexNumber { get; set; }
+                public string PrimaryType { get; set; } = "";
+                public string? SecondaryType { get; set; }
+                public string Name { get; set; } = "";
+                public string JapaneseName { get; set; } = "";
+                public byte HP { get; set; }
+            }
+
+            // Test Scenario: Duplicated Primary [Table] Names {error}
+            [Table("Miscellaneous")] public class Flight {
+                [PrimaryKey] public Guid ID { get; set; }
+                public string Airline { get; set; } = "";
+                public DateTime Departure { get; set; }
+                public DateTime Arrival { get; set; }
+                public string FromAirport { get; set; } = "";
+                public string ToAirport { get; set; } = "";
+                public byte Capacity { get; set; }
+            }
+            [Table("Miscellaneous")] public class Battle {
+                [PrimaryKey] public string Name { get; set; } = "";
+                [PrimaryKey] public string War { get; set; } = "";
+                public DateTime StartDate { get; set; }
+                public DateTime EndDate { get; set; }
+                public string WinningCommander { get; set; } = "";
+                public string LosingCommander { get; set; } = "";
+                public ulong Casualties { get; set; }
+            }
+
+            // [Table] Annotation Given Type's Namespace-Qualified Name + "Table" {error}
+            [Table("UT.Kvasir.Translation.TestComponents+BookmarkTable")] public class Bookmark {
+                [PrimaryKey] public string URL { get; set; } = "";
+                public bool IsFavorite { get; set; }
+                public string Icon { get; set; } = "";
+                public bool IsOnDesktop { get; set; }
+            }
+
+            // Test Scenario: Invalid [Table] Name {error}
+            [Table("")] public class LogIn {
+                [PrimaryKey] public string Username { get; set; } = "";
+                public string Password { get; set; } = "";
+            }
+
+            // Test Scenario: Entity Type Annotated with both [Table] ad [ExcludeNamespaceFromName] {error}
+            [Table("SomeTable"), ExcludeNamespaceFromName] public class Encryption {
+                [PrimaryKey] public string Scheme { get; set; } = "";
+                public ulong PublicKey { get; set; }
+                public ulong PrivateKey { get; set; }
+            }
+
+        /////// --- Field Naming
+        
+            // Test Scenario: Fields with Oddly-Shaped Names
+            public class Surah {
+                [PrimaryKey] public string _EnglishName { get; set; } = "";
+                public string __ArabicName { get; set; } = "";
+                public decimal juz_start { get; set; }
+                public decimal juzEnd { get; set; }
+            }
+        
+            // Test Scenario: Rename Field to Brand New Name
+            public class River {
+                [PrimaryKey] public string Name { get; set; } = "";
+                [Name("SourceElevation")] public ushort Ahuiehknaafuyur { get; set; }
+                [Name("Length")] public ushort OEperaehrugyUIWJKuygajk { get; set; }
+                public decimal MouthLatitude { get; set; }
+                public decimal MouthLongitude { get; set; }
+            }
+
+            // Test Scenario: Swap Names of Fields
+            public class Episode {
+                [PrimaryKey, Name("Number")] public byte Season { get; set; }
+                [PrimaryKey, Name("Season")] public short Number { get; set; }
+                public float Length { get; set; }
+                public int? Part { get; set; }
+                public string Title { get; set; } = "";
+            }
+
+            // Test Scenario: Duplicated Field Names {error}
+            public class Ticket2RideRoute {
+                [PrimaryKey, Name("Destination")] public string City1 { get; set; } = "";
+                [PrimaryKey, Name("Destination")] public string City2 { get; set; } = "";
+                public byte Points { get; set; }
+            }
+
+            // Test Scenario: Single Property with Multiple [Name] Annotations {error}
+            public class BankAccount {
+                public string Bank { get; set; } = "";
+                [PrimaryKey] public string AccountNumber { get; set; } = "";
+                [Name("Route"), Name("RoutingNmbr")] public ulong RoutingNumber { get; set; }
+            }
+
+            // Test Scenario: [Name] Annotation Given Property's Name {error}
+            public class Opera {
+                [PrimaryKey] public Guid ID { get; set; }
+                public string Composer { get; set; } = "";
+                [Name("PremiereDate")] public DateTime PremiereDate { get; set; }
+                public uint Length { get; set; }
+            }
+
+            // Test Scenario: Invalid Field [Name] {error}
+            public class Volcano {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public ulong Height { get; set; }
+                public DateTime LastEruption { get; set; }
+                [Name("")] public bool IsActive { get; set; }
+            }
+
+            // Test Scenario: <Path> Provided for [Name] on Scalar Property {error}
+            public class Legume {
+                [PrimaryKey] public Guid LegumeGuid { get; set; }
+                public string Name { get; set; } = "";
+                [Name("EnergyInKJ", Path = "---")] public decimal Energy { get; set; }
+                public double Carbohydrates { get; set; }
+                public double Fat { get; set; }
+                public double Protein { get; set; }
+            }
+
+        /////// --- Default Values
+
+            // Test Scenario: Valid Non-Null Default Values for Scalar Fields (excluding DateTime & Guid)
+            public class BloodType {
+                [PrimaryKey, Default("O")] public string ABO { get; set; } = "";
+                [PrimaryKey, Default(true)] public bool RHPositive { get; set; }
+                [Default(0.5f)] public float ApproxPrevalence { get; set; }
+                [Default(1)] public int NumSubgroups { get; set; }
+                public decimal AnnualDonationsL { get; set; }
+            }
+
+            // Test Scenario: Valid Non-Null Default Value for DateTime Field
+            public class Umpire {
+                [PrimaryKey] public Guid UniqueUmpireNumber { get; set; }
+                public ushort UniformNumber { get; set; }
+                public string Name { get; set; } = "";
+                [Default("1970-01-01")] public DateTime Debut { get; set; }
+                public uint Ejections { get; set; }
+            }
+
+            // Test Scenario: Valid Non-Null Default Value for Guid Field
+            public class Saint {
+                [Default("81a130d2-502f-4cf1-a376-63edeb000e9f")] public Guid SainthoodIdentifier { get; set; }
+                [PrimaryKey] public string Name { get; set; } = "";
+                public DateTime CanonizationDate { get; set; }
+                public byte FeastMonth { get; set; }
+                public byte FeastDay { get; set; }
+            }
+
+            // Test Scenario: Null Default Value for Nullable Field
+            public class Pepper {
+                [PrimaryKey] public string Genus { get; set; } = "";
+                [PrimaryKey] public string Species { get; set; } = "";
+                [Default(null)] public string? CommonName { get; set; }
+                public ulong ScovilleRating { get; set; }
+            }
+
+            // Test Scenario: Invalid and Unconvertible Non-Null Default Value {error}
+            public class Battleship {
+                [PrimaryKey] public string CallSign { get; set; } = "";
+                public DateTime? Launched { get; set; }
+                [Default("100 feet")] public ushort Length { get; set; }
+                public ushort TopSpeedMPH { get; set; }
+                public byte GunCount { get; set; }
+                public Guid ShipyardIdentifier { get; set; }
+            }
+
+            // Test Scenario: Invalid but Convertible Non-Null Default Value {error}
+            public class County {
+                [PrimaryKey] public ulong GNIS_ID { get; set; }
+                public string Name { get; set; } = "";
+                public string State { get; set; } = "";
+                [Default(5000000)] public ulong Population { get; set; }
+                public ulong Area { get; set; }
+                public DateTime Incorporation { get; set; }
+            }
+
+            // Test Scenario: Single-Element Array of Correct Type for Default Value {error}
+            public class BilliardBall {
+                [PrimaryKey] public string Color { get; set; } = "";
+                [PrimaryKey, Default(new int[] { 7 })] public int Number { get; set; }
+                public bool IsSolid { get; set; }
+            }
+
+            // Test Scenario: Invalid Non-Null Default Value for DateTime Field b/c of Formatting {error}
+            public class Tournament {
+                [PrimaryKey] public string Name { get; set; } = "";
+                [Default("20030714")] public DateTime Kickoff { get; set; }
+                public DateTime? Conclusion { get; set; }
+                public int Participants { get; set; }
+                public string Number1 { get; set; } = "";
+            }
+
+            // Test Scenario: Invalid Non-Null Default Value for DateTime Field b/c of Range {error}
+            public class Sculpture {
+                [PrimaryKey, Default("1344-18-18")] public DateTime CreationDate { get; set; }
+                public string Sculptor { get; set; } = "";
+                public ushort HeightFt { get; set; }
+                public ushort WeightLbs { get; set; }
+                public bool InOnePiece { get; set; }
+            }
+
+            // Test Scenario: Invalid Non-Null Default Value for DateTime Field b/c of Type {error}
+            public class RomanEmperor {
+                [PrimaryKey] public int ChronologicalIndex { get; set; }
+                public string LongName { get; set; } = "";
+                public string ShortName { get; set; } = "";
+                public DateTime ReignStart { get; set; }
+                [Default(true)] public DateTime ReignEnd { get; set; }
+            }
+
+            // Test Scenario: Invalid Non-Null Default Value for Guid Field b/c of Structure {error}
+            public class Gene {
+                [PrimaryKey, Default("ee98f44827b248a2bb9fc5ef342e7ab2!!!")] public Guid UUID { get; set; }
+                public string Identifier { get; set; } = "";
+                public long HumanEntrez { get; set; }
+                public string UCSCLocation { get; set; } = "";
+            }
+
+            // Test Scenario: Invalid Non-Null Default Value for Guid Field b/c of Type {error}
+            public class HogwartsHouse {
+                public string Name { get; set; } = "";
+                public ushort FirstPageMentioned { get; set; }
+                public long TotalMentions { get; set; }
+                [Default('^')] public Guid TermIndex { get; set; }
+            }
+
+            // Test Scenario: Null Default Value for Non-Nullable Field {error}
+            public class RadioStation {
+                [PrimaryKey] public bool IsFM { get; set; }
+                [PrimaryKey] public decimal StationNumber { get; set; }
+                [Default(null)] public string CallSign { get; set; } = "";
+            }
+
+            // Test Scenario: Valid Default Value on Field with Data Converter
+            public class CrosswordClue {
+                [PrimaryKey] public Guid PuzzleID { get; set; }
+                [DataConverter(typeof(CharToInt)), Default('A')] public char AcrossOrDown { get; set; }
+                public ushort Number { get; set; }
+                public byte NumLetters { get; set; }
+                public string ClueText { get; set; } = "";
+            }
+
+            // Test Scenario: Valid Default Value for Data-Coverted Target Type, Not Original Type {error}
+            public class Coupon {
+                [PrimaryKey] public Guid Barcode { get; set; }
+                public string? Code { get; set; }
+                [DataConverter(typeof(BoolToInt)), Default(0)] public bool IsBOGO { get; set; }
+                public double? DiscountPercentage { get; set; }
+                public float? MinimumPurchase { get; set; }
+                public DateTime? ExpirationDate { get; set; }
+            }
+
+            // Test Scenario: Multiple [Default] Annotations on a Single Field {error}
+            public class SkeeBall {
+                public int MachineID { get; set; }
+                [Default(1), Default(0)] public ushort L1Value { get; set; }
+                public ushort L2Value { get; set; }
+                public ushort L3Value { get; set; }
+                public ushort L4Value { get; set; }
+            }
+
+            // Test Scenario: <Path> Provided for [Default] on Scalar Property {error}
+            public class NativeAmericanTribe {
+                [PrimaryKey] public string Endonym { get; set; } = "";
+                [Default(null, Path = "---")] public string? Exonym { get; set; }
+                public ulong Population { get; set; }
+                public DateTime Established { get; set; }
+                public string GoverningBody { get; set; } = "";
+                public ulong Area { get; set; }
+            }
+
+        /////// --- Column Ordering
+
+            // Test Scenario: Apply [Column] Indices to All Fields
+            public class Fraction {
+                [PrimaryKey, Column(2)] public decimal Numerator { get; set; }
+                [Column(1)] public decimal Denominator { get; set; }
+                [Column(0)] public bool IsNegative { get; set; }
+            }
+
+            // Test Scenario: Apply [Column] Indices to Some Fields
+            public class Parashah {
+                [PrimaryKey] public string Book { get; set; } = "";
+                [PrimaryKey] public ushort StartChapter { get; set; }
+                [PrimaryKey] public ushort StartVerse { get; set; }
+                [Column(2)] public ushort EndChapter { get; set; }
+                [Column(3)] public ushort EndVerse { get; set; }
+            }
+
+            // Test Scenario: Duplicate [Column] Indices on Fields {error}
+            public class Pizza {
+                [PrimaryKey] public Guid ID { get; set; }
+                public float Diamater { get; set; }
+                [Column(1)] public string Chain { get; set; } = "";
+                public string Cheese { get; set; } = "";
+                [Column(7)] public string? Meat1 { get; set; }
+                public string? Meat2 { get; set; }
+                [Column(5)] public string? Veggie1 { get; set; }
+                [Column(7)] public string? Veggie2 { get; set; }
+                public string? Veggie3 { get; set; }
+            }
+
+            // Test Scenario: Gaps in [Column] Indices {error}
+            public class PhoneNumber {
+                [PrimaryKey, Column(1)] public byte CountryCode { get; set; }
+                [PrimaryKey] public ushort AreaCode { get; set; }
+                [PrimaryKey, Column(14)] public ushort Number { get; set; }
+            }
+
+            // Test Scenario: Negative [Column] Index {error}
+            public class NationalPark {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public string State { get; set; } = "";
+                [Column(-196)] public DateTime Established { get; set; }
+                public uint Area { get; set; }
+                public ulong AnnualVisitors { get; set; }
+            }
+
+        /////// --- Candidate Keys
+        
+            // Test Scenario: Multiple Unnamed Candidate Keys
+            public class Inmate {
+                [PrimaryKey] public Guid PrisonerNumber { get; set; }
+                [Unique] public int SSN { get; set; }
+                [Unique] public string FullName { get; set; } = "";
+            }
+
+            // Test Scenario: Named Candidate Key
+            public class BowlGame {
+                [PrimaryKey] public string Name { get; set; } = "";
+                [Unique("Sponsorship")] public string PrimarySponsor { get; set; } = "";
+                [Unique("Sponsorship")] public string? SecondarySponsor { get; set; } = "";
+                public DateTime Inception { get; set; }
+                public DateTime NextScheduled { get; set; }
+            }
+        
+            // Test Scenario: Single Field in Multiple Candidate Keys
+            public class KingOfEngland {
+                [PrimaryKey] public DateTime ReignStart { get; set; }
+                [PrimaryKey] public DateTime ReignEnd { get; set; }
+                [Unique("Uno"), Unique("Another")] public string RegnalName { get; set; } = "";
+                [Unique("Uno"), Unique("Third")] public byte RegnalNumber { get; set; }
+                [Unique("Another"), Unique("Third")] public string RoyalHouse { get; set; } = "";
+            }
+
+            // Test Scenario: Duplicate Named Candidate Keys {error}
+            public class Check {
+                [PrimaryKey] public Guid CID { get; set; }
+                public string Signatory { get; set; } = "";
+                public decimal Amount { get; set; }
+                public ulong RoutingNumber { get; set; }
+                [Unique("N1"), Unique("N2"), Unique("N3")] public byte CheckNumber { get; set; }
+            }
+
+            // Test Scenario: Duplicate Anonymous Candidate Keys {error}
+            public class Pigment {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public string DominantColor { get; set; } = "";
+                [Unique, Unique] public string ChemicalFormula { get; set; } = "";
+            }
+
+            // Test Scenario: Field Placed in Candidate Key Multiple Times {error}
+            public class Desert {
+                [PrimaryKey] public string Name { get; set; } = "";
+                [Unique("Size"), Unique("Size")] public ulong Length { get; set; }
+                [Unique("Size")] public ulong Width { get; set; }
+                public ulong TotalArea { get; set; }
+            }
+
+            // Test Scenario: Invalid [Unique] Name {error}
+            public class Allomancy {
+                [PrimaryKey] public char Symbol { get; set; }
+                public string Metal { get; set; } = "";
+                public byte Categorization { get; set; }
+                public bool IsInternal { get; set; }
+                public bool IsPushing { get; set; }
+                [Unique("")] public string MistingTerm { get; set; } = "";
+            }
+
+            // Test Scenario: Reserved [Unique] Name {error}
+            public class Lens {
+                [PrimaryKey] public Guid LensID { get; set; }
+                public bool AreContacts { get; set; }
+                [Unique("@@@Key")] public double IndexOfRefraction { get; set; }
+            }
+
+            // Test Scenario: <Path> Provided for [Unique] on Scalar Property {error}
+            public class Sonnet {
+                [PrimaryKey] public string Author { get; set; } = "";
+                [PrimaryKey] public string Title { get; set; } = "";
+                [Unique(Path = "---")] public string Line1 { get; set; } = "";
+                public string Line2 { get; set; } = "";
+                public string Line3 { get; set; } = "";
+                public string Line4 { get; set; } = "";
+                public string Line5 { get; set; } = "";
+                public string Line6 { get; set; } = "";
+                public string Line7 { get; set; } = "";
+                public string Line8 { get; set; } = "";
+                public string Line9 { get; set; } = "";
+                public string Line10 { get; set; } = "";
+                public string Line11 { get; set; } = "";
+                public string Line12{ get; set; } = "";
+                public string Line13 { get; set; } = "";
+                public string Line14 { get; set; } = "";
+            }
+
+            // Test Scenario: Candidate Key is Improper Superset of Primary Key {error}
+            public class WorldHeritageSite {
+                [PrimaryKey, Unique("X")] public string Name { get; set; } = "";
+                [Unique("X")] public DateTime Inscription { get; set; }
+                [PrimaryKey, Unique("X")] public ulong Area { get; set; }
+                [Unique("X")] public sbyte Components { get; set; }
+                public ushort ReferenceNumber { get; set; }
+            }
+
+        /////// --- Primary Key Identification
+
+            // Test Scenario: [PrimaryKey] Annotation Applied to Single Property
+            public class XKCDComic {
+                [PrimaryKey] public string URL { get; set; } = "";
+                public string Title { get; set; } = "";
+                public string ImageURL { get; set; } = "";
+                public string AltText { get; set; } = "";
+            }
+
+            // Test Scenario: [PrimaryKey] Annotation Applied to Multiple Properties
+            public class Month {
+                [PrimaryKey] public string Calendar { get; set; } = "";
+                [PrimaryKey] public uint Index { get; set; }
+                public string Name { get; set; } = "";
+                public ushort NumDays { get; set; }
+                public bool IsLeapMonth { get; set; }
+            }
+
+            // Test Scenario: [PrimaryKey] Annotation Applied to All Properties
+            public class Character {
+                [PrimaryKey] public char Glyph { get; set; }
+                [PrimaryKey] public uint CodePoint { get; set; }
+                [PrimaryKey] public bool IsASCII { get; set; }
+            }
+
+            // Test Scenario: Property Named ID
+            public class Actor {
+                public int ID { get; set; }
+                public string FirstName { get; set; } = "";
+                public string? MiddleName { get; set; }
+                public string LastName { get; set; } = "";
+                public DateTime Birthdate { get; set; }
+                public uint EmmyAwards { get; set; }
+                public uint OscarAwards { get; set; }
+            }
+
+            // Test Scenario: Property Named ID via [Name]
+            public class PokerHand {
+                [Name("ID")] public Guid HandIdentifier { get; set; }
+                public long BigBlind { get; set; }
+                public long SmallBlind { get; set; }
+                public bool HeadsUp { get; set; }
+                public long Pot { get; set; }
+                public ushort? Flop1 { get; set; }
+                public ushort? Flop2 { get; set; }
+                public ushort? Flop3 { get; set; }
+                public ushort? Turn { get; set; }
+                public ushort? River { get; set; }
+            }
+
+            // Test Scenario: Property Named <EntityType>ID
+            public class IntegerSequence {
+                public int IntegerSequenceID { get; set; }
+                public string Title { get; set; } = "";
+                public string Description { get; set; } = "";
+                public uint Citations { get; set; }
+                public int Element0 { get; set; }
+                public int? Element1 { get; set; }
+                public int? Element2 { get; set; }
+                public int? Element3 { get; set; }
+                public int? Element4 { get; set; }
+            }
+
+            // Test Scenario: Property Named <EntityType>ID via [Name]
+            public class Stadium {
+                [Name("StadiumID")] public Guid Identifier { get; set; }
+                public DateTime Opened { get; set; }
+                public DateTime? Closed { get; set; }
+                public ulong Capacity { get; set; }
+            }
+
+            // Test Scenario: Property Named <EntityType>ID and also <TableName>ID
+            [Table("Method")] public class Function {
+                public int FunctionID { get; set; }
+                public int MethodID { get; set; }
+                public string ReturnType { get; set; } = "";
+                public string Name { get; set; } = "";
+                public byte ArgumentCount { get; set; }
+                public bool IsGlobal { get; set; }
+                public bool IsFree { get; set; }
+                public bool IsMember { get; set; }
+            }
+
+            // Test Scenario: Single Candidate Key with Single Non-Nullable Field
+            public class Star {
+                [Unique] public string ARICNS { get; set; } = "";
+                public double Mass { get; set; }
+                public double Luminosity { get; set; }
+                public float Temperature { get; set; }
+                public float Distance { get; set; }
+                public ulong Period { get; set; }
+                public decimal Parallax { get; set; }
+            }
+
+            // Test Scenario: Single Candidate Key with Multiple Non-Nullable Fields
+            public class Expiration {
+                [Unique("PK")] public uint FeedCode { get; set; }
+                [Unique("PK")] public string Underlying { get; set; } = "";
+                public string Product { get; set; } = "";
+            }
+
+            // Test Scenario: Multiple Candidate Keys, only One with All Non-Nullable Fields
+            public class Vitamin {
+                [Unique("CK1")] public string Name { get; set; } = "";
+                [Unique("CK1")] public string? Alternative { get; set; }
+                [Unique("Formula")] public ushort Carbon { get; set; }
+                [Unique("Formula")] public ushort Hydrogen { get; set; }
+                [Unique("Formula")] public ushort Cobalt { get; set; }
+                [Unique("Formula")] public ushort Nitrogen { get; set; }
+                [Unique("Formula")] public ushort Oxygen { get; set; }
+                [Unique("Formula")] public ushort Phosphorus { get; set; }
+            }
+
+            // Test Scenario: Single Non-Nullable Field
+            public class Earthquake {
+                public Guid SeismicIdentificationNumber { get; set; }
+                public DateTime? Occurrence { get; set; }
+                public decimal? Magnitude { get; set; }
+                public double? EpicenterLatitude { get; set; }
+                public double? EpicenterLongitude { get; set; }
+            }
+
+            // Test Scenario: Single Non-Nullable Field via [NonNullable]
+            public class GeologicEpoch {
+                [NonNullable] public ulong? StartingMYA { get; set; }
+                public ulong? EndingMYA { get; set; }
+                public string? Name { get; set; }
+            }
+
+            // Test Scenario: Primary Key Cannot Be Deduced {error}
+            public class FederalLaw {
+                public string CommonName { get; set; } = "";
+                public string? ShortName { get; set; }
+                public DateTime Enacted { get; set; }
+                public float StatuteIdentifier { get; set; }
+                public string IntroducedBy { get; set; } = "";
+            }
+
+            // Test Scenario: Nullable Field is Annotated as [PrimaryKey] {error}
+            public class NorseWorld {
+                [PrimaryKey] public string OldNorse { get; set; } = "";
+                public string English { get; set; } = "";
+                [PrimaryKey] public int? EddaMentions { get; set; }
+            }
+
+            // Test Scenario: Property Named ID is Nullable
+            public class Rollercoaster {
+                public Guid? ID { get; set; }
+                public ulong RollercoasterID { get; set; }
+                public double Drop { get; set; }
+                public double TopSpeed { get; set; }
+                public DateTime Opening { get; set; }
+            }
+
+            // Test Scenario: Property Named <EntityType>ID is Nullable
+            public class Doctor {
+                public ushort? DoctorID { get; set; }
+                [Unique("DoctorWho")] public int Regeneration { get; set; }
+                [Unique("DoctorWho")] public string Portrayal { get; set; } = "";
+                public uint EpisodeCount { get; set; }
+                public bool NewWho { get; set; }            
+            }
+
+            // Test Scenario: Single Candidate Key Contains a Nullable Field
+            public class Polyhedron {
+                public string Name { get; set; } = "";
+                [Unique("Euler")] public ulong? Faces { get; set; }
+                [Unique("Euler")] public ulong? Vertices { get; set; }
+                [Unique("Euler")] public ulong? Edges { get; set; }
+                public decimal? DihedralAngle { get; set; }
+            }
+
+            // Test Scenario: [NamedPrimaryKey]
+            [NamedPrimaryKey("LetterPK")] public class HebrewLetter {
+                [PrimaryKey] public char Letter { get; set; }
+                public char IPA { get; set; }
+                public uint GematriaValue { get; set; }
+                public byte Position { get; set; }
+                public bool IsMaterLectionis { get; set; }
+            }
+
+            // Test Scenario: [NamedPrimaryKey] with Unnamed Single Candidate Key
+            [NamedPrimaryKey("PrimaryKey")] public class DatabaseField {
+                [Unique] public string QualifiedName { get; set; } = "";
+                public uint ColumnIndex { get; set; }
+                public byte DataType { get; set; }
+                public bool Nullable { get; set; }
+            }
+
+            // Test Scenario: Invalid [NamedPrimaryKey] {error}
+            [NamedPrimaryKey("")] public class Bay {
+                [PrimaryKey] public decimal Latitude { get; set; }
+                [PrimaryKey] public decimal Longitude { get; set; }
+                public string Name { get; set; } = "";
+                public ulong SurfaceArea { get; set; }
+                public ulong MaxDepth { get; set; }
+                public ulong Coastline { get; set; }
+            }
+
+            // Test Scenario: [NamedPrimaryKey] Conflicts with Name of Single Candidate Key {error}
+            [NamedPrimaryKey("Something")] public class JigsawPuzzle {
+                [Unique("GlobalIdentifier")] public Guid PuzzleID { get; set; }
+                public ushort NumPieces { get; set; }
+                public bool Is3D { get; set; }
+            }
+
+            // Test Scenario: [NamedPrimaryKey] Redundant with Name of Single Candidate Key {error}
+            [NamedPrimaryKey("PK")] public class TimeZone {
+                [Unique("PK")] public float GMT { get; set; }
+                public string Name { get; set; } = "";
+            }
+
+            // Test Scenario: [NamedPrimaryKey] Is Already Used by Non-PK Candidate Key {error}
+            [NamedPrimaryKey("Key13")] public class Currency {
+                [PrimaryKey] public string CountryOfUse { get; set; } = "";
+                [Unique("Key13")] public char Character { get; set; }
+                [Unique("Key13")] public double ExchangeRate { get; set; }
+                public long MaxDenomination { get; set; }
+                public long MinDenomination { get; set; }
+            }
+
+            // Test Scenario: Standalone [Unique] Field Is Marked as [PrimaryKey] {error}
+            public class Waterfall {
+                [PrimaryKey, Unique] public uint InternationalUnifiedWaterfallNumber { get; set; }
+                public string Exonym { get; set; } = "";
+                public string Endonym { get; set; } = "";
+                public ulong Height { get; set; }
+                public ulong WorldRanking { get; set; }
+            }
+
+            // Test Scenario: Single Property with Multiple [PrimaryKey] Annotations {error}
+            public class Airport {
+                [PrimaryKey, PrimaryKey] public string IATA { get; set; } = "";
+                public string Name { get; set; } = "";
+                public string City { get; set; } = "";
+                public DateTime Opening { get; set; }
+                public float AveragePassengers { get; set; }
+            }
+
+            // Test Scenario: <Path> Provided for [PrimaryKey] on Scalar Property {error}
+            public class Highway {
+                [PrimaryKey(Path = "---")] public int Number { get; set; }
+                public string StartingState { get; set; } = "";
+                public string EndingState { get; set; } = "";
+                public ulong LengthMiles { get; set; }
+                public float AverageSpeedLimit { get; set; }
+            }
+
+        /////// --- Data Converters
+
+            // Test Scenario: Data Converter Does Not Change Type
+            public class Cenote {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public float MaxDepth { get; set; }
+                [DataConverter(typeof(InvertBoolean))] public bool IsKarst { get; set; }
+                public decimal Latitude { get; set; }
+                public decimal Longitude { get; set; }
+            }
+
+            // Test Scenario: Data Converter Changes Type
+            public class Comet {
+                [PrimaryKey] public Guid AstronomicalIdentifier { get; set; }
+                public double Aphelion { get; set; }
+                [DataConverter(typeof(RoundDownDouble))] public double Perihelion { get; set; }
+                [DataConverter(typeof(RoundDownDouble))] public double Eccentricity { get; set; }
+                public ulong MassKg { get; set; }
+                public double Albedo { get; set; }
+                public float OrbitalPeriod { get; set; }
+            }
+
+            // Test Scenario: Data Converter with Non-Nullable Source on Nullable Field
+            public class RoyalHouse {
+                [PrimaryKey] public string HouseName { get; set; } = "";
+                public DateTime Founded { get; set; }
+                [DataConverter(typeof(DeNullify<string>))] public string? CurrentHead { get; set; }
+                public int TotalMonarchs { get; set; }
+            }
+
+            // Test Scenario: Data Converter with Nullable Source on Non-Nullable Field
+            public class Planeswalker {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public sbyte MannaCost { get; set; }
+                public sbyte InitialLoyalty { get; set; }
+                [DataConverter(typeof(Nullify<string>))] public string Ability1 { get; set; } = "";
+                [DataConverter(typeof(Nullify<string>))] public string Ability2 { get; set; } = "";
+                [DataConverter(typeof(Nullify<string>))] public string Ability3 { get; set; } = "";
+            }
+
+            // Test Scenario: Data Converter with Nullable Source for Non-Nullable Field
+            public class GolfHole {
+                [PrimaryKey] public int CourseID { get; set; }
+                [PrimaryKey] public byte HoleNumber { get; set; }
+                public byte Par { get; set; }
+                public ushort DistanceToFlag { get; set; }
+                [DataConverter(typeof(ByteModulo16))] public byte NumSandTraps { get; set; }
+                public bool ContainsWaterHazard { get; set; }
+            }
+
+            // Test Scenario: Data Converter Source Type Does Not Match and is Not Convertible {error}
+            public class Jedi {
+                [PrimaryKey] public int WookiepediaID { get; set; }
+                public string FirstName { get; set; } = "";
+                [DataConverter(typeof(DeNullify<bool>))] public string? MiddleName { get; set; }
+                public string? LastName { get; set; }
+                public string LightsaberColor { get; set; } = "";
+                public double Height { get; set; }
+                public double Weight { get; set; }
+                public int NumMovieLines { get; set; }
+                public int NumTelevisionLines { get; set; }
+            }
+
+            // Test Scenario: Data Converter Source Type Does Not Match but is Convertible {error}
+            public class ConstitutionalAmendment {
+                [PrimaryKey, DataConverter(typeof(Nullify<long>))] public int Number { get; set; }
+                public DateTime Ratified { get; set; }
+                public double RatificationPercentage { get; set; }
+                public string Text { get; set; } = "";
+            }
+
+            // Test Scenario: Data Converter Target Type is Not Supported {error}
+            public class SNLEpisode {
+                [PrimaryKey] public byte Season { get; set; }
+                [PrimaryKey] public byte EpisodeNumber { get; set; }
+                public string Host { get; set; } = "";
+                public string MusicalGuest { get; set; } = "";
+                [DataConverter(typeof(DateToError))] public DateTime AirDate { get; set; }
+                public ushort WeekendUpdateDuration { get; set; }
+            }
+
+            // Test Scenario: Data Converter Type is not a Data Converter {error}
+            public class MetraRoute {
+                [PrimaryKey] public int RouteID { get; set; }
+                public string Name { get; set; } = "";
+                public string SourceStation { get; set; } = "";
+                public string Destination { get; set; } = "";
+                [DataConverter(typeof(int))] public string Line { get; set; } = "";
+                public ushort DepartureTime { get; set; }
+            }
+
+            // Test Scenario: Identity Data Converter
+            public class FieldGoal {
+                [PrimaryKey, DataConverter(typeof(Identity<DateTime>))] public DateTime When { get; set; }
+                [DataConverter(typeof(Identity<bool>))] public bool Made { get; set; }
+                [DataConverter(typeof(Identity<int>))] public int Doinks { get; set; }
+                [DataConverter(typeof(Identity<string>))] public string Kicker { get; set; } = "";
+            }
+
+            // Test Scenario: Single Property with Multiple [DataConverter] Annotations {error}
+            public class BowlingFrame {
+                [PrimaryKey] public Guid FrameID { get; set; }
+                public short Round { get; set; }
+                [DataConverter(typeof(ByteModulo16)), DataConverter(typeof(Identity<byte>))] public byte FirstThrowPins { get; set; }
+                public byte? SecondThrowPins { get; set; }
+            }
+
+            // Test Scenario: <Path> Provided for [DataConverter] on Scalar Property {error}
+            public class DraftPick {
+                [PrimaryKey] public string League { get; set; } = "";
+                [PrimaryKey] public ushort Year { get; set; }
+                [PrimaryKey] public byte Round { get; set; }
+                [PrimaryKey] public byte PickNumber { get; set; }
+                [DataConverter(typeof(Identity<uint>), Path = "---")] public uint Overall { get; set; }
+                public string Selector { get; set; } = "";
+                public string Selection { get; set; } = "";
+            }
+    }
+}

--- a/test/UnitTests/_FluentExtensions/TableAssertions.cs
+++ b/test/UnitTests/_FluentExtensions/TableAssertions.cs
@@ -1,0 +1,248 @@
+﻿using Cybele.Extensions;
+using FluentAssertions.Execution;
+using Kvasir.Schema;
+using Optional;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FluentAssertions {
+    internal static partial class AssertionExtensions {
+        public static TableAssertion Should(this ITable self) {
+            return new TableAssertion(self);
+        }
+
+        public class TableAssertion : Primitives.ObjectAssertions {
+            public new ITable Subject { get; }
+            public TableAssertion(ITable subject)
+                : base(subject) {
+
+                Subject = subject;
+            }
+            protected override string Identifier => "Table";
+            private readonly HashSet<string> checkedFieldNames_ = new HashSet<string>();
+            private readonly HashSet<string> checkedKeyNames_ = new HashSet<string>();
+
+            [CustomAssertion]
+            public AndConstraint<TableAssertion> HaveName(string name, string because = "",
+                params object[] becauseArgs) {
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Name.ToString() == name)
+                    .FailWith($"Expected {{context:Table}} to have name '{name}'{{reason}}, but found {Subject.Name}");
+
+                return new AndConstraint<TableAssertion>(this);
+            }
+
+            [CustomAssertion]
+            private IField HaveField(string name, string because = "",
+                params object[] becauseArgs) {
+
+                IField? field = Subject.Fields.FirstOrDefault(f => f.Name.ToString() == name);
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(field is not null)
+                    .FailWith($"Expected {{context:Table}} to contain a Field with name '{name}'{{reason}}");
+
+                checkedFieldNames_.Add(name);
+                return field!;
+            }
+
+            [CustomAssertion]
+            public AndConstraint<TableAssertion> HaveField(string name, DBType dataType, IsNullable nullable,
+                string because = "", params object[] becauseArgs) {
+
+                var field = HaveField(name, because, becauseArgs);
+                string expectedNullability = (nullable == IsNullable.Yes) ? "nullable" : "non-nullable";
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(field.DataType == dataType)
+                    .FailWith($"Expected Field '{name}' to have data type {dataType}{{reason}}, but its data type is " +
+                              field.DataType.ToString());
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(field.Nullability == nullable)
+                    .FailWith($"Expected Field '{name}' to be {expectedNullability}{{reason}}");
+
+                return new AndConstraint<TableAssertion>(this);
+            }
+
+            [CustomAssertion]
+            public AndConstraint<TableAssertion> HaveField(string name, int column, string because = "",
+                params object[] becauseArgs) {
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(column < Subject.Dimension)
+                    .FailWith($"Expected Field '{name}' at column index #{column}{{reason}}, but the " +
+                              $"{{context:Table}} only has {Subject.Dimension} " +
+                              $"Field{(Subject.Dimension > 1 ? "s" : "")}");
+
+                HaveField(name);
+                var actualAtColumn = Subject.Fields[column];
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(actualAtColumn.Name.ToString() == name)
+                    .FailWith($"Expected Field '{name}' at column index #{column}{{reason}}, but found Field " +
+                              actualAtColumn.Name.ToString());
+
+                return new AndConstraint<TableAssertion>(this);
+            }
+
+            [CustomAssertion]
+            public AndConstraint<TableAssertion> HaveField<T>(string name, Option<T> defaultValue,
+                string because = "", params object[] becauseArgs) {
+
+                var field = HaveField(name);
+
+                defaultValue.Match(
+                    some: v => {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .ForCondition(field.DefaultValue.HasValue)
+                            .FailWith($"Expected Field '{name}' to have a default value{{reason}}");
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .ForCondition(field.DefaultValue.Unwrap().Datum.Equals(v))
+                            .FailWith($"Expected Field '{name}' to have default value " +
+                                      $"<{DBValue.Create(v)}>{{reason}}, but found <{field.DefaultValue}>");
+                    },
+                    none: () => {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .ForCondition(!field.DefaultValue.HasValue)
+                            .FailWith($"Expected Field '{name}' to have no default value{{reason}}");
+                    }
+                );
+
+                return new AndConstraint<TableAssertion>(this);
+            }
+
+            [CustomAssertion]
+            public AndConstraint<TableAssertion> NotHaveField(string name, string because = "",
+                params object[] becauseArgs) {
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Fields.FirstOrDefault(f => f.Name.ToString() == name) is null)
+                    .FailWith($"Expected {{context:Table}} to not contain a Field with name '{name}'{{reason}}");
+
+                return new AndConstraint<TableAssertion>(this);
+            }
+
+            [CustomAssertion]
+            public KeyAssertion HavePrimaryKey(params string[] fieldNames) {
+                var pkFields = new HashSet<string>(Subject.PrimaryKey.Fields.Select(f => f.Name.ToString()));
+                var expected = new HashSet<string>(fieldNames);
+
+                var missing = pkFields.Except(expected);
+                var extra = expected.Except(pkFields);
+
+                foreach (var name in fieldNames) {
+                    // Deliberately use a new Assertion object so that the Field names do not get recorded in the
+                    // running list, since this is not strictly a Field-presence check
+                    Subject.Should().HaveField(name);
+                }
+
+                Execute.Assertion
+                    .BecauseOf("")
+                    .ForCondition(missing.IsEmpty() && extra.IsEmpty())
+                    .FailWith($"Expected {{context:Table}} to have Primary Key consisting of Fields [" +
+                              $"{string.Join(", ", expected)}]{{reason}}, but found Fields [" +
+                              $"{string.Join(", ", pkFields)}]");
+
+                return new KeyAssertion(Subject.PrimaryKey, this, "Primary");
+            }
+
+            [CustomAssertion]
+            public KeyAssertion HaveCandidateKey(params string[] fieldNames) {
+                var cks = Subject.CandidateKeys;
+                var expected = new HashSet<string>(fieldNames);
+
+                foreach (var name in fieldNames) {
+                    // Deliberately use a new Assertion object so that the Field names do not get recorded in the
+                    // running list, since this is not strictly a Field-presence check
+                    Subject.Should().HaveField(name);
+                }
+
+                var key = cks.FirstOrDefault(k => k.Fields.Select(f => f.Name.ToString()).ToHashSet().SetEquals(expected));
+                Execute.Assertion
+                    .BecauseOf("")
+                    .ForCondition(key is not null)
+                    .FailWith($"Expected {{context:Table}} to have a Candidate Key with Fields " +
+                              $"[{string.Join(", ", expected)}]{{reason}}, but no such Candidate Key was found");
+
+                checkedKeyNames_.Add(key!.Name.ToString());
+                return new KeyAssertion(key!, this, "Candidate");
+            }
+
+            [CustomAssertion]
+            public void NoOtherFields(string because = "", params object[] becauseArgs) {
+                var fieldNames = new HashSet<string>(Subject.Fields.Select(f => f.Name.ToString()));
+                var extras = fieldNames.Except(checkedFieldNames_);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(extras.IsEmpty())
+                    .FailWith($"{{context:Table}} also has the following Fields: {string.Join(", ", extras)}");
+            }
+
+            [CustomAssertion]
+            public void NoOtherCandidateKeys(string because = "", params object[] becauseArgs) {
+                var keyNames = new HashSet<string>(Subject.CandidateKeys.Select(f => f.Name.ToString()));
+                var extras = keyNames.Except(checkedKeyNames_);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(extras.IsEmpty())
+                    .FailWith($"{{context:Table}} also has the following Candidate Keys: {string.Join(", ", extras)}");
+            }
+        }
+
+        public class KeyAssertion : TableAssertion {
+            public new IKey Subject { get; }
+            public KeyAssertion(IKey key, TableAssertion parent, string flavor)
+                : base(parent.Subject) {
+
+                Subject = key;
+                Identifier = $"{flavor} Key";
+                And = parent;
+            }
+            protected override string Identifier { get; }
+            public TableAssertion And { get; }
+
+            [CustomAssertion]
+            public AndConstraint<TableAssertion> WithName(string name, string because = "",
+                params object[] becauseArgs) {
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Name.HasValue)
+                    .FailWith($"Expected {{context:{Identifier}}} to have name{{reason}}");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Name.Unwrap().ToString() == name)
+                    .FailWith($"Expected {{context:{Identifier}}} to have name '{name}'{{reason}}, but found " +
+                              $"'{Subject.Name.Unwrap()}'");
+
+                return new AndConstraint<TableAssertion>(And);
+            }
+
+            [CustomAssertion]
+            public AndConstraint<TableAssertion> WithoutName(string because = "", params object[] becauseArgs) {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!Subject.Name.HasValue)
+                    .FailWith(() =>
+                        new FailReason(
+                            $"Expected {{context:{Identifier}}} to have no name, " +
+                            $"but found '{Subject.Name.Unwrap()}'")
+                    );
+
+                return new AndConstraint<TableAssertion>(And);
+            }
+        }
+    }
+}

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -1,0 +1,142 @@
+﻿Actor/Actress
+Address
+Airplane
+Airport
+Allomancy
+Amino Acid
+Animal
+Bank Account
+Batting Order
+Battle
+Battleship
+Bay
+Billiard Ball
+Blood Type
+Bone
+Book
+Bookmark (web browsing)
+Botanical Garden
+Bowl Game
+Bowling Frame
+Carbohydrate
+Cenote
+Character (text)
+Check
+Chemical Element
+Chess Piece
+Circle
+Civilization VI Military Unit
+Coin
+Color
+Comet
+Constitutional Amendment
+Country
+County
+Coupon
+Court Case
+Credit Card
+Crossword Clue
+Currency
+D&D Character
+Database Field
+Date
+Desert
+Doctor (Doctor Who)
+Draft Pick
+Drum
+Earthquake
+Encryption
+Enumeration
+Episode
+Expiration
+Federal Law
+Field Goal
+Fighter Jet
+Flight
+Flower
+Fraction
+Function (programming)
+Gene
+Geologic Epoch
+Git Commit
+Golf Hole
+Greek God
+Haiku
+Hebrew Letter
+Hebrew Prayer
+Highway
+Hogwarts House
+Holiday
+Hurricane
+Inmate
+Integer
+Integer Sequence
+IP Address
+Jedi
+Jigsaw Puzzle
+King of England
+Lake
+Language
+Legume
+Lens
+Liquor
+Log-In Credentials
+MetraRoute
+Month
+Monopoly Property
+Mountain
+Movie
+National Park
+Native American Park
+Norse World
+Opera
+Painting
+Parashah
+Patent
+Pepper
+Phone Number
+Pigment (biology)
+Pizza
+Planeswalker
+Playing Card
+PO Box
+Pokémon
+Poker Hand
+Polyhedron
+Presidential Election
+Quadratic Equation
+Radio Station
+Retail Product
+River
+Rollercoaster
+Roman Emperor
+Royal House
+Saint
+Scrabble Tile
+Sculpture
+Season
+Skee-Ball
+Slack Channel
+SNL Episode
+Song
+Sonnet
+Speedometer
+Stadium
+Star
+Submarine
+Super Bowl
+Surah
+Ticket2Ride Route
+Time Zone
+Timestamp
+Tossup Question
+Tournament
+Umpire
+University
+URL
+Vitamin
+Volcano
+Waterfall
+World Heritage Site
+xkcd Comic
+YouTube Video


### PR DESCRIPTION
This commit is the first major milestone in the implementation of the Translation Layer of Kvasir. With this commit, the Framework is able to properly translate any Entity Type consisting solely of scalar properties into a data model. Nearly all annotations are supported; the only one that isn't is the CheckAttribute. Primary Key deduction is fully implemented, as is Candidate Key identification. All naming rules are recognized for both Fields and for Tables. All pertinent error checking is present, with error messages contextualized to explain where the error is coming from. More than 140 unit tests ensure that the logic is sound. The only changes to the specification were clarifications made; no substantive content was modified.