### PR TITLE
Translation of Enumeration-Type Fields

### DIFF
--- a/src/Cybele/Extensions/Enum.cs
+++ b/src/Cybele/Extensions/Enum.cs
@@ -42,7 +42,7 @@ namespace Cybele.Extensions {
         ///   the declaration of <typeparamref name="TEnum"/> or is a bitwise combination of such values.
         /// </returns>
         public static bool IsValid<TEnum>(this TEnum self) where TEnum : Enum {
-            var enumType = typeof(TEnum);
+            var enumType = self.GetType();
             var underlyingCode = self.GetTypeCode();
             var numeric = self.AsInt64();
 

--- a/src/Kvasir/Annotations/EnumAttributes.cs
+++ b/src/Kvasir/Annotations/EnumAttributes.cs
@@ -19,4 +19,23 @@ namespace Kvasir.Annotations {
         /// </summary>
         public string Path { get; init; } = "";
     }
+
+    /// <summary>
+    ///   An annotation that specifies that the type of the Field backing a particular property should correspond to the
+    ///   built-in string representation of the property's own type, which must be an <see cref="Enum"/>.
+    /// </summary>
+    /// <remarks>
+    ///   The default storage scheme for Enumeration-type Fields depends on the capabilities of the back-end database,
+    ///   but decays to <c>string</c> (with <c>CHECK</c> constraints as possible) in the absence of any explicit
+    ///   enumeration support. the <see cref="AsStringAttribute"/> can be used to override the default storage behavior
+    ///   and insist that the storage be a string type even if enumeration support is available.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public sealed class AsStringAttribute : Attribute {
+        /// <summary>
+        ///   The dot-separated path, relative to the property on which the annotation is placed, to the property to
+        ///   which the annotation actually applies.
+        /// </summary>
+        public string Path { get; init; } = "";
+    }
 }

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -597,6 +597,24 @@
               which the annotation actually applies.
             </summary>
         </member>
+        <member name="T:Kvasir.Annotations.AsStringAttribute">
+            <summary>
+              An annotation that specifies that the type of the Field backing a particular property should correspond to the
+              built-in string representation of the property's own type, which must be an <see cref="T:System.Enum"/>.
+            </summary>
+            <remarks>
+              The default storage scheme for Enumeration-type Fields depends on the capabilities of the back-end database,
+              but decays to <c>string</c> (with <c>CHECK</c> constraints as possible) in the absence of any explicit
+              enumeration support. the <see cref="T:Kvasir.Annotations.AsStringAttribute"/> can be used to override the default storage behavior
+              and insist that the storage be a string type even if enumeration support is available.
+            </remarks>
+        </member>
+        <member name="P:Kvasir.Annotations.AsStringAttribute.Path">
+            <summary>
+              The dot-separated path, relative to the property on which the annotation is placed, to the property to
+              which the annotation actually applies.
+            </summary>
+        </member>
         <member name="T:Kvasir.Annotations.CodeOnlyAttribute">
             <summary>
               An annotation that marks a particular property as "code-only."
@@ -6310,7 +6328,7 @@
               The <see cref="T:Kvasir.Translation.FieldDescriptor"/> describing the constraints.
             </param>
             <param name="field">
-              The <see cref="T:Kvasir.Schema.IField">Field</see> to which the <c>CHEKC</c> constraints apply.
+              The <see cref="T:Kvasir.Schema.IField">Field</see> to which the <c>CHECK</c> constraints apply.
             </param>
             <returns>
               A (possibly empty) collection of <c>CHECK</c> constraints that apply to <paramref name="field"/>.

--- a/src/Kvasir/Translation/Descriptors.cs
+++ b/src/Kvasir/Translation/Descriptors.cs
@@ -22,6 +22,7 @@ namespace Kvasir.Translation {
         Option<Bound> MaximumLength,
         IReadOnlySet<object> AllowedValues,
         IReadOnlySet<object> DisallowedValues,
+        IReadOnlySet<object> RestrictedImage,
         IReadOnlyList<CheckGen> CHECKs
     );
 

--- a/src/Kvasir/Translation/FieldConstraints.cs
+++ b/src/Kvasir/Translation/FieldConstraints.cs
@@ -386,10 +386,14 @@ namespace Kvasir.Translation {
                 }
 
                 // It is an error for all of the allowed values to be disallowed by other constraints
-                var hadInclusions = !constraints.AllowedValues.IsEmpty();
                 var inclusions = new HashSet<object>();
-                foreach (var inclusion in constraints.AllowedValues) {
+                var effective = constraints.AllowedValues.IsEmpty() ? constraints.RestrictedImage : constraints.AllowedValues;
+                var hadInclusions = !effective.IsEmpty();
+                foreach (var inclusion in effective) {
                     if (constraints.DisallowedValues.Contains(inclusion)) {
+                        continue;
+                    }
+                    if (!constraints.RestrictedImage.IsEmpty() && !constraints.RestrictedImage.Contains(inclusion)) {
                         continue;
                     }
 
@@ -405,7 +409,7 @@ namespace Kvasir.Translation {
                     }
                 }
                 if (hadInclusions && inclusions.IsEmpty()) {
-                    var allowed = constraints.AllowedValues.ToArray().ForDisplay();
+                    var allowed = effective.ToArray().ForDisplay();
                     var msg = $"each of the allowed values {allowed} is disallowed by another constraint";
                     throw Error.ConstraintsInConflict(context, msg);
                 }

--- a/src/Kvasir/Translation/Parsing.cs
+++ b/src/Kvasir/Translation/Parsing.cs
@@ -81,6 +81,11 @@ namespace Kvasir.Translation {
                 return Option.None<object?, string>($"expected value of type '{into.Name}'");
             }
 
+            // It is an error for an annotation value to be an invalid enumerator
+            if (into.IsEnum && !((Enum)self).IsValid()) {
+                return Option.None<object?, string>($"enumerator is invalid");
+            }
+
             // Perform actual parsing, if necessary
             if (into == typeof(DateTime)) {
                 if (!DateTime.TryParse((string)self, out DateTime result)) {

--- a/test/UnitTests/Kvasir/Annotations/TagAttributes.cs
+++ b/test/UnitTests/Kvasir/Annotations/TagAttributes.cs
@@ -172,5 +172,29 @@ namespace UT.Kvasir.Annotations {
             // Assert
             isUnique.Should().BeTrue();
         }
+
+        [TestMethod] public void AsString_Construct() {
+            // Arrange
+            var path = "Nested.Path";
+
+            // Act
+            var direct = new AsStringAttribute();
+            var nested = new AsStringAttribute() { Path = path };
+
+            // Assert
+            direct.Path.Should().BeEmpty();
+            nested.Path.Should().Be(path);
+        }
+
+        [TestMethod] public void AsString_UniqueId() {
+            // Arrange
+            var attr = new AsStringAttribute();
+
+            // Act
+            var isUnique = ids_.Add(attr.TypeId);
+
+            // Assert
+            isUnique.Should().BeTrue();
+        }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
@@ -113,6 +113,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Guid));                               // details / explanation
         }
 
+        [TestMethod] public void IsGreaterThan_EnumerationField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Orisha);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Orisha.BelongsTo))                    // error location
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsGreaterThan]")                     // details / explanation
+                .WithMessageContaining("totally ordered")                           // details / explanation
+                .WithMessageContaining(nameof(Orisha.Culture));                     // details / explanation
+        }
+
         [TestMethod] public void IsGreaterThan_NullableTotallyOrderedFields() {
             // Arrange
             var translator = new Translator();
@@ -507,6 +525,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsLessThan]")                        // details / explanation
                 .WithMessageContaining("totally ordered")                           // details / explanation
                 .WithMessageContaining(nameof(Guid));                               // details / explanation
+        }
+
+        [TestMethod] public void IsLessThan_EnumerationField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SolicitorGeneral);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(SolicitorGeneral.Affiliation))        // error location
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsLessThan]")                        // details / explanation
+                .WithMessageContaining("totally ordered")                           // details / explanation
+                .WithMessageContaining(nameof(SolicitorGeneral.PoliticalParty));    // details / explanation
         }
 
         [TestMethod] public void IsLessThan_NullableTotallyOrderedFields() {
@@ -905,6 +941,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Guid));                               // details / explanation
         }
 
+        [TestMethod] public void IsGreaterOrEqualTo_EnumerationField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(CivCityState);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(CivCityState.Type))                   // error location
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsGreaterOrEqualTo]")                // details / explanation
+                .WithMessageContaining("totally ordered")                           // details / explanation
+                .WithMessageContaining(nameof(CivCityState.Category));              // details / explanation
+        }
+
         [TestMethod] public void IsGreaterOrEqualTo_NullableTotallyOrderedFields() {
             // Arrange
             var translator = new Translator();
@@ -1297,6 +1351,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Guid));                               // details / explanation
         }
 
