### PR TITLE
Built-In Enumeration DataConverters

### DIFF
--- a/src/Kvasir/Core/EnumConverters.cs
+++ b/src/Kvasir/Core/EnumConverters.cs
@@ -1,0 +1,121 @@
+﻿using Cybele.Core;
+using System;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Kvasir.Core {
+    /// <summary>
+    ///   A built-in <see cref="IDataConverter"/> that bidirectionally converts between enumerations and their
+    ///   underlying numeric value.
+    /// </summary>
+    internal sealed class EnumToNumericConverter : IDataConverter {
+        /// <inheritdoc/>
+        public DataConverter ConverterImpl => impl_;
+
+        /// <summary>
+        ///   Initialize the static state of the <see cref="EnumToNumericConverter"/> class.
+        /// </summary>
+        static EnumToNumericConverter() {
+            var flags = BindingFlags.Static | BindingFlags.NonPublic;
+            MAKE_IMPL_FN = typeof(EnumToNumericConverter).GetMethod(nameof(MakeImpl), flags)!;
+        }
+
+        /// <summary>
+        ///   Constructs a new <see cref="EnumToNumericConverter"/>.
+        /// </summary>
+        /// <param name="enumType">
+        ///   The type of the enumeration to convert.
+        /// </param>
+        public EnumToNumericConverter(Type enumType) {
+            Debug.Assert(enumType is not null);
+            Debug.Assert(enumType.IsEnum);
+
+            var underlyingType = Enum.GetUnderlyingType(enumType);
+            var maker = MAKE_IMPL_FN.MakeGenericMethod(enumType, underlyingType);
+            impl_ = (DataConverter)maker.Invoke(null, Array.Empty<object?>())!;
+        }
+
+        /// <summary>
+        ///   Creates a <see cref="DataConverter"/> that bidirectionally converts between a specific enumeration type
+        ///   and its underlying numeric type.
+        /// </summary>
+        /// <typeparam name="TEnum">
+        ///   The enumeration type.
+        /// </typeparam>
+        /// <typeparam name="TNumeric">
+        ///   The underlying numeric type of <typeparamref name="TEnum"/>.
+        /// </typeparam>
+        /// <returns>
+        ///   A <see cref="DataConverter"/> that converts instances of <typeparamref name="TEnum"/> into the equivalent
+        ///   <typeparamref name="TNumeric"/>, and vice-versa.
+        /// </returns>
+        private static DataConverter MakeImpl<TEnum, TNumeric>() where TEnum : Enum where TNumeric : struct {
+            Debug.Assert(Enum.GetUnderlyingType(typeof(TEnum)) == typeof(TNumeric));
+            Converter<TEnum, TNumeric> fwd = e => (TNumeric)Convert.ChangeType(e, typeof(TNumeric));
+            Converter<TNumeric, TEnum> bwd = n => (TEnum)Enum.ToObject(typeof(TEnum), n);
+            return DataConverter.Create(fwd, bwd);
+        }
+
+
+        private readonly DataConverter impl_;
+        private static readonly MethodInfo MAKE_IMPL_FN;
+    }
+
+    /// <summary>
+    ///   A built-in <see cref="IDataConverter"/> that bidirectionally converts between enumerations and their string
+    ///   representation.
+    /// </summary>
+    /// <remarks>
+    ///   The string representation of an enumeration is usually the result of invoking <c>ToString()</c> on the
+    ///   enumeration. For unnamed combinations of <see cref="FlagsAttribute">flag enumerators</see>, the string
+    ///   representation is the <c>ToString()</c> result with the "comma-space" delimiter replaced by a vertical bar
+    ///   (<c>|</c>).
+    /// </remarks>
+    internal sealed class EnumToStringConverter : IDataConverter {
+        /// <inheritdoc/>
+        public DataConverter ConverterImpl => impl_;
+
+        /// <summary>
+        ///   Initialize the static state of the <see cref="EnumToStringConverter"/> class.
+        /// </summary>
+        static EnumToStringConverter() {
+            var flags = BindingFlags.Static | BindingFlags.NonPublic;
+            MAKE_IMPL_FN = typeof(EnumToStringConverter).GetMethod(nameof(MakeImpl), flags)!;
+        }
+
+        /// <summary>
+        ///   Constructs a new <see cref="EnumToStringConverter"/>.
+        /// </summary>
+        /// <param name="enumType">
+        ///   The type of the enumeration to convert.
+        /// </param>
+        public EnumToStringConverter(Type enumType) {
+            Debug.Assert(enumType is not null);
+            Debug.Assert(enumType.IsEnum);
+
+            var maker = MAKE_IMPL_FN.MakeGenericMethod(enumType);
+            impl_ = (DataConverter)maker.Invoke(null, Array.Empty<object?>())!;
+        }
+
+        /// <summary>
+        ///   Creates a <see cref="DataConverter"/> that bidirectionally converts between a specific enumeration type
+        ///   and its Kvasir-defined string representation.
+        /// </summary>
+        /// <typeparam name="TEnum">
+        ///   The enumeration type.
+        /// </typeparam>
+        /// <returns>
+        ///   A <see cref="DataConverter"/> that converts instances of <typeparamref name="TEnum"/> into the equivalent
+        ///   <see cref="string"/>, and vice-versa.
+        /// </returns>
+        private static DataConverter MakeImpl<TEnum>() where TEnum : Enum {
+            Converter<TEnum, string> fwd = e => e.ToString()!.Replace(", ", "|");
+            Converter<string, TEnum> bwd = s => (TEnum)Enum.Parse(typeof(TEnum), s.Replace("|", ", "));
+            return DataConverter.Create(fwd, bwd);
+        }
+
+
+        private readonly DataConverter impl_;
+        private static readonly MethodInfo MAKE_IMPL_FN;
+    }
+}

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -798,6 +798,85 @@
               The name of the <c>UNIQUE</c> constraint.
             </param>
         </member>
