### PR TITLE
Utility for Obtaining Array of Valid Enumerators

### DIFF
--- a/src/Cybele/Intellisense.xml
+++ b/src/Cybele/Intellisense.xml
@@ -1007,6 +1007,22 @@
               the declaration of <typeparamref name="TEnum"/> or is a bitwise combination of such values.
             </returns>
         </member>
+        <member name="M:Cybele.Extensions.EnumExtensions.ValidValues(System.Type)">
+            <summary>
+              Produces an array of "valid" enumerators for an <see cref="T:System.Enum">enumeration type</see>
+            </summary>
+            <seealso cref="M:Cybele.Extensions.EnumExtensions.IsValid``1(``0)"/>
+            <param name="self">
+              The <see cref="T:System.Type"/> on which the extension method is invoked.
+            </param>
+            <returns>
+              An array of all the "valid" enumerators of <paramref name="self"/>, in no particular order. For a precise
+              definition of what it means for an enumerator to be valid, see <see cref="M:Cybele.Extensions.EnumExtensions.IsValid``1(``0)"/>.
+            </returns>
+            <exception cref="T:System.ArgumentException">
+              if <paramref name="self"/> is not an <see cref="T:System.Enum">enumeration type</see>.
+            </exception>
+        </member>
         <member name="M:Cybele.Extensions.EnumExtensions.#cctor">
             <summary>
               Initializes the <see langword="static"/> state of the <see cref="T:Cybele.Extensions.EnumExtensions"/> class.

--- a/test/UnitTests/Cybele/Extensions/Enum.cs
+++ b/test/UnitTests/Cybele/Extensions/Enum.cs
@@ -174,4 +174,83 @@ namespace UT.Cybele.Extensions {
             invalidNationalityValidity.Should().BeFalse();
         }
     }
+
+    [TestClass, TestCategory("Enum: ValidValues")]
+    public sealed class Enum_ValidValues : ExtensionTests {
+        [TestMethod] public void NonEnumeration_IsError() {
+            // Arrange
+            var type = typeof(Type);
+
+            // Act
+            var action = () => type.ValidValues();
+
+            // Assert
+            action.Should().ThrowExactly<ArgumentException>().WithMessage("*enumeration*");
+        }
+
+        [TestMethod] public void NoEnumeratorsDefined() {
+            // Arrange
+            var type = typeof(Empty);
+
+            // Act
+            var values = type.ValidValues();
+
+            // Assert
+            values.Should().BeEmpty();
+        }
+
+        [TestMethod] public void NonFlagEnumeration() {
+            // Arrange
+            var type = typeof(Month);
+
+            // Act
+            var values = type.ValidValues();
+
+            // Assert
+            values.Should().HaveCount(12);
+            values.Should().Contain(Month.January);
+            values.Should().Contain(Month.February);
+            values.Should().Contain(Month.March);
+            values.Should().Contain(Month.April);
+            values.Should().Contain(Month.May);
+            values.Should().Contain(Month.June);
+            values.Should().Contain(Month.July);
+            values.Should().Contain(Month.August);
+            values.Should().Contain(Month.September);
+            values.Should().Contain(Month.October);
+            values.Should().Contain(Month.November);
+            values.Should().Contain(Month.December);
+        }
+
+        [TestMethod] public void FlagEnumerationConsecutive() {
+            // Arrange
+            var type = typeof(Color);
+
+            // Act
+            var values = type.ValidValues();
+
+            // Assert
+            values.Should().HaveCount(8);
+            values.Should().Contain(Color.Black);
+            values.Should().Contain(Color.Red);
+            values.Should().Contain(Color.Blue);
+            values.Should().Contain(Color.Yellow);
+            values.Should().Contain(Color.White);
+            values.Should().Contain(Color.Blue | Color.Yellow);
+            values.Should().Contain(Color.Blue | Color.Red);
+            values.Should().Contain(Color.Yellow | Color.Red);
+        }
+
+        [TestMethod] public void FlagEnumerationNonConsecutiveNoZero() {
+            // Arrange
+            var type = typeof(BaseballPosition);
+
+            // Act
+            var values = type.ValidValues();
+
+            // Assert
+            values.Should().HaveCount(4095);                        // 2^12 - 1 (12 enumerators, but no 0)
+            values.Should().NotContain((BaseballPosition)0L);
+        }
+    }
 }

--- a/test/UnitTests/Cybele/Extensions/_TestClass.cs
+++ b/test/UnitTests/Cybele/Extensions/_TestClass.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace UT.Cybele.Extensions {
     public class ExtensionTests {
+        protected enum Empty {}
         [Flags] protected enum Color : byte {
             Black = 0,
             Red = 1 << 1,


### PR DESCRIPTION
This commit adds a utility function that, given an Enumeration type, produces an unordered array of the type's valid enumerators. This is a companion function to the long-existing Enumerator.IsValid() extension method, and has the same general-purpose use cases. Specifically, though, this function will be used by the Translation Layer when translating Enumeration-type Fields, as the Schema Layer has to be seeded with the allowed set. Note importantly that this new method is computationally expensive for flag enumerations, and therefore the IsValid() extension does not simply call this method and then check for containment.