+        [TestMethod] public void IsLessOrEqualTo_EnumerationField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ConcertTour);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(ConcertTour.ArtistType))              // error location
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsLessOrEqualTo]")                   // details / explanation
+                .WithMessageContaining("totally ordered")                           // details / explanation
+                .WithMessageContaining(nameof(ConcertTour.Type));                   // details / explanation
+        }
+
         [TestMethod] public void IsLessOrEqualTo_NullableTotallyOrderedFields() {
             // Arrange
             var translator = new Translator();
@@ -1680,6 +1752,31 @@ namespace UT.Kvasir.Translation {
             // Assert
             translation.Principal.Table.Should()
                 .HaveConstraint(nameof(Church.ChurchID), ComparisonOperator.NE, new Guid("a3c3ac24-4cf2-428e-a4db-76b30958cc90")).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNot_EnumerationField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(MarianApparition);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(MarianApparition.When)).OfTypeDateTime().BeingNonNullable().And
+                .HaveField(nameof(MarianApparition.Location)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(MarianApparition.Witnesses)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(MarianApparition.MarianTitle)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(MarianApparition.Recognition)).OfTypeEnumeration(
+                    MarianApparition.Status.Accepted,
+                    MarianApparition.Status.Alleged,
+                    MarianApparition.Status.Confirmed,
+                    MarianApparition.Status.Documented,
+                    MarianApparition.Status.Recognized
+                ).BeingNonNullable().And
+                .HaveNoOtherFields().And
                 .HaveNoOtherConstraints();
         }
 

--- a/test/UnitTests/Kvasir/Translation/DataConverters.cs
+++ b/test/UnitTests/Kvasir/Translation/DataConverters.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Core;
 using Kvasir.Exceptions;
+using Kvasir.Schema;
 using Kvasir.Translation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -11,7 +12,6 @@ using static UT.Kvasir.Translation.TestConverters;
 namespace UT.Kvasir.Translation {
     [TestClass, TestCategory("DataConverters")]
     public class DataConverterTests {
-
         [TestMethod] public void NoChangeToFieldsType_Redundant() {
             // Arrange
             var translator = new Translator();
@@ -48,6 +48,102 @@ namespace UT.Kvasir.Translation {
                 .HaveField(nameof(Comet.Albedo)).OfTypeDouble().BeingNonNullable().And
                 .HaveField(nameof(Comet.OrbitalPeriod)).OfTypeSingle().BeingNonNullable().And
                 .HaveNoOtherFields();
+        }
+
+        [TestMethod] public void EnumerationToUnrelatedType() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(HomeRunDerby);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(HomeRunDerby.Year)).OfTypeUInt32().BeingNonNullable().And
+                .HaveField(nameof(HomeRunDerby.Victor)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(HomeRunDerby.TotalHomers)).OfTypeUInt16().BeingNonNullable().And
+                .HaveField(nameof(HomeRunDerby.LongestHomer)).OfTypeUInt16().BeingNonNullable().And
+                .HaveField(nameof(HomeRunDerby.CharityMoney)).OfTypeDecimal().BeingNonNullable().And
+                .HaveField(nameof(HomeRunDerby.Structure)).OfTypeDateTime().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveConstraint(nameof(HomeRunDerby.Structure), InclusionOperator.In,
+                    new DateTime(2000, 1, 1),
+                    new DateTime(2000, 1, 2),
+                    new DateTime(2000, 1, 3),
+                    new DateTime(2000, 1, 4)
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void EnumerationToNumericBackingType() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Quarterback);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(Quarterback.Name)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(Quarterback.ThrowingArm)).OfTypeInt8().BeingNonNullable().And
+                .HaveField(nameof(Quarterback.DraftRound)).OfTypeInt16().BeingNonNullable().And
+                .HaveField(nameof(Quarterback.QBStyle)).OfTypeInt32().BeingNonNullable().And
+                .HaveField(nameof(Quarterback.CareerAchievements)).OfTypeInt64().BeingNonNullable().And
+                .HaveField(nameof(Quarterback.Status)).OfTypeUInt8().BeingNonNullable().And
+                .HaveField(nameof(Quarterback.HasBeenTraded)).OfTypeUInt16().BeingNonNullable().And
+                .HaveField(nameof(Quarterback.FurthestPlayoffAdvancement)).OfTypeUInt32().BeingNonNullable().And
+                .HaveField(nameof(Quarterback.Leagues)).OfTypeUInt64().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveConstraint(nameof(Quarterback.ThrowingArm), InclusionOperator.In,
+                    (sbyte)0, (sbyte)1
+                ).And
+                .HaveConstraint(nameof(Quarterback.DraftRound), InclusionOperator.In,
+                    (short)14, (short)188, (short)2, (short)-16, (short)19054, (short)-333, (short)0, (short)8
+                ).And
+                .HaveConstraint(nameof(Quarterback.QBStyle), InclusionOperator.In,
+                    0, 1, 2, 3
+                ).And
+                .HaveConstraint(nameof(Quarterback.CareerAchievements), InclusionOperator.In,
+                    1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L,
+                    23L, 24L, 25L, 26L, 27L, 28L, 29L, 30L, 31L
+                ).And
+                .HaveConstraint(nameof(Quarterback.Status), InclusionOperator.In,
+                    (byte)0, (byte)1, (byte)2, (byte)3, (byte)4
+                ).And
+                .HaveConstraint(nameof(Quarterback.HasBeenTraded), InclusionOperator.In,
+                    (ushort)0, (ushort)1
+                ).And
+                .HaveConstraint(nameof(Quarterback.FurthestPlayoffAdvancement), InclusionOperator.In,
+                    0U, 1827412U, 44U, 949012U, 55U
+                ).And
+                .HaveConstraint(nameof(Quarterback.Leagues), InclusionOperator.In,
+                    2UL, 64UL, 66UL, 128UL, 130UL, 192UL, 194UL
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void EnumerationToString() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(EcumenicalCouncil);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(EcumenicalCouncil.Name)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(EcumenicalCouncil.Opening)).OfTypeDateTime().BeingNonNullable().And
+                .HaveField(nameof(EcumenicalCouncil.Closing)).OfTypeDateTime().BeingNonNullable().And
+                .HaveField(nameof(EcumenicalCouncil.RecognizedBy)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(EcumenicalCouncil.Attendance)).OfTypeUInt32().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveConstraint(nameof(EcumenicalCouncil.RecognizedBy), InclusionOperator.In,
+                    "CatholicChurch", "EasternOrthodoxChurch", "Unrecognized"
+                ).And
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void ConverterOnNullablePropertyHasNonNullableTargetType() {
@@ -189,6 +285,245 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("error constructing")                        // details / explanation
                 .WithMessageContaining(nameof(Unconstructible<short>))              // details / explanation
                 .WithMessageContaining(CANNOT_CONSTRUCT_MSG);                       // details / explanation
+        }
+
+        [TestMethod] public void DataConverterTypeThrowsOnConversion_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Ligament);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Ligament.Classification))             // error location
+                .WithMessageContaining("[DataConverter]")                           // details / explanation
+                .WithMessageContaining("error converting")                          // details / explanation
+                .WithMessageContaining("Type.Articular")                            // details / explanation
+                .WithMessageContaining(CANNOT_CONVERT_MSG);                         // details / explanation
+        }
+
+        [TestMethod] public void NumericConverterOnBooleanField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Pillow);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Pillow.IsThrowPillow))                // error location
+                .WithMessageContaining("[Numeric]")                                 // details / explanation
+                .WithMessageContaining(nameof(Boolean))                             // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void NumericConverterOnTextualField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(VigenereCipher);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(VigenereCipher.Key))                  // error location
+                .WithMessageContaining("[Numeric]")                                 // details / explanation
+                .WithMessageContaining(nameof(String))                              // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void NumericConverterOnNumericField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Satellite);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Satellite.OrbitsCompleted))           // error location
+                .WithMessageContaining("[Numeric]")                                 // details / explanation
+                .WithMessageContaining(nameof(UInt64))                              // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void NumericConverterOnDateTimeField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Symphony);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Symphony.PremiereDate))               // error location
+                .WithMessageContaining("[Numeric]")                                 // details / explanation
+                .WithMessageContaining(nameof(DateTime))                            // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void NumericConverterOnGuidField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(WordSearch);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(WordSearch.PuzzleID))                 // error location
+                .WithMessageContaining("[Numeric]")                                 // details / explanation
+                .WithMessageContaining(nameof(Guid))                                // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void AsStringConverterOnBooleanField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BondGirl);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(BondGirl.SleptWithBond))              // error location
+                .WithMessageContaining("[AsString]")                                // details / explanation
+                .WithMessageContaining(nameof(Boolean))                             // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void AsStringConverterOnTextualField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BatmanVillain);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(BatmanVillain.Grade))                 // error location
+                .WithMessageContaining("[AsString]")                                // details / explanation
+                .WithMessageContaining(nameof(Char))                                // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void AsStringConverterOnNumericField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Cemetery);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Cemetery.Latitude))                   // error location
+                .WithMessageContaining("[AsString]")                                // details / explanation
+                .WithMessageContaining(nameof(Double))                              // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void AsStringConverterOnDateTimeField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ImmaculateGrid);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(ImmaculateGrid.Date))                 // error location
+                .WithMessageContaining("[AsString]")                                // details / explanation
+                .WithMessageContaining(nameof(DateTime))                            // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void AsStringConverterOnGuidField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Eyeglasses);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Eyeglasses.GlassesID))                // error location
+                .WithMessageContaining("[AsString]")                                // details / explanation
+                .WithMessageContaining(nameof(Guid))                                // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void DataConverterAndNumeric_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SecretHitlerGame);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(SecretHitlerGame.Player7))            // error location
+                .WithMessageContaining("mutually exclusive")                        // category
+                .WithMessageContaining("[DataConverter]")                           // details / explanation
+                .WithMessageContaining("[Numeric]");                                // details / explanation
+        }
+
+        [TestMethod] public void DataConverterAndAsString_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Mezuzah);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Mezuzah.MadeOf))                      // error location
+                .WithMessageContaining("mutually exclusive")                        // category
+                .WithMessageContaining("[DataConverter]")                           // details / explanation
+                .WithMessageContaining("[AsString]");                               // details / explanation
+        }
+
+        [TestMethod] public void NumericAndAsString_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Atoll);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Atoll.Ocean))                         // error location
+                .WithMessageContaining("mutually exclusive")                        // category
+                .WithMessageContaining("[Numeric]")                                 // details / explanation
+                .WithMessageContaining("[AsString]");                               // details / explanation
         }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/DiscretenessConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/DiscretenessConstraints.cs