+        <member name="T:Kvasir.Core.EnumToNumericConverter">
+            <summary>
+              A built-in <see cref="T:Kvasir.Core.IDataConverter"/> that bidirectionally converts between enumerations and their
+              underlying numeric value.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Core.EnumToNumericConverter.ConverterImpl">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Core.EnumToNumericConverter.#cctor">
+            <summary>
+              Initialize the static state of the <see cref="T:Kvasir.Core.EnumToNumericConverter"/> class.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Core.EnumToNumericConverter.#ctor(System.Type)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Core.EnumToNumericConverter"/>.
+            </summary>
+            <param name="enumType">
+              The type of the enumeration to convert.
+            </param>
+        </member>
+        <member name="M:Kvasir.Core.EnumToNumericConverter.MakeImpl``2">
+            <summary>
+              Creates a <see cref="T:Cybele.Core.DataConverter"/> that bidirectionally converts between a specific enumeration type
+              and its underlying numeric type.
+            </summary>
+            <typeparam name="TEnum">
+              The enumeration type.
+            </typeparam>
+            <typeparam name="TNumeric">
+              The underlying numeric type of <typeparamref name="TEnum"/>.
+            </typeparam>
+            <returns>
+              A <see cref="T:Cybele.Core.DataConverter"/> that converts instances of <typeparamref name="TEnum"/> into the equivalent
+              <typeparamref name="TNumeric"/>, and vice-versa.
+            </returns>
+        </member>
+        <member name="T:Kvasir.Core.EnumToStringConverter">
+            <summary>
+              A built-in <see cref="T:Kvasir.Core.IDataConverter"/> that bidirectionally converts between enumerations and their string
+              representation.
+            </summary>
+            <remarks>
+              The string representation of an enumeration is usually the result of invoking <c>ToString()</c> on the
+              enumeration. For unnamed combinations of <see cref="T:System.FlagsAttribute">flag enumerators</see>, the string
+              representation is the <c>ToString()</c> result with the "comma-space" delimiter replaced by a vertical bar
+              (<c>|</c>).
+            </remarks>
+        </member>
+        <member name="P:Kvasir.Core.EnumToStringConverter.ConverterImpl">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Core.EnumToStringConverter.#cctor">
+            <summary>
+              Initialize the static state of the <see cref="T:Kvasir.Core.EnumToStringConverter"/> class.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Core.EnumToStringConverter.#ctor(System.Type)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Core.EnumToStringConverter"/>.
+            </summary>
+            <param name="enumType">
+              The type of the enumeration to convert.
+            </param>
+        </member>
+        <member name="M:Kvasir.Core.EnumToStringConverter.MakeImpl``1">
+            <summary>
+              Creates a <see cref="T:Cybele.Core.DataConverter"/> that bidirectionally converts between a specific enumeration type
+              and its Kvasir-defined string representation.
+            </summary>
+            <typeparam name="TEnum">
+              The enumeration type.
+            </typeparam>
+            <returns>
+              A <see cref="T:Cybele.Core.DataConverter"/> that converts instances of <typeparamref name="TEnum"/> into the equivalent
+              <see cref="T:System.String"/>, and vice-versa.
+            </returns>
+        </member>
         <member name="T:Kvasir.Core.IConstraintGenerator">
             <summary>
               The interface for tying a user-defined <c>CHECK</c> constraint to one or more Fields.