@@ -114,6 +114,27 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
+        [TestMethod] public void IsOneOf_EnumerationField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Tooth);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(Tooth.ToothID)).OfTypeGuid().BeingNonNullable().And
+                .HaveField(nameof(Tooth.Origin)).OfTypeEnumeration(
+                    Tooth.Source.Animal, Tooth.Source.Human
+                ).BeingNonNullable().And
+                .HaveField(nameof(Tooth.Type)).OfTypeEnumeration(
+                    Tooth.ToothType.Incisor, Tooth.ToothType.Bicuspid, Tooth.ToothType.Canine, Tooth.ToothType.Molar
+                ).BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void IsOneOf_NullableFields() {
             // Arrange
             var translator = new Translator();
@@ -183,6 +204,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsOneOf]")                           // details / explanation
                 .WithMessageContaining($"0 of type {nameof(Byte)}")                 // details / explanation
                 .WithMessageContaining(nameof(SByte));                              // details / explanation
+        }
+
+        [TestMethod] public void IsOneOf_InvalidEnumerator_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SpeedLimit);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(SpeedLimit.TypeOfStreet))             // error location
+                .WithMessageContaining("user-provided value*is invalid")            // category
+                .WithMessageContaining("[Check.IsOneOf]")                           // details / explanation
+                .WithMessageContaining("StreetType.40000")                          // details / explanation
+                .WithMessageContaining("enumerator is invalid");                    // details / explanation
         }
 
         [TestMethod] public void IsOneOf_ArrayValue_IsError() {
@@ -403,6 +442,29 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
+        [TestMethod] public void IsOneOf_SingleEnumeratorAllowed() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Treehouse);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(Treehouse.ID)).OfTypeGuid().BeingNonNullable().And
+                .HaveField(nameof(Treehouse.MadeBy)).OfTypeEnumeration(
+                    Treehouse.Manufacturing.Professional
+                ).BeingNonNullable().And
+                .HaveField(nameof(Treehouse.Elevation)).OfTypeDouble().BeingNonNullable().And
+                .HaveField(nameof(Treehouse.Height)).OfTypeDouble().BeingNonNullable().And
+                .HaveField(nameof(Treehouse.Length)).OfTypeDouble().BeingNonNullable().And
+                .HaveField(nameof(Treehouse.Width)).OfTypeDouble().BeingNonNullable().And
+                .HaveField(nameof(Treehouse.PrimaryWood)).OfTypeText().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void IsOneOf_PathIsNull_IsError() {
             // Arrange
             var translator = new Translator();
@@ -560,6 +622,27 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
+        [TestMethod] public void IsNotOneOf_EnumerationField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(RorschachInkBlot);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(RorschachInkBlot.BlotNumber)).OfTypeInt32().BeingNonNullable().And
+                .HaveField(nameof(RorschachInkBlot.MostCommonAnswer)).OfTypeEnumeration(
+                    RorschachInkBlot.Object.Skin, RorschachInkBlot.Object.Bat, RorschachInkBlot.Object.Humans,
+                    RorschachInkBlot.Object.Butterfly
+                ).BeingNonNullable().And
+                .HaveField(nameof(RorschachInkBlot.Commentary)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(RorschachInkBlot.ImageURL)).OfTypeText().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void IsNotOneOf_NullableFields() {
             // Arrange
             var translator = new Translator();
@@ -629,6 +712,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsNotOneOf]")                        // details / explanation
                 .WithMessageContaining($"8 of type {nameof(Byte)}")                 // details / explanation
                 .WithMessageContaining(nameof(UInt16));                             // details / explanation
+        }
+
+        [TestMethod] public void IsNotOneOf_InvalidEnumerator_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Emotion);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Emotion.Connotation))                 // error location
+                .WithMessageContaining("user-provided value*is invalid")            // category
+                .WithMessageContaining("[Check.IsNotOneOf]")                        // details / explanation
+                .WithMessageContaining("EmotionType.-3")                            // details / explanation
+                .WithMessageContaining("enumerator is invalid");                    // details / explanation
         }
 
         [TestMethod] public void IsNotOneOf_ArrayValue_IsError() {
@@ -846,6 +947,22 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(Transformer.IsAutobot))               // error location
                 .WithMessageContaining("both true and false explicitly disallowed") // category
+                .WithMessageContaining("one or more [Check.xxx] constraints");      // details / explanation
+        }
+
+        [TestMethod] public void IsNotOneOf_AllEnumeratorsDisallowed_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ProgrammingLanguage);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(ProgrammingLanguage.Type))            // error location
+                .WithMessageContaining("each of the allowed values*is disallowed")  // details / explanation
                 .WithMessageContaining("one or more [Check.xxx] constraints");      // details / explanation
         }
 

--- a/test/UnitTests/Kvasir/Translation/MixedConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/MixedConstraints.cs
@@ -587,5 +587,107 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("each of the allowed values*is disallowed")  // details / explanation
                 .WithMessageContaining("{ 75 }");                                   // details / explanation
         }
+
+        [TestMethod] public void NumericConversionWithSignedness() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Soup);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(nameof(Soup.Variety), InclusionOperator.In,
+                    14, 177, 90
+                ).And
+                .HaveConstraint(nameof(Soup.HasNoodles), InclusionOperator.In,
+                    1, -1
+                ).And
+                .HaveConstraint(nameof(Soup.BrothProtein), InclusionOperator.In,
+                    -8124, -4, -99
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void NumericConversionWithComparisons() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(CavePainting);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(nameof(CavePainting.Material), InclusionOperator.In,
+                    3, 4
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void NumericConversionWithDiscreteness() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Triangle);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(nameof(Triangle.Kind), InclusionOperator.In,
+                    1, 2, 4, 8, 6, 10
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void AsStringConversionWithComparisons() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Casino);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(nameof(Casino.TopMoneyMaker), InclusionOperator.In,
+                    "Poker", "Craps", "Roulette", "Pachinko"
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void AsStringConversionWithLengths() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(FacebookPost);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(nameof(FacebookPost.Visibility), InclusionOperator.In,
+                    "Private", "FriendsOnly", "Subscribers"
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void AsStringConversionWithDiscreteness() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ZodiacSign);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(nameof(ZodiacSign.SignSeason), InclusionOperator.In,
+                    "Summer", "Autumn"
+                ).And
+                .HaveNoOtherConstraints();
+        }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
+++ b/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
@@ -252,5 +252,52 @@ namespace UT.Kvasir.Translation {
                 .HaveField(nameof(DNDCharacter.Wisdom)).OfTypeUInt8().BeingNonNullable().And
                 .HaveNoOtherFields();
         }
+
+        [TestMethod] public void Enumerations() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(DNDWeapon);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(DNDWeapon.Name)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(DNDWeapon.AttackBonus)).OfTypeUInt16().BeingNonNullable().And
+                .HaveField(nameof(DNDWeapon.AverageDamage)).OfTypeUInt16().BeingNonNullable().And
+                .HaveField(nameof(DNDWeapon.Type)).OfTypeEnumeration(
+                    WeaponType.Simple,
+                    WeaponType.Martial,
+                    WeaponType.Improvised
+                ).BeingNonNullable().And
+                .HaveField(nameof(DNDWeapon.Properties)).OfTypeEnumeration(
+                    WeaponProperty.Finesse,
+                    WeaponProperty.Silvered,
+                    WeaponProperty.Ranged,
+                    WeaponProperty.TwoHanded,
+                    WeaponProperty.Finesse | WeaponProperty.Silvered,
+                    WeaponProperty.Finesse | WeaponProperty.Ranged,
+                    WeaponProperty.Finesse | WeaponProperty.TwoHanded,
+                    WeaponProperty.Silvered | WeaponProperty.Ranged,
+                    WeaponProperty.Silvered | WeaponProperty.TwoHanded,
+                    WeaponProperty.Ranged | WeaponProperty.TwoHanded,
+                    WeaponProperty.Finesse | WeaponProperty.Silvered | WeaponProperty.Ranged,
+                    WeaponProperty.Finesse | WeaponProperty.Silvered | WeaponProperty.TwoHanded,
+                    WeaponProperty.Silvered | WeaponProperty.Ranged | WeaponProperty.TwoHanded,
+                    WeaponProperty.Ranged | WeaponProperty.TwoHanded | WeaponProperty.Finesse,
+                    WeaponProperty.Finesse | WeaponProperty.Silvered | WeaponProperty.Ranged | WeaponProperty.TwoHanded
+                ).BeingNonNullable().And
+                .HaveField(nameof(DNDWeapon.MostEffectiveOn)).OfTypeEnumeration(
+                    DayOfWeek.Sunday,
+                    DayOfWeek.Monday,
+                    DayOfWeek.Tuesday,
+                    DayOfWeek.Wednesday,
+                    DayOfWeek.Thursday,
+                    DayOfWeek.Friday,
+                    DayOfWeek.Saturday
+                ).BeingNullable().And
+                .HaveNoOtherFields();
+        }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/SignednessConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/SignednessConstraints.cs
@@ -116,6 +116,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Guid));                               // details / explanation
         }
 
+        [TestMethod] public void IsPositive_EnumerationField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Mythbusting);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Mythbusting.Rating))                  // error location
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsPositive]")                        // details / explanation
+                .WithMessageContaining("numeric")                                   // details / explanation
+                .WithMessageContaining(nameof(Mythbusting.Resolution));             // details / explanation
+        }
+
         [TestMethod] public void IsPositive_FieldWithNumericDataConversionTarget() {
             // Arrange
             var translator = new Translator();
@@ -337,6 +355,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Guid));                               // details / explanation
         }
 
+        [TestMethod] public void IsNegative_EnumerationField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SerialKiller);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(SerialKiller.CurrentStatus))          // error location
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsNegative]")                        // details / explanation
+                .WithMessageContaining("numeric")                                   // details / explanation
+                .WithMessageContaining(nameof(SerialKiller.Status));                // details / explanation
+        }
+
         [TestMethod] public void IsNegative_FieldWithNumericDataConversionTarget() {
             // Arrange
             var translator = new Translator();
@@ -539,6 +575,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsNonZero]")                         // details / explanation
                 .WithMessageContaining("numeric")                                   // details / explanation
                 .WithMessageContaining(nameof(Guid));                               // details / explanation
+        }
+
+        [TestMethod] public void IsNonZero_EnumerationField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(IPO);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(IPO.PostingMethod))                   // error location
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsNonZero]")                         // details / explanation
+                .WithMessageContaining("numeric")                                   // details / explanation
+                .WithMessageContaining(nameof(IPO.Method));                         // details / explanation
         }
 
         [TestMethod] public void IsNonZero_FieldWithNumericDataConversionTarget() {

--- a/test/UnitTests/Kvasir/Translation/_Converters.cs
+++ b/test/UnitTests/Kvasir/Translation/_Converters.cs
@@ -1,5 +1,6 @@
 ﻿using Kvasir.Core;
 using System;
+using System.Collections.Generic;
 
 namespace UT.Kvasir.Translation {
     internal static class TestConverters {
@@ -15,6 +16,26 @@ namespace UT.Kvasir.Translation {
         public class Invert : IDataConverter<bool, bool> {
             public bool Convert(bool source) { return !source; }
             public bool Revert(bool result) { return !result; }
+        }
+        public class MakeDate<T> : IDataConverter<T, DateTime> where T : notnull {
+            public MakeDate() {
+                conversions_ = new Dictionary<T, DateTime>();
+                reversions_ = new Dictionary<DateTime, T>();
+                lastDate_ = new DateTime(2000, 1, 1);
+            }
+            public DateTime Convert(T source) {
+                conversions_.TryAdd(source, lastDate_);
+                lastDate_ = lastDate_.AddDays(1);
+                return conversions_[source];
+            }
+            public T Revert(DateTime result) {
+                return reversions_[result];
+            }
+
+
+            public DateTime lastDate_;
+            public readonly Dictionary<T, DateTime> conversions_;
+            public readonly Dictionary<DateTime, T> reversions_;
         }
         public class Nullify<T> : IDataConverter<T, T?> where T : notnull {
             public T? Convert(T source) { return source; }
@@ -41,8 +62,13 @@ namespace UT.Kvasir.Translation {
             public T Convert(T source) { return source; }
             public T Revert(T result) { return result; }
         }
+        public class Unconvertible<T> : IDataConverter<T, T> {
+            public T Convert(T source) { throw new InvalidOperationException(CANNOT_CONVERT_MSG); }
+            public T Revert(T result) { return result; }
+        }
 
 
         public static readonly string CANNOT_CONSTRUCT_MSG = "This converter type is not constructible";
+        public static readonly string CANNOT_CONVERT_MSG = "This value cannot be converted";
     }
 }

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -160,6 +160,18 @@ namespace UT.Kvasir.Translation {
             [CodeOnly] public IArmor? Armor { get; set; }
             [CodeOnly] public CustomBackground<DNDCharacter>? Background { get; set; }
         }
+
+        // Test Scenario: Enumerations (✓recognized✓)
+        public enum WeaponType { Simple, Martial, Improvised };
+        [Flags] public enum WeaponProperty { Ranged = 1, TwoHanded = 2, Finesse = 4, Silvered = 8 };
+        public class DNDWeapon {
+            [PrimaryKey] public string Name { get; set; } = "";
+            public ushort AttackBonus { get; set; }
+            public ushort AverageDamage { get; set; }
+            public WeaponType Type { get; set; }
+            public WeaponProperty Properties { get; set; }
+            public DayOfWeek? MostEffectiveOn { get; set; }
+        }
     }
 
     internal static class EntityShapes {
@@ -809,13 +821,47 @@ namespace UT.Kvasir.Translation {
             public byte FeastDay { get; set; }
         }
 
-        // Test Scenario: `null` Default for Nullable Field (✓valid✓)
+        // Test Scenario: Non-`null` Valid Enumeration Default (✓valid✓)
+        public class Oceanid {
+            [Flags] public enum Source { Hesiod = 1, HomericHymn = 2, Apollodorus = 4, Hyginus = 8 };
+
+            public string Name { get; set; } = "";
+            [PrimaryKey] public string Greek { get; set; } = "";
+            [Default(Source.Hesiod | Source.Hyginus)] public Source MentionedIn { get; set; }
+            public int NumChildren { get; set; }
+        }
+
+        // Test Scenario: Non-`null` Invalid Enumeration Default (✗invalid✗)
+        public class HallOfFame {
+            public enum Category { Sports, Entertainment, Journalism }
+
+            [PrimaryKey] public string For { get; set; } = "";
+            public uint Enshrinees { get; set; }
+            [Default((Category)185)] public Category Categorization { get; set; }
+            public float Latitude { get; set; }
+            public float Longitude { get; set; }
+            public DateTime Opened { get; set; }
+        }
+
+        // Test Scenario: `null` Default for Nullable Scalar Field (✓valid✓)
         public class Pepper {
             [PrimaryKey] public string Genus { get; set; } = "";
             [PrimaryKey] public string Species { get; set; } = "";
             [Default(null)] public string? CommonName { get; set; }
             [Default(null)] public DateTime? FirstCultivated { get; set; }
             public ulong ScovilleRating { get; set; }
+        }
+
+        // Test Scenario: `null` Default for Nullable Enumeration Filed (✓valid✓)
+        public class Cryptid {
+            public enum Continent { NorthAmerica, SouthAmerica, Asia, Europe, Africa, Oceania, Antarctica };
+            [Flags] public enum Features { Flying = 1, Carnivorous = 2, Humanoid = 4, Aquatic = 8, FireProof = 16, Hematophagous = 32 };
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            public uint AllegedSightings { get; set; }
+            [Default(null)] public Continent? HomeContinent { get; set; }
+            [Default(null)] public Features? FeatureSet { get; set; }
+            public bool ProvenHoax { get; set; }
         }
 
         // Test Scenario: `null` Default for Non-Nullable Field (✗invalid✗)
@@ -843,6 +889,33 @@ namespace UT.Kvasir.Translation {
             [Default(5000000)] public ulong Population { get; set; }
             public ulong Area { get; set; }
             public DateTime Incorporation { get; set; }
+        }
+
+        // Test Scenario: Enumeration Default on [Numeric] Field (✗invalid✗)
+        public class MasterClass {
+            public enum Domain : ushort { Sports, Acting, Marketing, Business, Politics, Art, Writing, Comedy, Cooking }
+
+            [PrimaryKey] public Guid ClassID { get; set; }
+            public string Title { get; set; } = "";
+            public string Teacher { get; set; } = "";
+            [Default(Domain.Politics), Numeric] public Domain Category { get; set; }
+            public uint Sessions { get; set; }
+            public uint Minutes { get; set; }
+            public decimal Price { get; set; }
+            public string URL { get; set; } = "";
+        }
+
+        // Test Scenario: Enumeration Default on [AsString] Field (✗invalid✗)
+        public class Orphanage {
+            public enum Kind { Public, Private, Medical }
+
+            [PrimaryKey] public float Latitude { get; set; }
+            [PrimaryKey] public float Longitude { get; set; }
+            public string Name { get; set; } = "";
+            [Default(Kind.Private), AsString] public Kind Type { get; set; }
+            public ushort Occupants { get; set; }
+            public double AdoptionRate { get; set; }
+            public string Headmistress { get; set; } = "";
         }
 
         // Test Scenario: Single-Element Array Default (✗invalid✗)
@@ -909,6 +982,30 @@ namespace UT.Kvasir.Translation {
             public string Identifier { get; set; } = "";
             public long HumanEntrez { get; set; }
             public string UCSCLocation { get; set; } = "";
+        }
+
+        // Test Scenario: Enumeration Default is not Named Enumerator (✗invalid✗)
+        public class MoonOfJupiter {
+            public enum Group { Galilean, Themisto, Himalia, Carpo, Valetudo, Ananke, Carme, Pasiphae };
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            public DateTime Discovered { get; set; }
+            [Default((Group)87123)] public Group MoonGroup { get; set; }
+            public long Volume { get; set; }
+            public float SurfaceGravity { get; set; }
+            public double ApparentMagnitude { get; set; }
+        }
+
+        // Test Scenario: Flag Enumeration Default is not Valid Combination (✗invalid✗)
+        public class Newspaper {
+            public enum Section { Sports, Politics, Comics, Cultures, FilmReviews, Obituaries, Weather, Classifieds }
+
+            public string City { get; set; } = "";
+            [PrimaryKey] public string Title { get; set; } = "";
+            public bool PublishedDaily { get; set; }
+            [Default((Section)15)] public Section Contents { get; set; }
+            public string Jan1Headline { get; set; } = "";
+            public long Circulation { get; set; }
         }
 
         // Test Scenario: Default of Source Type on Data-Converted Property (✗invalid✗)
@@ -1430,6 +1527,51 @@ namespace UT.Kvasir.Translation {
             public float OrbitalPeriod { get; set; }
         }
 
+        // Test Scenario: Custom Data Conversion for Enumeration Field (✓applied✓)
+        public class HomeRunDerby {
+            public enum Variety { Bracketed, SingleElimination, SingleRound, GroupProgression }
+
+            [PrimaryKey] public uint Year { get; set; }
+            public string Victor { get; set; } = "";
+            public ushort TotalHomers { get; set; }
+            public ushort LongestHomer { get; set; }
+            public decimal CharityMoney { get; set; }
+            [DataConverter(typeof(MakeDate<Variety>))] public Variety Structure { get; set; }
+        }
+
+        // Test Scenario: [Numeric] Data Conversion for Enumeration Field (✓applied✓)
+        public class Quarterback {
+            public enum Throws : sbyte { Left, Right }
+            public enum Round : short { R1 = 14, R2 = 188, R3 = 2, R4 = -16, R5 = 19054, R6 = -333, R7 = 0, Undrafted = 8 }
+            public enum Style : int { PocketPasser, Mobile, Gunslinger, BackUp }
+            [Flags] public enum Accolade : long { ProBowl = 1, AllPro = 2, OPOY = 4, MVP = 8, HallOfFame = 16 }
+            public enum PlayerStatus : byte { Retired, Active, Injured, PracticeSquad, FreeAgent }
+            public enum YesNo : ushort { Yes, No }
+            public enum PlayoffRound : uint { Never = 0, WildCard = 1827412, Champ = 44, SuperBowl = 949012, Lombardy = 55 }
+            [Flags] public enum League : ulong { NFL = 128, XFL = 2, CFL = 64 }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            [Numeric] public Throws ThrowingArm { get; set; }
+            [Numeric] public Round DraftRound { get; set; }
+            [Numeric] public Style QBStyle { get; set; }
+            [Numeric] public Accolade CareerAchievements { get; set; }
+            [Numeric] public PlayerStatus Status { get; set; }
+            [Numeric] public YesNo HasBeenTraded { get; set; }
+            [Numeric] public PlayoffRound FurthestPlayoffAdvancement { get; set; }
+            [Numeric] public League Leagues { get; set; }
+        }
+
+        // Test Scenario: [AsString] Data Conversion for Enumeration Field (✓applied✓)
+        public class EcumenicalCouncil {
+            public enum Recognition { CatholicChurch, EasternOrthodoxChurch, Unrecognized }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            public DateTime Opening { get; set; }
+            public DateTime Closing { get; set; }
+            [AsString] public Recognition RecognizedBy { get; set; }
+            public uint Attendance { get; set; }
+        }
+
         // Test Scenario: Data Conversion Source Type is Non-Nullable on Nullable Field (✓applied✓)
         public class RoyalHouse {
             [PrimaryKey] public string HouseName { get; set; } = "";
@@ -1513,6 +1655,157 @@ namespace UT.Kvasir.Translation {
             public int Kills { get; set; }
             [DataConverter(typeof(Unconstructible<short>))] public short YearForged { get; set; }
         }
+
+        // Test Scenario: Data Converter Throws upon Execution (✗propagated✗)
+        public class Ligament {
+            public enum Type { Articular, Pretioneal, FetalRemnant }
+
+            [PrimaryKey] public string MeSH { get; set; } = "";
+            public string Name { get; set; } = "";
+            [DataConverter(typeof(Unconvertible<Type>))] public Type Classification { get; set; }
+            public float Length { get; set; }
+            public string From { get; set; } = "";
+            public string To { get; set; } = "";
+        }
+
+        // Test Scenario: [Numeric] Applied to Boolean Field (✗impermissible✗)
+        public class Pillow {
+            [PrimaryKey] public Guid ID { get; set; }
+            public float Length { get; set; }
+            public float Width { get; set; }
+            [Numeric] public bool IsThrowPillow { get; set; }
+            public bool IsChilled { get; set; }
+        }
+
+        // Test Scenario: [Numeric] Applied to Textual Field (✗impermissible✗)
+        public class VigenereCipher {
+            [PrimaryKey, Numeric] public string Key { get; set; } = "";
+            public bool IsCracked { get; set; }
+        }
+
+        // Test Scenario: [Numeric] Applied to Numeric Field (✗impermissible✗)
+        public class Satellite {
+            [PrimaryKey] public string Name { get; set; } = "";
+            public double Weight { get; set; }
+            public ushort MissionDuration { get; set; }
+            public DateTime Launch { get; set; }
+            [Numeric] public ulong OrbitsCompleted { get; set; }
+        }
+
+        // Test Scenario: [Numeric] Applied to DateTime Field (✗impermissible✗)
+        public class Symphony {
+            [PrimaryKey] public string Composer { get; set; } = "";
+            [PrimaryKey] public uint OpusNumber { get; set; }
+            public ushort Length { get; set; }
+            public string Key { get; set; } = "";
+            [Numeric] public DateTime PremiereDate { get; set; }
+        }
+
+        // Test Scenario: [Numeric] Applied to Guid Field (✗impermissible✗)
+        public class WordSearch {
+            [PrimaryKey, Numeric] public Guid PuzzleID { get; set; }
+            public uint LettersWide { get; set; }
+            public uint LettersTall { get; set; }
+            public ulong NumWords { get; set; }
+            public bool DiagonalsAllowed { get; set; }
+            public bool BackwardsAllowed { get; set; }
+            public string Title { get; set; } = "";
+        }
+
+        // Test Scenario: [AsString] Applied to Boolean Field (✗impermissible✗)
+        public class BondGirl {
+            [PrimaryKey] public string Name { get; set; } = "";
+            public string Actress { get; set; } = "";
+            public string Debut { get; set; } = "";
+            public ushort Appearances { get; set; }
+            [AsString] public bool SleptWithBond { get; set; }
+        }
+
+        // Test Scenario: [AsString] Applied to Textual Field (✗impermissible✗)
+        public class BatmanVillain {
+            public string Name { get; set; } = "";
+            [PrimaryKey] public string AlterEgo { get; set; } = "";
+            public bool IsAlive { get; set; }
+            public ulong NumAppearances { get; set; }
+            public DateTime Debut { get; set; }
+            public bool InCahootsWithJoker { get; set; }
+            [AsString] public char Grade { get; set; }
+        }
+
+        // Test Scenario: [AsString] Applied to Numeric Field (✗impermissible✗)
+        public class Cemetery {
+            [PrimaryKey] public double Longitude { get; set; }
+            [PrimaryKey, AsString] public double Latitude { get; set; }
+            public ulong Area { get; set; }
+            public int Capacity { get; set; }
+            public bool IsNational { get; set; }
+            public uint NumMausoleums { get; set; }
+        }
+
+        // Test Scenario: [AsString] Applied to DateTime Field (✗impermissible✗)
+        public class ImmaculateGrid {
+            [PrimaryKey, AsString] public DateTime Date { get; set; }
+            public string V1 { get; set; } = "";
+            public string V2 { get; set; } = "";
+            public string V3 { get; set; } = "";
+            public string H1 { get; set; } = "";
+            public string H2 { get; set; } = "";
+            public string H3 { get; set; } = "";
+            public double ImmaculatePercentage { get; set; }
+        }
+
+        // Test Scenario: [AsString] Applied to Guid Field (✗impermissible✗)
+        public class Eyeglasses {
+            [PrimaryKey, AsString] public Guid GlassesID { get; set; }
+            public string Prescription { get; set; } = "";
+            public bool IsMonocle { get; set; }
+            public bool ForReadingOnly { get; set; }
+            public float LensArea { get; set; }
+        }
+
+        // Test Scenario: Property Marked with [DataConverter] and [Numeric] (✗conflicting✗)
+        public class SecretHitlerGame {
+            public enum Role { Liberal, Fascist, Hitler }
+
+            [PrimaryKey] public Guid GameID { get; set; }
+            public Role Player1 { get; set; }
+            public Role Player2 { get; set; }
+            public Role Player3 { get; set; }
+            public Role Player4 { get; set; }
+            public Role Player5 { get; set; }
+            public Role? Player6 { get; set; }
+            [DataConverter(typeof(ToString<Role>)), Numeric] public Role? Player7 { get; set; }
+            public byte LiberalPolicies { get; set; }
+            public byte FascistPolicies { get; set; }
+            public bool HitlerElectedChancellor { get; set; }
+            public bool HitlerKilled { get; set; }
+        }
+
+        // Test Scenario: Property Marked with [DataConverter] and [AsString] (✗conflicting✗)
+        public class Mezuzah {
+            public enum Material { Gold, Silver, Steel, Plastic, Clay, Wood }
+
+            [PrimaryKey] public Guid MezuzahID { get; set; }
+            public double Weight { get; set; }
+            public double Length { get; set; }
+            public decimal? RetailPrice { get; set; }
+            [DataConverter(typeof(ToInt<Material>)), AsString] public Material MadeOf { get; set; }
+            public bool CurrentlyAffixed { get; set; }
+        }
+
+        // Test Scenario: Property Marked with [Numeric] and [AsString] (✗conflicting✗)
+        public class Atoll {
+            public enum Sea { Arctic, Indian, Pacific, Atlantic }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            [Numeric, AsString] public Sea Ocean { get; set; }
+            public uint NumIslands { get; set; }
+            public ulong Area { get; set; }
+            public ulong Population { get; set; }
+            public float Latitude { get; set; }
+            public float Longitude { get; set; }
+            public bool CoralReefs { get; set; }
+        }
     }
 
     internal static class SignednessConstraints {
@@ -1578,6 +1871,17 @@ namespace UT.Kvasir.Translation {
                 public ushort Runtime { get; set; }
                 public DateTime ReleaseDate { get; set; }
                 public bool NeverBeforeSeenFootage { get; set; }
+            }
+
+            // Test Scenario: Applied to Enumeration Field (✗impermissible✗)
+            public class Mythbusting {
+                public enum Resolution { Busted, Plausible, Confirmed }
+
+                [PrimaryKey] public uint Season { get; set; }
+                [PrimaryKey] public uint Episode { get; set; }
+                [PrimaryKey] public uint MythNumber { get; set; }
+                public string MythDescription { get; set; } = "";
+                [Check.IsPositive] public Resolution Rating { get; set; }
             }
 
             // Test Scenario: Applied to Field Data-Converted to Numeric Type (✓constrained✓)
@@ -1718,6 +2022,17 @@ namespace UT.Kvasir.Translation {
                 public decimal DependentBenefits { get; set; }
             }
 
+            // Test Scenario: Applied to Enumeration Field (✗impermissible✗)
+            public class SerialKiller {
+                public enum Status { AtLarge, Incarerated, Apprehended, InTrial }
+
+                [PrimaryKey] public string AlterEgo { get; set; } = "";
+                public string? Identity { get; set; }
+                [Check.IsNegative] public Status CurrentStatus { get; set; }
+                public uint KnownVictims { get; set; }
+                public bool FBIMostWanted { get; set; }
+            }
+
             // Test Scenario: Applied to Field Data-Converted to Numeric Type (✓constrained✓)
             public class Boxer {
                 [PrimaryKey] public string FirstName { get; set; } = "";
@@ -1829,6 +2144,19 @@ namespace UT.Kvasir.Translation {
                 public float TopologicalDimension { get; set; }
                 public float HausdorffDimension { get; set; }
                 public bool CanTesselate { get; set; }
+            }
+
+            // Test Scenario: Applied to Enumeration Field (✗impermissible✗)
+            public class IPO {
+                public enum Method { BestEfforts, FirmCommittment, AllOrNone, BoughtDeal }
+
+                [PrimaryKey] public string Company { get; set; } = "";
+                public string Symbol { get; set; } = "";
+                public string Exchange { get; set; } = "";
+                [Check.IsNonZero] public Method PostingMethod { get; set; }
+                public ulong Shares { get; set; }
+                public decimal OpeningPrice { get; set; }
+                public decimal ClosingPrice { get; set; }
             }
 
             // Test Scenario: Applied to Field Data-Converted to Numeric Type (✓constrained✓)
@@ -1948,6 +2276,16 @@ namespace UT.Kvasir.Translation {
                 public ulong AntennaHeight { get; set; }
                 public DateTime Completed { get; set; }
                 public byte Elevators { get; set; }
+            }
+
+            // Test Scenario: Applied to Enumeration Field (✗impermissible✗)
+            public class Orisha {
+                [Flags] public enum Culture { Yoruba = 1, Santeria = 2, Oyotunji = 4, Candomble = 8 }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                [Check.IsGreaterThan(Culture.Santeria)] public Culture BelongsTo { get; set; }
+                public string Domain { get; set; } = "";
+                public uint WikipediaWords { get; set; }
             }
 
             // Test Scenario: Applied to Nullable Fields with Total Orders (✓constrained✓)
@@ -2189,6 +2527,17 @@ namespace UT.Kvasir.Translation {
                 public float Version { get; set; }
             }
 
+            // Test Scenario: Applied to Enumeration Field (✗impermissible✗)
+            public class SolicitorGeneral {
+                public enum PoliticalParty { Democrat, Republican, Green, Socialist, Independent }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                public string AppointedBy { get; set; } = "";
+                [Check.IsLessThan(PoliticalParty.Green)] public PoliticalParty? Affiliation { get; set; }
+                public uint CasesArgued { get; set; }
+                public DateTime FirstSCOTUS { get; set; }
+            }
+
             // Test Scenario: Applied to Nullable Fields with Total Orders (✓constrained✓)
             public class AutoRacetrack {
                 [PrimaryKey] public string Name { get; set; } = "";
@@ -2404,6 +2753,17 @@ namespace UT.Kvasir.Translation {
                 public string Background { get; set; } = "";
                 public string Foreground { get; set; } = "";
                 public string Tressure { get; set; } = "";
+            }
+
+            // Test Scenario: Applied to Enumeration Field (✗impermissible✗)
+            public class CivCityState {
+                public enum Category { Cultural, Scientific, Economic, Militaristic, Industrial, Religious }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                [Check.IsGreaterOrEqualTo(Category.Cultural)] public Category Type { get; set; }
+                public ulong RealWorldPopulation { get; set; }
+                public string Introduced { get; set; } = "";
+                public string SuzerainBonus { get; set; } = "";
             }
 
             // Test Scenario: Applied to Nullable Fields with Total Orders (✓constrained✓)
@@ -2628,6 +2988,21 @@ namespace UT.Kvasir.Translation {
                 public bool IsNatural { get; set; }
             }
 
+            // Test Scenario: Applied to Enumeration Field (✗impermissible✗)
+            public class ConcertTour {
+                public enum Type { Solo, Band, Reunion, Jukebox }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                public string Artist { get; set; } = "";
+                [Check.IsLessOrEqualTo(Type.Jukebox)] public Type ArtistType { get; set; }
+                public string StartCity { get; set; } = "";
+                public string EndCity { get; set; } = "";
+                public uint NumShows { get; set; }
+                public DateTime StartDate { get; set; }
+                public DateTime EndDate { get; set; }
+                public decimal Gross { get; set; }
+            }
+
             // Test Scenario: Applied to Nullable Fields with Total Orders (✓constrained✓)
             public class Subreddit {
                 [PrimaryKey] public string Identifier { get; set; } = "";
@@ -2848,6 +3223,17 @@ namespace UT.Kvasir.Translation {
                 public double Height { get; set; }
                 public ushort NumBells { get; set; }
                 public DateTime Established { get; set; }
+            }
+
+            // Test Scenario: Applied to Enumeration Field (✓constrained✓)
+            public class MarianApparition {
+                public enum Status { Alleged, Confirmed, Accepted, Recognized, Documented, Ignored }
+
+                [PrimaryKey] public DateTime When { get; set; }
+                [PrimaryKey] public string Location { get; set; } = "";
+                public string Witnesses { get; set; } = "";
+                public string MarianTitle { get; set; } = "";
+                [Check.IsNot(Status.Ignored)] public Status Recognition { get; set; }
             }
 
             // Test Scenario: Applied to Nullable Fields (✓constrained✓)
@@ -3628,6 +4014,16 @@ namespace UT.Kvasir.Translation {
                 public decimal TotalCost { get; set; }
             }
 
+            // Test Scenario: Applied to Enumeration Field (✓limiting✓)
+            public class Tooth {
+                public enum Source { Human, Animal, Synthetic }
+                public enum ToothType { Incisor, Molar, Canine, Bicuspid }
+
+                [PrimaryKey] public Guid ToothID { get; set; }
+                [Check.IsOneOf(Source.Human, Source.Animal)] public Source Origin { get; set; }
+                [Check.IsOneOf(ToothType.Incisor, ToothType.Molar, ToothType.Canine, ToothType.Bicuspid)] public ToothType Type { get; set; }
+            }
+
             // Test Scenario: Applied to Nullable Fields (✓constrained✓)
             public class Wildfire {
                 [PrimaryKey] public Guid WildfireID { get; set; }
@@ -3662,6 +4058,18 @@ namespace UT.Kvasir.Translation {
                 [Check.IsOneOf((byte)0, (byte)15, (byte)30, (byte)40)] public sbyte Player1Score { get; set; }
                 public sbyte Player2Score { get; set; }
                 public string? Tournament { get; set; }
+            }
+
+            // Test Scenario: Invalid Enumerator Allowed Value (✗invalid✗)
+            public class SpeedLimit {
+                public enum StreetType { Residential, Highway, Public, Unincorporated, Personal }
+
+                [PrimaryKey] public string StreetName { get; set; } = "";
+                [Check.IsOneOf(StreetType.Highway, StreetType.Public, (StreetType)40000)] public StreetType TypeOfStreet { get; set; }
+                [PrimaryKey] public float StartDistance { get; set; }
+                [PrimaryKey] public float EndDistance { get; set; }
+                public ushort MaximumSpeed { get; set; }
+                public ushort MinimumSpeed { get; set; }
             }
 
             // Test Scenario: Single-Element Array Allowed Value (✗invalid✗)
@@ -3780,6 +4188,19 @@ namespace UT.Kvasir.Translation {
                 public bool IsAutomatic { get; set; }
             }
 
+            // Test Scenario: Only One Enumerator Permitted (✓valid✓)
+            public class Treehouse {
+                [Flags] public enum Manufacturing { Amateur, Professional, Kit, Factory }
+
+                [PrimaryKey] public Guid ID { get; set; }
+                [Check.IsOneOf(Manufacturing.Professional)] public Manufacturing MadeBy { get; set; }
+                public double Elevation { get; set; }
+                public double Height { get; set; }
+                public double Length { get; set; }
+                public double Width { get; set; }
+                public string PrimaryWood { get; set; } = "";
+            }
+
             // Test Scenario: <Path> is `null` (✗illegal✗)
             public class Dragon {
                 [PrimaryKey] public Guid DragonID { get; set; }
@@ -3869,6 +4290,16 @@ namespace UT.Kvasir.Translation {
                 public bool OnSpotify { get; set; }
             }
 
+            // Test Scenario: Applied to Enumeration Field (✓limiting✓)
+            public class RorschachInkBlot {
+                public enum Object { Bat, Butterfly, Humans, Skin, Lobster, Other }
+
+                [PrimaryKey] public int BlotNumber { get; set; }
+                [Check.IsNotOneOf(Object.Other, Object.Lobster)] public Object MostCommonAnswer { get; set; }
+                public string Commentary { get; set; } = "";
+                public string ImageURL { get; set; } = "";
+            }
+
             // Test Scenario: Applied to Nullable Fields (✓constrained✓)
             public class PIERoot {
                 [PrimaryKey] public string Root { get; set; } = "";
@@ -3910,6 +4341,16 @@ namespace UT.Kvasir.Translation {
                 public bool MasteredEarth { get; set; }
                 public bool MasteredAir { get; set; }
                 public bool MasteredEnergy { get; set; }
+            }
+
+            // Test Scenario: Invalid Enumerator Disallowed Value (✗invalid✗)
+            public class Emotion {
+                public enum EmotionType { Positive, Negative, Neutral }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                public string? Color { get; set; }
+                [Check.IsNotOneOf((EmotionType)(-3))] public EmotionType Connotation { get; set; }
+                public bool DeadlySin { get; set; }
             }
 
             // Test Scenario: Single-Element Array Disallowed Value (✗invalid✗)
@@ -4024,6 +4465,18 @@ namespace UT.Kvasir.Translation {
                 public uint TelevisionApperances { get; set; }
                 public uint MovieAppearances { get; set; }
                 [Check.IsNotOneOf(true, false)] public bool IsAutobot { get; set; }
+            }
+
+            // Test Scenario: All Enumerators Disallowed (✗unsatisfiable✗)
+            public class ProgrammingLanguage {
+                public enum Style { ObjectOriented, Functional, Logical, Assembly }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                [Check.IsNotOneOf(Style.ObjectOriented, Style.Functional, Style.Logical, Style.Assembly)] public Style Type { get; set; }
+                public uint NumKeywords { get; set; }
+                public double StackOverflowShare { get; set; }
+                public string LatestStandard { get; set; } = "";
+                public bool IsCompiled { get; set; }
             }
 
             // Test Scenario: Scalar Property Constrained Multiple Times (✓union✓)
@@ -4636,6 +5089,80 @@ namespace UT.Kvasir.Translation {
             public bool ClothingRequired { get; set; }
             public bool IsWhiteSand { get; set; }
             public bool IsSurfSpot { get; set; }
+        }
+
+        // Test Scenario: [Numeric] + <Signedness> (✓former, evaluated against latter✓)
+        public class Soup {
+            public enum Kind { Standard = 14, Bisque = -2, Chowder = 177, Stew = 90 }
+            public enum YesNo { Yes = 1, No = -1, Maybe = 0 }
+            public enum Protein { Chicken = -8124, Beef = -4, Venison = -99, Rabbit = 185, Seafood = 26667 }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            [Numeric, Check.IsPositive] public Kind Variety { get; set; }
+            [Numeric, Check.IsNonZero] public YesNo HasNoodles { get; set; }
+            [Numeric, Check.IsNegative] public Protein BrothProtein { get; set; }
+            public uint CaloriesPerServing { get; set; }
+            public bool ServedHot { get; set; }
+        }
+
+        // Test Scenario: [Numeric] + <Comparisons> (✓former, evaluated against latter✓)
+        public class CavePainting {
+            public enum PaintMaterial { Chalk, Blood, NaturalDye, Graphite, GemDust, Etching }
+
+            [PrimaryKey] public string Cave { get; set; } = "";
+            [PrimaryKey] public uint CatalogNumber { get; set; }
+            [Check.IsGreaterThan(2), Check.IsLessOrEqualTo(4), Numeric] public PaintMaterial Material { get; set; }
+            public double Area { get; set; }
+            public DateTime Discovered { get; set; }
+            public ulong Age { get; set; }
+            public string Description { get; set; } = "";
+        }
+
+        // Test Scenario: [Numeric] + <Discreteness> (✓former, evaluated against latter✓)
+        public class Triangle {
+            [Flags] public enum Variety { Equilateral = 1, Right = 2, Isosceles = 4, Scalene = 8, RightIsosceles = Right | Isosceles, RightScalene = Right | Scalene }
+
+            [PrimaryKey] public Guid ID { get; set; }
+            public double X1 { get; set; }
+            public double Y1 { get; set; }
+            public double X2 { get; set; }
+            public double Y2 { get; set; }
+            public double X3 { get; set; }
+            public double Y3 { get; set; }
+            [Check.IsOneOf(0, 1, 2, 4, 8, 6, 10, 17, 186, 222), Numeric] public Variety Kind { get; set; }
+        }
+
+        // Test Scenario: [AsString] + <Comparisons> (✓former, evaluated against latter✓)
+        public class Casino {
+            public enum Game { Blackjack, Poker, Craps, Roulette, Slots, Baccarat, Pachinko, Bingo, SportsBetting }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            public string? Proprietor { get; set; }
+            public decimal CashOnHand { get; set; }
+            public double FloorArea { get; set; }
+            [Check.IsGreaterOrEqualTo("Cards"), Check.IsLessThan("Safety"), AsString] public Game TopMoneyMaker { get; set; }
+        }
+
+        // Test Scenario: [AsString] + <Lengths> (✓former, evaluated against latter✓)
+        public class FacebookPost {
+            public enum Viz { Public, Private, FriendsOnly, FriendsOfFriends, Subscribers }
+
+            [PrimaryKey] public Guid PostID { get; set; }
+            public ulong PosterID { get; set; }
+            public string Content { get; set; } = "";
+            public uint Likes { get; set; }
+            public uint Comments { get; set; }
+            [Check.LengthIsBetween(7, 15), AsString] public Viz Visibility { get; set; }
+        }
+
+        // Test Scenario: [AsString] + <Discreteness> (✓former, evaluated against latter✓)
+        public class ZodiacSign {
+            public enum Season : short { Winter, Spring, Summer, Autumn }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            [Check.IsNotOneOf("Winter", "Spring", "Fall", "Year-Round"), AsString] public Season SignSeason { get; set; }
+            public char ZodiacSymbol { get; set; }
+            public string HinduSolarEquivalent { get; set; } = "";
         }
     }
 }

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -27,6 +27,7 @@ Arthurian Knight
 Artiodactyl
 Astronaut
 Atmospheric Layer
+Atoll
 Attribute (C#)
 Auction Lot
 Avatar
@@ -40,6 +41,7 @@ Baryon
 Baseball Bat
 Baseball Card
 Basketball Player
+Batman Villain
 Battery
 Batting Order
 Battle
@@ -57,6 +59,7 @@ Biological Cycle
 Birth Control
 Blender
 Blood Type
+Bond Girl
 Bone
 Book
 Bookmark (web browsing)
@@ -85,8 +88,11 @@ Canyon
 Capacitor
 Carbohydrate
 Carousel
+Casino
 Cave
+Cave Painting
 Celtic God
+Cemetery
 Cenote
 Census
 Cereal
@@ -104,6 +110,7 @@ Cider Mill
 CinemaSins
 Circle
 Circle of Hell
+Civilization VI City State
 Civilization VI Military Unit
 Climate
 Clock Tower
@@ -119,6 +126,7 @@ Commercial
 Compiler Warning
 Concentration Camp
 Concert
+Concert Tour
 Constitutional Amendment
 Coral Reef
 Country
@@ -128,10 +136,12 @@ Court Case
 Credit Card
 Crossword Clue
 Cruise
+Cryptid
 Cryptocurrency
 Currency
 D&D Character
 D&D Spell
+D&D Weapon
 Dalai Lama
 Dam
 Data Structure
@@ -147,13 +157,15 @@ Doctor (Doctor Who)
 Documentary
 Domino
 Donut
-Dragon
 Draft Pick
+Dragon
 Dreidel
 Drum
 E-Mail
 Earthquake
+Ecumenical Council
 Elevator
+Emotion
 Encryption
 Encyclopedia
 Enumeration
@@ -162,6 +174,8 @@ ETF
 Eurovision Song Contest
 Excel Range
 Expiration
+Eyeglasses
+Facebook Post
 Fairy Tale
 Federal Law
 Field Goal
@@ -201,6 +215,7 @@ Guillotine
 Guitar
 Gymnast
 Haiku
+Hall of Fame
 Hash Function
 Headphones
 Healing Potion (D&D)
@@ -214,6 +229,7 @@ Hoedown (WLIIA)
 Hogwarts House
 Holiday
 Holy Roman Emperor
+Home Run Derby
 Homeric Hymn
 Hormone
 Hospital
@@ -225,6 +241,7 @@ HTML Element
 HTTP Error
 Hurricane
 Igloo
+Immaculate Grid
 Inator
 Inmate
 Insurance Policy
@@ -232,6 +249,7 @@ Integer
 Integer Sequence
 Integral
 IP Address
+IPO
 ISO Standard
 Isthmus
 Jedi
@@ -250,6 +268,7 @@ Lease
 Legume
 Lens
 License Plate
+Ligament
 Linux Distribution
 Lipstick
 Liquor
@@ -262,19 +281,23 @@ Lottery Ticket
 Lyric
 Magazine
 Marathon
+Marian Apparition
 Mark-Up Symbol
 Masked Singer
 Massacre
+MasterClass
 Mayor
 Medal of Honor
 Medical Specialty
 Meme
 Metra Route
+Mezuzah
 Military Base
 Milkshake
 Mint (currency)
 Monopoly Property
 Month
+Moon of Jupiter
 Mosque
 Mountain
 Movie
@@ -283,16 +306,18 @@ Multiple Choice Question
 Mummy
 Muppet
 Muscle
-Mushroom
 Museum
+Mushroom
 Musical
 Mutant (X-Men)
+Mythbusting
 National Anthem
 National Park
 Native American Tribe
 Nazca Line
 Nebula
 Neurotoxin
+Newspaper
 Nobel Prize
 Norse God
 Norse World
@@ -301,10 +326,13 @@ NuGet Package
 Obelisk
 Obi
 Oceanic Trench
+Oceanid
 Oil (cooking)
 Oil Spill
 Olympiad
 Opera
+Orisha
+Orphanage
 Painting
 Parashah
 Parking Garage
@@ -323,6 +351,7 @@ Phobia
 Phone Number
 Pie
 Pigment (biology)
+Pillow
 Ping
 Pirate
 Pizza
@@ -344,11 +373,13 @@ Presidential Election
 Printer
 Prison
 Process (computing)
+Programming Langauge
 Prophet
 Proto-Indo-European Root
 Pterosaur
 Pulley
 Quadratic Equation
+Quarterback
 Quatrain
 Racehorse
 Racetrack (auto racing)
@@ -364,11 +395,13 @@ Ring of Power
 River
 Rollercoaster
 Roman Emperor
+Rorschach Ink Blot
 Royal House
 Rube Goldberg Machine
 Rune
 Russian Tsar
 Saint
+Satellite
 Scholarship
 Scooby-Doo Movie
 Scrabble Tile
@@ -376,6 +409,7 @@ Screwdriver
 SCUBA Dive
 Sculpture
 Season
+Secret Hitler Game
 Senator
 Set Card
 Shard of Adonalsium
@@ -396,12 +430,14 @@ Snake
 SNL Episode
 Soccer Team
 Solar Eclipse
+Solicitor General
 Song
 Sonnet
 Sorority
+Soup
+Speed Limit
 Speedometer
 Sporcle Quiz
-Surfing Maneuver
 SQL Query
 Stadium
 Stamp
@@ -415,9 +451,11 @@ Sunscreen
 Super Bowl
 SuperPAC
 Surah
+Surfing Maneuver
 Survivor
 Swimming Pool
 Sword
+Symphony
 Talk Show
 Tar Pits
 Tarot Card
@@ -425,13 +463,14 @@ Tectonic Plate
 Telescope
 Tendon
 Tennis Match
-Therapist
 Terminator
+Therapist
 Thesis
 Tic-Tac-Toe Game
 Ticket2Ride Route
 Time Zone
 Timestamp
+Tooth
 Toothpaste
 Top 10 List
 Tossup Question
@@ -439,6 +478,8 @@ Tournament
 Transformer (robot)
 Transistor
 Treasury Bond
+Tree House
+Triangle
 Trilogy
 Tsunami
 Tuxedo
@@ -451,6 +492,7 @@ Upanishad
 URL
 UUID
 Vampire Slayer
+Vigenère Cipher
 Vitamin
 Voicemail
 Voir Dire
@@ -465,10 +507,12 @@ Wikipedia Page
 Wildfire
 Winter Storm
 Witch Hunt
+Word Search
 World Cup
 World Heritage Site
 Wristwatch
 xkcd Comic
 YouTube Video
 Yu-Gi-Oh Monster
+Zodiac Sign
 Zoo


### PR DESCRIPTION
This commit adds support for translation of enumeration-type Fields. For the most part, this translation is the same as translating a scalar: names, nullability, and default values are processed the same way. The biggest difference is that enumeration-type Fields have an implicitly restricted image that is not recognized as a constraint, but instead as a special property of the EnumField in the Schema Layer. The discreteness constraints can still be applied, but they operate on the restricted image. Other constraints, aside from IsNot, are inapplicable.

There are also two new annotations that are valid only on enumeration-type Fields: [IsString] and [Numeric]. These annotations direct the framework to use either the string or underlying numeric representation, respectively, as the native storage in the back-end database, even if that back-end database has support for enumerations directly. From a technical perspective, these are equivalent to a DataConverter annotation with a pre-defined converter type.