--- a/test/UnitTests/Kvasir/Core/EnumConverters.cs
+++ b/test/UnitTests/Kvasir/Core/EnumConverters.cs
@@ -1,0 +1,380 @@
+﻿using FluentAssertions;
+using Kvasir.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace UT.Kvasir.Core {
+    [TestClass, TestCategory("Built-In Enum Converters")]
+    public class EnumConverterTests {
+        [TestMethod] public void NonNullByteEnumToNumeric() {
+            // Arrange
+            var type = typeof(Byte);
+            var enumerator = Byte.B1;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(byte));
+            conversion.Should().Be((byte)1);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NonNullIntEnumToNumeric() {
+            // Arrange
+            var type = typeof(Int);
+            var enumerator = Int.I3;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(int));
+            conversion.Should().Be(3);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NonNullLongEnumToNumeric() {
+            // Arrange
+            var type = typeof(Long);
+            var enumerator = Long.L2;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(long));
+            conversion.Should().Be(2L);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NonNullSByteEnumToNumeric() {
+            // Arrange
+            var type = typeof(SByte);
+            var enumerator = SByte.SB2;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(sbyte));
+            conversion.Should().Be((sbyte)2);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NonNullShortEnumToNumeric() {
+            // Arrange
+            var type = typeof(Short);
+            var enumerator = Short.S1;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(short));
+            conversion.Should().Be((short)1);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NonNullUIntEnumToNumeric() {
+            // Arrange
+            var type = typeof(UInt);
+            var enumerator = UInt.UI0;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(uint));
+            conversion.Should().Be(0U);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NonNullULongEnumToNumeric() {
+            // Arrange
+            var type = typeof(ULong);
+            var enumerator = ULong.UL3;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(ulong));
+            conversion.Should().Be(3UL);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NonNullUShortEnumToNumeric() {
+            // Arrange
+            var type = typeof(UShort);
+            var enumerator = UShort.US2;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(ushort));
+            conversion.Should().Be((ushort)2);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NullByteEnumToNumeric() {
+            // Arrange
+            var type = typeof(Byte);
+            Byte? enumerator = null;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(byte));
+            conversion.Should().Be(null);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NullIntEnumToNumeric() {
+            // Arrange
+            var type = typeof(Int);
+            Int? enumerator = null;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(int));
+            conversion.Should().Be(null);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NullLongEnumToNumeric() {
+            // Arrange
+            var type = typeof(Long);
+            Long? enumerator = null;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(long));
+            conversion.Should().Be(null);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NullSByteEnumToNumeric() {
+            // Arrange
+            var type = typeof(SByte);
+            SByte? enumerator = null;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(sbyte));
+            conversion.Should().Be(null);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NullShortEnumToNumeric() {
+            // Arrange
+            var type = typeof(Short);
+            Short? enumerator = null;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(short));
+            conversion.Should().Be(null);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NullUIntEnumToNumeric() {
+            // Arrange
+            var type = typeof(UInt);
+            UInt? enumerator = null;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(uint));
+            conversion.Should().Be(null);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NullULongEnumToNumeric() {
+            // Arrange
+            var type = typeof(ULong);
+            ULong? enumerator = null;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(ulong));
+            conversion.Should().Be(null);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NullUShortEnumToNumeric() {
+            // Arrange
+            var type = typeof(UShort);
+            UShort? enumerator = null;
+
+            // Act
+            var converter = new EnumToNumericConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(ushort));
+            conversion.Should().Be(null);
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NonFlagEnumToString() {
+            // Arrange
+            var type = typeof(String);
+            var enumerator = String.Water;
+
+            // Act
+            var converter = new EnumToStringConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(string));
+            conversion.Should().Be("Water");
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void FlagEnumFlagToString() {
+            // Arrange
+            var type = typeof(Flags);
+            var enumerator = Flags.Disabled;
+
+            // Act
+            var converter = new EnumToStringConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(string));
+            conversion.Should().Be("Disabled");
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void FlagEnumCombinationToString() {
+            // Arrange
+            var type = typeof(Flags);
+            var enumerator = Flags.On | Flags.Mixed | Flags.Enabled;
+
+            // Act
+            var converter = new EnumToStringConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            impl.SourceType.Should().Be(type);
+            impl.ResultType.Should().Be(typeof(string));
+            conversion.Should().Be("On|Enabled|Mixed");
+            reversion.Should().Be(enumerator);
+        }
+
+        [TestMethod] public void NullEnumToString() {
+            // Arrange
+            var type = typeof(String);
+            String? enumerator = null;
+
+            // Act
+            var converter = new EnumToStringConverter(type);
+            var impl = converter.ConverterImpl;
+            var conversion = impl.Convert(enumerator);
+            var reversion = impl.Revert(conversion);
+
+            // Assert
+            conversion.Should().Be(null);
+            reversion.Should().Be(enumerator);
+        }
+
+
+        enum Byte : byte { B0, B1, B2, B3 };
+        enum Int : int { I0, I1, I2, I3 };
+        enum Long : long { L0, L1, L2, L3 };
+        enum SByte : sbyte { SB0, SB1, SB2, SB3 };
+        enum Short : short { S0, S1, S2, S3 };
+        enum UInt : uint { UI0, UI1, UI2, UI3 };
+        enum ULong : ulong { UL0, UL1, UL2, UL3 };
+        enum UShort : ushort { US0, US1, US2, US3 };
+
+        enum String { Water, Earth, Fire, Air, Energy }
+        [Flags] enum Flags { None = 0, On = 1, Off = 2, Enabled = 4, Disabled = 8, Partial = 16, Mixed = 32 }
+    }
+}


### PR DESCRIPTION
This commit adds two DataConverter implementations that operate on enumerations. The first interconverts between enumerators and their underlying numeric values, supporting all possible such numeric types. The second interconverts between enumerators and strings, using the ToString() function for all except unnamed flag combinations, where the flags are instead separated by a vertical bar. Out of necessity, these implementations make heavy use of reflection: the source type is provided as a runtime Type object, but the Cybele utility requires compile-time type specifications.