### PR TITLE
Translation of Reference Fields

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -6832,7 +6832,16 @@
             </returns>
         </member>
         <member name="M:Kvasir.Translation.Error.AmbiguousNullability(Kvasir.Translation.PropertyTranslationContext)">
-            [TODO]
+            <summary>
+              Create a <see cref="T:Kvasir.Exceptions.KvasirException"/> describing an ambiguous nullability deduction and/or specification.
+            </summary>
+            <param name = "ctxt" >
+              The <see cref="T:Kvasir.Translation.PropertyTranslationContext">context</see> in which it was identified that the nullability of one or more Fields
+              is ambiguous.This should generally be the context of the translation of the outer Aggregate or Reference.
+            </param>
+            <returns>
+              A <see cref="T:Kvasir.Exceptions.KvasirException"/> with a contextualized error message.
+            </returns>
         </member>
         <member name="M:Kvasir.Translation.Error.UserError(Kvasir.Translation.PropertyTranslationContext,System.Attribute,System.String)">
             <summary>

--- a/src/Kvasir/Translation/Descriptors.cs
+++ b/src/Kvasir/Translation/Descriptors.cs
@@ -3,7 +3,9 @@
 using Cybele.Core;
 using Kvasir.Schema;
 using Optional;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 // Descriptors are the intermediate stages of Translation. The purpose of Descriptors is to reflect the information
 // known up to a point, with the expectation being that future logic may update or extend the initial translation. The
@@ -36,6 +38,7 @@ namespace Kvasir.Translation {
         Option<object?> Default,
         bool InPrimaryKey,
         IReadOnlySet<string> CandidateKeyMemberships,
+        Option<Type> ForeignReference,
         ConstraintBucket Constraints
     );
 

--- a/src/Kvasir/Translation/Exceptions.cs
+++ b/src/Kvasir/Translation/Exceptions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-
 using Ctxt = Kvasir.Translation.PropertyTranslationContext;
 
 namespace Kvasir.Translation {
@@ -347,7 +346,16 @@ namespace Kvasir.Translation {
             return MakeError(ctxt, annotations, msg);
         }
 
-        /// [TODO]
+        /// <summary>
+        ///   Create a <see cref="KvasirException"/> describing an ambiguous nullability deduction and/or specification.
+        /// </summary>
+        /// <param name = "ctxt" >
+        ///   The <see cref="Ctxt">context</see> in which it was identified that the nullability of one or more Fields
+        ///   is ambiguous.This should generally be the context of the translation of the outer Aggregate or Reference.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="KvasirException"/> with a contextualized error message.
+        /// </returns>
         public static KvasirException AmbiguousNullability(Ctxt ctxt) {
             Debug.Assert(ctxt.Property is not null);
             Debug.Assert(ctxt.Path == "");

--- a/src/Kvasir/Translation/TranslateProperty.cs
+++ b/src/Kvasir/Translation/TranslateProperty.cs
@@ -5,7 +5,6 @@ using Kvasir.Schema;
 using Optional;
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 
 namespace Kvasir.Translation {
@@ -59,8 +58,9 @@ namespace Kvasir.Translation {
                     PropertyCategory.Scalar => ApplyAnnotations(property, ScalarBaseTranslation(property)),
                     PropertyCategory.Enumeration => ApplyAnnotations(property, EnumBaseTranslation(property)),
                     PropertyCategory.Aggregate => ApplyAnnotations(property, AggregateBaseTranslation(property)),
-                    PropertyCategory.Reference => throw new NotSupportedException("reference properties not yet supported"),
+                    PropertyCategory.Reference => ApplyAnnotations(property, ReferenceBaseTranslation(property)),
                     PropertyCategory.Relation => throw new NotSupportedException("relation properties not yet supported"),
+
                     _ => throw new ApplicationException("switch statement exhausted")
                 }
             );

--- a/src/Kvasir/Translation/Translator.cs
+++ b/src/Kvasir/Translation/Translator.cs
@@ -52,16 +52,20 @@ namespace Kvasir.Translation {
 
             settings_ = settings;
             sourceAssembly_ = Assembly.GetCallingAssembly();
+            inProgress_ = new Stack<Type>();
             typeCache_ = new Dictionary<Type, TypeDescriptor>();
             entityCache_ = new Dictionary<Type, Translation>();
+            primaryKeyCache_ = new Dictionary<Type, FieldsListing>();
             tableNames_ = new HashSet<TableName>();
         }
 
 
         private readonly Settings settings_;
         private readonly Assembly sourceAssembly_;
+        private readonly Stack<Type> inProgress_;
         private readonly Dictionary<Type, TypeDescriptor> typeCache_;
         private readonly Dictionary<Type, Translation> entityCache_;
+        private readonly Dictionary<Type, FieldsListing> primaryKeyCache_;
         private readonly HashSet<TableName> tableNames_;
         private const char NAME_SEPARATOR = '.';
         private const char PATH_SEPARATOR = '.';

--- a/test/UnitTests/Kvasir/Translation/ColumnOrdering.cs
+++ b/test/UnitTests/Kvasir/Translation/ColumnOrdering.cs
@@ -68,6 +68,48 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherFields();
         }
 
+        [TestMethod] public void ReferenceFieldsOrdered() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(EdibleArrangement);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(EdibleArrangement.ID)).AtColumn(3).And
+                .HaveField(nameof(EdibleArrangement.Price)).AtColumn(8).And
+                .HaveField(nameof(EdibleArrangement.Strawberries)).AtColumn(9).And
+                .HaveField(nameof(EdibleArrangement.Bananas)).AtColumn(0).And
+                .HaveField(nameof(EdibleArrangement.Grapes)).AtColumn(2).And
+                .HaveField(nameof(EdibleArrangement.Cantaloupe)).AtColumn(1).And
+                .HaveField(nameof(EdibleArrangement.OtherFruit)).AtColumn(4).And
+                .HaveField("Vessel.FactoryID").AtColumn(6).And
+                .HaveField("Vessel.Brand").AtColumn(7).And
+                .HaveField("Vessel.Item").AtColumn(5).And
+                .HaveNoOtherFields();
+        }
+
+        [TestMethod] public void ReferencePrimaryKeysAreNonSequential() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(MassExtinction);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(MassExtinction.Index)).AtColumn(4).And
+                .HaveField("ExitBoundary.Name").AtColumn(2).And
+                .HaveField("ExitBoundary.MYA").AtColumn(3).And
+                .HaveField("EntryBoundary.Name").AtColumn(0).And
+                .HaveField("EntryBoundary.MYA").AtColumn(1).And
+                .HaveField(nameof(MassExtinction.Severity)).AtColumn(5).And
+                .HaveNoOtherFields();
+        }
+
         [TestMethod] public void TwoScalarFieldsOrderedToSameIndex_IsError() {
             // Arrange
             var translator = new Translator();
@@ -136,6 +178,22 @@ namespace UT.Kvasir.Translation {
             // Arrange
             var translator = new Translator();
             var source = typeof(Verb);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining("unable to assign Fields to columns")        // category
+                .WithMessageContaining("gaps");                                     // details / explanation
+        }
+
+        [TestMethod] public void ColumnOrderingOfReferencesLeavesGaps_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Origami);
 
             // Act
             var translate = () => translator[source];

--- a/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
@@ -131,7 +131,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Orisha.Culture));                     // details / explanation
         }
 
-        [TestMethod] public void IsGreaterThan_NestedApplicableScalar() {
+        [TestMethod] public void IsGreaterThan_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Opioid);
@@ -146,7 +146,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsGreaterThan_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void IsGreaterThan_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Wordle);
@@ -180,6 +180,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsGreaterThan]")                     // details / explanation
                 .WithMessageContaining("\"Leader\"");                               // details / explanation
+        }
+
+        [TestMethod] public void IsGreaterThan_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Apostle);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Adherence.Identifier", ComparisonOperator.GT, "Atheism").And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsGreaterThan_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Influenza);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Influenza.DeadliestOutbreak))         // error location
+                .WithMessageContaining("\"OutbreakID\"")                            // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsGreaterThan]")                     // details / explanation
+                .WithMessageContaining("totally ordered")                           // details / explanation
+                .WithMessageContaining(nameof(Influenza.Outbreak));                 // details / explanation
+        }
+
+        [TestMethod] public void IsGreaterThan_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BloodDrive);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(BloodDrive.SponsoredBy))              // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsGreaterThan]")                     // details / explanation
+                .WithMessageContaining("\"Hospital\"");                             // details / explanation
         }
 
         [TestMethod] public void IsGreaterThan_NullableTotallyOrderedFields() {
@@ -495,6 +545,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsGreaterThan]");                    // details / explanation
         }
 
+        [TestMethod] public void IsGreaterThan_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(InstallationWizard);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(InstallationWizard.Program))          // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsGreaterThan]")                     // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsGreaterThan_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BugSpray);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(BugSpray.ActiveIngredient))           // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsGreaterThan]")                     // details / explanation
+                .WithMessageContaining("\"LethalDose\"");                           // details / explanation
+        }
+
+        [TestMethod] public void IsGreaterThan_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Intern);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Intern.Manager))                      // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsGreaterThan]");                    // details / explanation
+        }
+
         [TestMethod] public void IsGreaterThan_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator();
@@ -629,7 +729,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(SolicitorGeneral.PoliticalParty));    // details / explanation
         }
 
-        [TestMethod] public void IsLessThan_NestedApplicableScalar() {
+        [TestMethod] public void IsLessThan_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Raptor);
@@ -646,7 +746,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsLessThan_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void IsLessThan_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Feruchemy);
@@ -680,6 +780,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsLessThan]")                        // details / explanation
                 .WithMessageContaining("\"ServiceArea\"");                          // details / explanation
+        }
+
+        [TestMethod] public void IsLessThan_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Butterfly);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Genus.Name", ComparisonOperator.LT, "Zojemana").And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsLessThan_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Cartel);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Cartel.Control))                      // error location
+                .WithMessageContaining("\"Kind\"")                                  // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsLessThan]")                        // details / explanation
+                .WithMessageContaining("totally ordered")                           // details / explanation
+                .WithMessageContaining(nameof(Cartel.CommodityType));               // details / explanation
+        }
+
+        [TestMethod] public void IsLessThan_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Hallucination);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Hallucination.Reason))                // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsLessThan]")                        // details / explanation
+                .WithMessageContaining("\"Drug\"");                                 // details / explanation
         }
 
         [TestMethod] public void IsLessThan_NullableTotallyOrderedFields() {
@@ -995,6 +1145,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsLessThan]");                       // details / explanation
         }
 
+        [TestMethod] public void IsLessThan_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(NationalMonument);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(NationalMonument.EstablishedBy))      // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsLessThan]")                        // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsLessThan_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(YogaPosition);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(YogaPosition.SanskritName))           // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsLessThan]")                        // details / explanation
+                .WithMessageContaining("\"Sanskrit\"");                             // details / explanation
+        }
+
+        [TestMethod] public void IsLessThan_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PubCrawl);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(PubCrawl.FirstPub))                   // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsLessThan]");                       // details / explanation
+        }
+
         [TestMethod] public void IsLessThan_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator();
@@ -1129,7 +1329,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(CivCityState.Category));              // details / explanation
         }
 
-        [TestMethod] public void IsGreaterOrEqualTo_NestedApplicableScalar() {
+        [TestMethod] public void IsGreaterOrEqualTo_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(FamilyTree);
@@ -1144,7 +1344,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsGreaterOrEqualTo_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void IsGreaterOrEqualTo_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Readymade);
@@ -1178,6 +1378,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsGreaterOrEqualTo]")                // details / explanation
                 .WithMessageContaining("\"Street\"");                               // details / explanation
+        }
+
+        [TestMethod] public void IsGreaterOrEqualTo_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(CandyBar);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Plant.Name", ComparisonOperator.GTE, "Kraft-Heinz 87").And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsGreaterOrEqualTo_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SlumberParty);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(SlumberParty.Place))                  // error location
+                .WithMessageContaining("\"StreetSuffix\"")                          // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsGreaterOrEqualTo]")                // details / explanation
+                .WithMessageContaining("totally ordered")                           // details / explanation
+                .WithMessageContaining(nameof(SlumberParty.RoadType));              // details / explanation
+        }
+
+        [TestMethod] public void IsGreaterOrEqualTo_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Barbie);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Barbie.Relationships))                // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsGreaterOrEqualTo]")                // details / explanation
+                .WithMessageContaining("\"Boyfriend.Ken\"");                        // details / explanation
         }
 
         [TestMethod] public void IsGreaterOrEqualTo_NullableTotallyOrderedFields() {
@@ -1488,6 +1738,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsGreaterOrEqualTo]");               // details / explanation
         }
 
+        [TestMethod] public void IsGreaterOrEqualTo_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Druid);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Druid.WildShape2))                    // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsGreaterOrEqualTo]")                // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsGreaterOrEqualTo_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Mirror);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Mirror.MirrorShape))                  // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsGreaterOrEqualTo]")                // details / explanation
+                .WithMessageContaining("\"Sides\"");                                // details / explanation
+        }
+
+        [TestMethod] public void IsGreaterOrEqualTo_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Chromosome);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Chromosome.FirstIsolatedGene))        // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsGreaterOrEqualTo]");               // details / explanation
+        }
+
         [TestMethod] public void IsGreaterOrEqualTo_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator();
@@ -1623,7 +1923,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(ConcertTour.Type));                   // details / explanation
         }
 
-        [TestMethod] public void IsLessOrEqualTo_NestedApplicableScalar() {
+        [TestMethod] public void IsLessOrEqualTo_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Hominin);
@@ -1637,7 +1937,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsLessOrEqualTo_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void IsLessOrEqualTo_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(AmazonService);
@@ -1671,6 +1971,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsLessOrEqualTo]")                   // details / explanation
                 .WithMessageContaining("\"Ages\"");                                 // details / explanation
+        }
+
+        [TestMethod] public void IsLessOrEqualTo_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Gatorade);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("BottledAt.Operational", ComparisonOperator.LTE, new DateTime(2566, 11, 15)).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsLessOrEqualTo_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Knife);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Knife.Categorization))                // error location
+                .WithMessageContaining("\"Which\"")                                 // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsLessOrEqualTo]")                   // details / explanation
+                .WithMessageContaining("totally ordered")                           // details / explanation
+                .WithMessageContaining(nameof(Knife.Category));                     // details / explanation
+        }
+
+        [TestMethod] public void IsLessOrEqualTo_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Ransomware);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Ransomware.Extortion))                // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsLessOrEqualTo]")                   // details / explanation
+                .WithMessageContaining("\"Ransom\"");                               // details / explanation
         }
 
         [TestMethod] public void IsLessOrEqualTo_NullableTotallyOrderedFields() {
@@ -1981,6 +2331,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsLessOrEqualTo]");                  // details / explanation
         }
 
+        [TestMethod] public void IsLessOrEqualTo_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(FoodPantry);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(FoodPantry.WhichState))               // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsLessOrEqualTo]")                   // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsLessOrEqualTo_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(FittedSheet);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(FittedSheet.Dimensions))              // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsLessOrEqualTo]")                   // details / explanation
+                .WithMessageContaining("\"ThreadCount\"");                          // details / explanation
+        }
+
+        [TestMethod] public void IsLessOrEqualTo_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Playlist);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Playlist.MostPlayed))                 // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsLessOrEqualTo]");                  // details / explanation
+        }
+
         [TestMethod] public void IsLessOrEqualTo_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator();
@@ -2117,7 +2517,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsNot_NestedScalar() {
+        [TestMethod] public void IsNot_AggregateNestedScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(SeventhInningStretch);
@@ -2147,6 +2547,41 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsNot]")                             // details / explanation
                 .WithMessageContaining("\"OneDollarPayout\"");                      // details / explanation
+        }
+
+        [TestMethod] public void IsNot_ReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(StanleyCup);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Champion.Abbreviation", ComparisonOperator.NE, "NBC").And
+                .HaveNoOtherConstraints().And
+                .HaveField("RunnerUp.Conference").OfTypeEnumeration(
+                    StanleyCup.Conf.Eastern,
+                    StanleyCup.Conf.Western
+                );
+        }
+
+        [TestMethod] public void IsNot_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(FishingRod);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(FishingRod.ManfucaturingInfo))        // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsNot]")                             // details / explanation
+                .WithMessageContaining("\"Manufacturer\"");                         // details / explanation
         }
 
         [TestMethod] public void IsNot_NullableTotallyOrderedFields() {
@@ -2457,6 +2892,56 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(Balk.Pitcher))                        // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsNot]");                            // details / explanation
+        }
+
+        [TestMethod] public void IsNot_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Planetarium);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Planetarium.Architect))               // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsNot]")                             // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsNot_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(LiquorStore);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(LiquorStore.BestSellingWine))         // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsNot]")                             // details / explanation
+                .WithMessageContaining("\"Vineyard\"");                             // details / explanation
+        }
+
+        [TestMethod] public void IsNot_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Waterbending);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Waterbending.StrongestPractitioner))  // error location
                 .WithMessageContaining("path is required")                          // category
                 .WithMessageContaining("[Check.IsNot]");                            // details / explanation
         }

--- a/test/UnitTests/Kvasir/Translation/DataConverters.cs
+++ b/test/UnitTests/Kvasir/Translation/DataConverters.cs
@@ -163,6 +163,23 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("neither a scalar nor an enumeration");      // details / explanation
         }
 
+        [TestMethod] public void ConverterOnReferenceField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Decathlon);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Decathlon.Winner))                    // error location
+                .WithMessageContaining("[DataConverter]")                           // details / explanation
+                .WithMessageContaining(nameof(Decathlon.Athlete))                   // details / explanation
+                .WithMessageContaining("neither a scalar nor an enumeration");      // details / explanation
+        }
+
         [TestMethod] public void ConverterOnNullablePropertyHasNonNullableTargetType() {
             // Arrange
             var translator = new Translator();
@@ -424,6 +441,23 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("enumeration");                              // details / explanation
         }
 
+        [TestMethod] public void NumericConverterOnReferenceField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SlamBallMatch);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(SlamBallMatch.Defeated))              // error location
+                .WithMessageContaining("[Numeric]")                                 // details / explanation
+                .WithMessageContaining(nameof(SlamBallMatch.SlamBallTeam))          // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
         [TestMethod] public void AsStringConverterOnBooleanField_IsError() {
             // Arrange
             var translator = new Translator();
@@ -523,6 +557,23 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Windmill.EnergyGenerated))            // error location
                 .WithMessageContaining("[AsString]")                                // details / explanation
                 .WithMessageContaining(nameof(Windmill.EnergyOutput))               // details / explanation
+                .WithMessageContaining("enumeration");                              // details / explanation
+        }
+
+        [TestMethod] public void AsStringConverterOnReferenceField_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Chakra);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Chakra.AssociatedYogini))             // error location
+                .WithMessageContaining("[AsString]")                                // details / explanation
+                .WithMessageContaining(nameof(Chakra.Yogini))                       // details / explanation
                 .WithMessageContaining("enumeration");                              // details / explanation
         }
 

--- a/test/UnitTests/Kvasir/Translation/DiscretenessConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/DiscretenessConstraints.cs
@@ -135,7 +135,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsOneOf_NestedScalarField() {
+        [TestMethod] public void IsOneOf_AggregateNestedScalarField() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Earring);
@@ -166,6 +166,39 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                                // category
                 .WithMessageContaining("[Check.IsOneOf]")                                       // details / explanation
                 .WithMessageContaining("\"ABCDEFGHIJK.GHIJK\"");                                // details / explanation
+        }
+
+        [TestMethod] public void IsOneOf_ReferenceNestedScalarField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(FerrisWheel);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Designer.FirstName", InclusionOperator.In,
+                    "Alexander", "Randall", "Corrine"
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsOneOf_NestedReferenceProperty_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Pulsar);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                  // source type
+                .WithMessageContaining(nameof(Pulsar.OBS))                          // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsOneOf]")                           // details / explanation
+                .WithMessageContaining("\"Observatory\"");                          // details / explanation
         }
 
         [TestMethod] public void IsOneOf_NullableFields() {
@@ -564,6 +597,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsOneOf]");                          // details / explanation
         }
 
+        [TestMethod] public void IsOneOf_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Safari);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Safari.Elephants))                    // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsOneOf]")                           // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsOneOf_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Adverb);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Adverb.WordSuffix))                   // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsOneOf]")                           // details / explanation
+                .WithMessageContaining("\"PartOfSpeech\"");                         // details / explanation
+        }
+
+        [TestMethod] public void IsOneOf_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Swamp);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Swamp.PredominantTree))               // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsOneOf]");                          // details / explanation
+        }
+
         [TestMethod] public void IsOneOf_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator();
@@ -709,7 +792,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsNotOneOf_NestedScalarField() {
+        [TestMethod] public void IsNotOneOf_AggregateNestedScalarField() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Condiment);
@@ -740,6 +823,39 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsNotOneOf]")                        // details / explanation
                 .WithMessageContaining("\"Color\"");                                // details / explanation
+        }
+
+        [TestMethod] public void IsNotOneOf_ReferenceNestedScalarField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Lifeguard);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("FirstJob.PoolNumber", InclusionOperator.NotIn,
+                    7U, 17U, 27U, 37U
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNotOneOf_NestedReferenceProperty_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(NurseyRhyme);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(NurseyRhyme.MainCharacter))           // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsNotOneOf]")                        // details / explanation
+                .WithMessageContaining("\"Character\"");                            // details / explanation
         }
 
         [TestMethod] public void IsNotOneOf_NullableFields() {
@@ -1143,6 +1259,56 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(Scattergories.Round))                 // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsNotOneOf]");                       // details / explanation
+        }
+
+        [TestMethod] public void IsNotOneOf_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Pencil);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Pencil.Lead))                         // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsNotOneOf]")                        // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsNotOneOf_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Mitzvah);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Mitzvah.Commandment))                 // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsNotOneOf]")                        // details / explanation
+                .WithMessageContaining("\"Hebrew\"");                               // details / explanation
+        }
+
+        [TestMethod] public void IsNotOneOf_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Eunuch);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Eunuch.Castrator))                    // error location
                 .WithMessageContaining("path is required")                          // category
                 .WithMessageContaining("[Check.IsNotOneOf]");                       // details / explanation
         }

--- a/test/UnitTests/Kvasir/Translation/Nullability.cs
+++ b/test/UnitTests/Kvasir/Translation/Nullability.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Kvasir.Exceptions;
+using Kvasir.Schema;
 using Kvasir.Translation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -48,6 +49,30 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherFields();
         }
 
+        [TestMethod] public void NonNullableReferenceMarkedNullable() {
+            // Arrange
+            var source = typeof(Jukebox);
+            var translator = new Translator();
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(Jukebox.ProductID)).OfTypeGuid().BeingNonNullable().And
+                .HaveField(nameof(Jukebox.NumSongs)).OfTypeUInt16().BeingNonNullable().And
+                .HaveField("MostPlayed.Title").OfTypeText().BeingNullable().And
+                .HaveField("MostPlayed.Singer").OfTypeText().BeingNullable().And
+                .HaveField(nameof(Jukebox.CostPerPlay)).OfTypeDecimal().BeingNonNullable().And
+                .HaveField(nameof(Jukebox.IsDigital)).OfTypeBoolean().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveForeignKey("MostPlayed.Singer", "MostPlayed.Title")
+                    .Against(translator[typeof(Jukebox.Song)].Principal.Table)
+                    .WithOnDeleteBehavior(OnDelete.Cascade)
+                    .WithOnUpdateBehavior(OnUpdate.Cascade).And
+                .HaveNoOtherForeignKeys();
+        }
+
         [TestMethod] public void NullableScalarsMarkedNonNullable() {
             // Arrange
             var translator = new Translator();
@@ -91,6 +116,33 @@ namespace UT.Kvasir.Translation {
                 .HaveField("Composition.Brass.Trombones").OfTypeUInt32().BeingNullable().And
                 .HaveField("Composition.Brass.Tubas").OfTypeUInt32().BeingNullable().And
                 .HaveNoOtherFields();
+        }
+
+        [TestMethod] public void NullableReferenceMarkedNonNullable() {
+            // Arrange
+            var source = typeof(Bodhisattva);
+            var translator = new Translator();
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(Bodhisattva.Name)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(Bodhisattva.Buddhism)).OfTypeEnumeration(
+                    Bodhisattva.Denomination.Nikaya,
+                    Bodhisattva.Denomination.Theravada,
+                    Bodhisattva.Denomination.Mahayana
+                ).BeingNonNullable().And
+                .HaveField("LastBhumi.English").OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(Bodhisattva.DateOfBirth)).OfTypeDateTime().BeingNonNullable().And
+                .HaveField(nameof(Bodhisattva.DateOfDeath)).OfTypeDateTime().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveForeignKey("LastBhumi.English")
+                    .Against(translator[typeof(Bodhisattva.Bhumi)].Principal.Table)
+                    .WithOnDeleteBehavior(OnDelete.Cascade)
+                    .WithOnUpdateBehavior(OnUpdate.Cascade).And
+                .HaveNoOtherForeignKeys();
         }
 
         [TestMethod] public void NullableScalarsMarkedAsNullable_Redundant() {

--- a/test/UnitTests/Kvasir/Translation/PrimaryKeys.cs
+++ b/test/UnitTests/Kvasir/Translation/PrimaryKeys.cs
@@ -56,7 +56,7 @@ namespace UT.Kvasir.Translation {
                 );
         }
 
-        [TestMethod] public void NestedScalarMarkedPrimaryKey() {
+        [TestMethod] public void AggregateNestedScalarMarkedPrimaryKey() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Tepui);
@@ -93,6 +93,53 @@ namespace UT.Kvasir.Translation {
                     "Ingredient3.Name.Alternative",
                     "Ingredient4.Name.English",
                     "Ingredient4.Name.Alternative"
+                );
+        }
+
+        [TestMethod] public void ReferenceMarkedPrimaryKey() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Etiology);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HavePrimaryKey().OfFields(
+                    "Source.Name",
+                    "Source.Abbreviation"
+                );
+        }
+
+        [TestMethod] public void ReferenceNestedScalarMarkedPrimaryKey() {
+            // Arrange
+            var tranlator = new Translator();
+            var source = typeof(PoirotMystery);
+
+            // Act
+            var translation = tranlator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HavePrimaryKey().OfFields("ISBN.ValuePart1");
+        }
+
+        [TestMethod] public void NestedReferenceMarkedPrimaryKey() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Prophecy);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HavePrimaryKey().OfFields(
+                    nameof(Prophecy.ProphecyID),
+                    "Subjects.P1.FirstName",
+                    "Subjects.P1.MiddleInitial",
+                    "Subjects.P1.LastName"
                 );
         }
 
@@ -453,6 +500,57 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("path*does not exist")                       // category
                 .WithMessageContaining("[PrimaryKey]")                              // details / explanation
                 .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PhoneBooth);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(PhoneBooth.Manufacturer))             // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[PrimaryKey]")                              // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ScientificExperiment);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(ScientificExperiment.ControlGroup))   // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[PrimaryKey]")                              // details / explanation
+                .WithMessageContaining("\"Animate\"");                              // details / explanation
+        }
+
+        [TestMethod] public void PathOnReferenceRefersToPartiallyExposedAggregate_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Cryochamber);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Cryochamber.MinTemperature))          // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[PrimaryKey]")                              // details / explanation
+                .WithMessageContaining("\"Temp\"");                                 // details / explanation
         }
     }
 

--- a/test/UnitTests/Kvasir/Translation/ReferenceCycles.cs
+++ b/test/UnitTests/Kvasir/Translation/ReferenceCycles.cs
@@ -1,0 +1,56 @@
+﻿using FluentAssertions;
+using Kvasir.Exceptions;
+using Kvasir.Translation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using static UT.Kvasir.Translation.ReferenceCycles;
+
+namespace UT.Kvasir.Translation {
+    [TestClass, TestCategory("ReferenceCycles")]
+    public class ReferenceCycleTests {
+        [TestMethod] public void SelfReferentialEntity_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Constitution);
+
+            // Act
+            var translate = () => translator[source];
+            var cycle = "Constitution → Constitution";
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining("reference cycle detected")                  // category
+                .WithMessageContaining(cycle);                                      // details / explanation
+        }
+
+        [TestMethod] public void EntityReferenceChainLength2_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Niqqud);
+
+            // Act
+            var translate = () => translator[source];
+            var cycle = "Niqqud → Vowel → Niqqud";
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining("reference cycle detected")                  // category
+                .WithMessageContaining(cycle);                                      // details / explanation
+        }
+
+        [TestMethod] public void EntityReferenceCycleLength3OrMore_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(RefugeeCamp);
+
+            // Act
+            var translate = () => translator[source];
+            var cycle = "RefugeeCamp → Person → Country → CivilWar → RefugeeCamp";
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining("reference cycle detected")                  // category
+                .WithMessageContaining(cycle);                                      // details / explanation
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/SignednessConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/SignednessConstraints.cs
@@ -134,7 +134,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Mythbusting.Resolution));             // details / explanation
         }
 
-        [TestMethod] public void IsPositive_NestedApplicableScalar() {
+        [TestMethod] public void IsPositive_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(IceAge);
@@ -149,7 +149,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsPositive_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void IsPositive_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(GoldenRaspberry);
@@ -183,6 +183,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsPositive]")                        // details / explanation
                 .WithMessageContaining("\"Bottom\"");                               // details / explanation
+        }
+
+        [TestMethod] public void IsPositive_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Runway);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Host.ID", ComparisonOperator.GT, 0U).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsPositive_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(CaesareanSection);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(CaesareanSection.Doctor ))            // error location
+                .WithMessageContaining("\"LastName\"")                              // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsPositive]")                        // details / explanation
+                .WithMessageContaining("numeric")                                   // details / explanation
+                .WithMessageContaining(nameof(String));                             // details / explanation
+        }
+
+        [TestMethod] public void IsPositive_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Lamp);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Lamp.Power))                          // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsPositive]")                        // details / explanation
+                .WithMessageContaining("\"Unit\"");                                 // details / explanation
         }
 
         [TestMethod] public void IsPositive_FieldWithNumericDataConversionTarget() {
@@ -293,6 +343,56 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(Philosopher.Name))                    // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsPositive]");                       // details / explanation
+        }
+
+        [TestMethod] public void IsPositive_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(HappyHour);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(HappyHour.Location))                  // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsPositive]")                        // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsPositive_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Aquifer);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Aquifer.DiscoveringGeologist))        // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsPositive]")                        // details / explanation
+                .WithMessageContaining("\"Qualifications\"");                       // details / explanation
+        }
+
+        [TestMethod] public void IsPositive_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(FactCheck);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(FactCheck.Fact))                      // error location
                 .WithMessageContaining("path is required")                          // category
                 .WithMessageContaining("[Check.IsPositive]");                       // details / explanation
         }
@@ -457,7 +557,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(SerialKiller.Status));                // details / explanation
         }
 
-        [TestMethod] public void IsNegative_NestedApplicableScalar() {
+        [TestMethod] public void IsNegative_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Flood);
@@ -471,7 +571,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsNegative_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void IsNegative_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(TrolleyProblem);
@@ -505,6 +605,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsNegative]")                        // details / explanation
                 .WithMessageContaining("\"Kingdom\"");                              // details / explanation
+        }
+
+        [TestMethod] public void IsNegative_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(HawaiianGod);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("MaoriEquivalent.DeityID", ComparisonOperator.LT, (short)0).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNegative_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(OceanCurrent);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(OceanCurrent.WhichOcean))             // error location
+                .WithMessageContaining("\"Name\"")                                  // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsNegative]")                        // details / explanation
+                .WithMessageContaining("numeric")                                   // details / explanation
+                .WithMessageContaining(nameof(String));                             // details / explanation
+        }
+
+        [TestMethod] public void IsNegative_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(AirBNB);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(AirBNB.HouseAddress))                 // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsNegative]")                        // details / explanation
+                .WithMessageContaining("\"State\"");                                // details / explanation
         }
 
         [TestMethod] public void IsNegative_FieldWithNumericDataConversionTarget() {
@@ -615,6 +765,56 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(Yacht.Sails))                         // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsNegative]");                       // details / explanation
+        }
+
+        [TestMethod] public void IsNegative_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Pharmacy);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Pharmacy.HeadPharmacist))             // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsNegative]")                        // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsNegative_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Popcorn);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Popcorn.Topping))                     // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsNegative]")                        // details / explanation
+                .WithMessageContaining("\"Calories\"");                             // details / explanation
+        }
+
+        [TestMethod] public void IsNegative_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(WinForm);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(WinForm.SubmitButton))                // error location
                 .WithMessageContaining("path is required")                          // category
                 .WithMessageContaining("[Check.IsNegative]");                       // details / explanation
         }
@@ -762,7 +962,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(IPO.Method));                         // details / explanation
         }
 
-        [TestMethod] public void IsNonZero_NestedApplicableScalar() {
+        [TestMethod] public void IsNonZero_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Essay);
@@ -780,7 +980,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsNonZero_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void IsNonZero_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(IDE);
@@ -814,6 +1014,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsNonZero]")                         // details / explanation
                 .WithMessageContaining("\"Name\"");                                 // details / explanation
+        }
+
+        [TestMethod] public void IsNonZero_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(EgyptianPyramid);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Entombed.RegnalNumber", ComparisonOperator.NE, (byte)0).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNonZero_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Pajamas);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Pajamas.Retailer))                    // error location
+                .WithMessageContaining("\"ID\"")                                    // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsNonZero]")                         // details / explanation
+                .WithMessageContaining("numeric")                                   // details / explanation
+                .WithMessageContaining(nameof(Guid));                               // details / explanation
+        }
+
+        [TestMethod] public void IsNonZero_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Galaxy);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Galaxy.Discovery))                    // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsNonZero]")                         // details / explanation
+                .WithMessageContaining("\"Astronomer\"");                           // details / explanation
         }
 
         [TestMethod] public void IsNonZero_FieldWithNumericDataConversionTarget() {
@@ -924,6 +1174,56 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(Smoothie.Base))                       // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsNonZero]");                        // details / explanation
+        }
+
+        [TestMethod] public void IsNonZero_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Antibiotic);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Antibiotic.Formula))                  // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsNonZero]")                         // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsNonZero_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Chopsticks);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Chopsticks.Chopstick2))               // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsNonZero]")                         // details / explanation
+                .WithMessageContaining("\"Weight\"");                               // details / explanation
+        }
+
+        [TestMethod] public void IsNonZero_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(TongueTwister);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(TongueTwister.Word11))                // error location
                 .WithMessageContaining("path is required")                          // category
                 .WithMessageContaining("[Check.IsNonZero]");                        // details / explanation
         }

--- a/test/UnitTests/Kvasir/Translation/StringLengthConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/StringLengthConstraints.cs
@@ -150,7 +150,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Mustache.Kind));                      // details / explanation
         }
 
-        [TestMethod] public void IsNonEmpty_NestedApplicableScalar() {
+        [TestMethod] public void IsNonEmpty_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(BarGraph);
@@ -165,7 +165,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void IsNonError_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void IsNonError_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(BackyardBaseballPlayer);
@@ -199,6 +199,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsNonEmpty]")                        // details / explanation
                 .WithMessageContaining("\"Place.Coordinate\"");                     // details / explanation
+        }
+
+        [TestMethod] public void IsNonEmpty_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(VacuumCleaner);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "Manufacturer.Name", ComparisonOperator.GTE, 1).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNonEmpty_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Limerick);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Limerick.Author))                     // error location
+                .WithMessageContaining("\"SSN\"")                                   // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.IsNonEmpty")                         // details / explanation
+                .WithMessageContaining(nameof(String))                              // details / explanation
+                .WithMessageContaining(nameof(UInt32));                             // details / explanation
+        }
+
+        [TestMethod] public void IsNonEmpty_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(RomanBaths);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(RomanBaths.Rooms))                    // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.IsNonEmpty]")                        // details / explanation
+                .WithMessageContaining("\"Caldarium\"");                            // details / explanation
         }
 
         [TestMethod] public void IsNonEmpty_FieldWithStringDataConversionTarget() {
@@ -309,6 +359,56 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(Kaiju.Size))                          // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.IsNonEmpty]");                       // details / explanation
+        }
+
+        [TestMethod] public void IsNonEmpty_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Peerage);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Peerage.PeerageTitle))                // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsNonEmpty]")                        // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void IsNonEmpty_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BountyHunter);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(BountyHunter.Credentials))            // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.IsNonEmpty]")                        // details / explanation
+                .WithMessageContaining("\"IssuingAgency\"");                        // details / explanation
+        }
+
+        [TestMethod] public void IsNonEmpty_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Linker);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Linker.TargetLanguage))               // error location
                 .WithMessageContaining("path is required")                          // category
                 .WithMessageContaining("[Check.IsNonEmpty]");                       // details / explanation
         }
@@ -471,7 +571,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Cybersite.Season));                   // details / explanation
         }
 
-        [TestMethod] public void LengthIsAtLeast_NestedApplicableScalar() {
+        [TestMethod] public void LengthIsAtLeast_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Dubbing);
@@ -486,7 +586,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void LengthIsAtLeast_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void LengthIsAtLeast_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(BaseballMogul);
@@ -520,6 +620,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.LengthIsAtLeast]")                   // details / explanation
                 .WithMessageContaining("\"Zeroth\"");                               // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtLeast_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(TEDTalk);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "Speaker.LastName", ComparisonOperator.GTE, 14).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void LengthIsAtLeast_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Arrondissement);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Arrondissement.Department))           // error location
+                .WithMessageContaining("\"Population\"")                            // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.LengthIsAtLeast]")                   // details / explanation
+                .WithMessageContaining(nameof(String))                              // details / explanation
+                .WithMessageContaining(nameof(UInt64));                             // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtLeast_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Constellation);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Constellation.MainAsterism))          // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.LengthIsAtLeast]")                   // details / explanation
+                .WithMessageContaining("\"CentralStar\"");                          // details / explanation
         }
 
         [TestMethod] public void LengthIsAtLeast_FieldWithStringDataConversionTarget() {
@@ -661,6 +811,56 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(SederPlate.Karpas))                   // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.LengthIsAtLeast]");                  // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtLeast_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Crusade);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Crusade.MuslimLeader))                // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.LengthIsAtLeast]")                   // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtLeast_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(StateOfTheUnion);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(StateOfTheUnion.DesignatedSurvivor))  // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.LengthIsAtLeast]")                   // details / explanation
+                .WithMessageContaining("\"Department\"");                           // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtLeast_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Triptych);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Triptych.MiddlePanel))                // error location
                 .WithMessageContaining("path is required")                          // category
                 .WithMessageContaining("[Check.LengthIsAtLeast]");                  // details / explanation
         }
@@ -825,7 +1025,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(ComputerVirus.Type));                 // details / explanation
         }
 
-        [TestMethod] public void LengthIsAtMost_NestedApplicableScalar() {
+        [TestMethod] public void LengthIsAtMost_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(MafiaFamily);
@@ -840,7 +1040,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void LengthIsAtMost_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void LengthIsAtMost_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Kayak);
@@ -874,6 +1074,56 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.LengthIsAtMost]")                    // details / explanation
                 .WithMessageContaining("\"Name\"");                                 // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtMost_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Denarian);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "Fallen.Name", ComparisonOperator.LTE, 673).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void LengthIsAtMost_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(IceCreamSundae);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(IceCreamSundae.Scoop3))               // error location
+                .WithMessageContaining("\"ID\"")                                    // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.LengthIsAtMost]")                    // details / explanation
+                .WithMessageContaining(nameof(String))                              // details / explanation
+                .WithMessageContaining(nameof(Guid));                               // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtMost_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Orgasm);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Orgasm.Receiver))                     // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.LengthIsAtMost]")                    // details / explanation
+                .WithMessageContaining("\"Who\"");                                  // details / explanation
         }
 
         [TestMethod] public void LengthIsAtMost_FieldWithStringDataConversionTarget() {
@@ -1016,6 +1266,56 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(Newscast.Sports))                     // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.LengthIsAtMost]");                   // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtMost_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PhaseDiagram);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(PhaseDiagram.CriticalPoint))          // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.LengthIsAtMost]")                    // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtMost_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Sundial);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Sundial.CenterLocation))              // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.LengthIsAtMost]")                    // details / explanation
+                .WithMessageContaining("\"Identifier\"");                           // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtMost_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Zoombini);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Zoombini.LostAt))                     // error location
                 .WithMessageContaining("path is required")                          // category
                 .WithMessageContaining("[Check.LengthIsAtMost]");                   // details / explanation
         }
@@ -1180,7 +1480,7 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Kinesis.Group));                      // details / explanation
         }
 
-        [TestMethod] public void LengthIsBetween_NestedApplicableScalar() {
+        [TestMethod] public void LengthIsBetween_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(LiteraryTrope);
@@ -1197,7 +1497,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
-        [TestMethod] public void LengthIsBetween_NestedInapplicableScalar_IsError() {
+        [TestMethod] public void LengthIsBetween_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(OvernightCamp);
@@ -1231,6 +1531,57 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.LengthIsBetween]")                   // details / explanation
                 .WithMessageContaining("\"Doctorate\"");                            // details / explanation
+        }
+
+        [TestMethod] public void LengthIsBetween_ReferenceNestedApplicableScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Onomatopoeia);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "DictionaryEntry.Dictionary", ComparisonOperator.GTE, 14).And
+                .HaveConstraint(FieldFunction.LengthOf, "DictionaryEntry.Dictionary", ComparisonOperator.LTE, 53).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void LengthIsBetween_ReferenceNestedInapplicableScalar_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(TrivialPursuitPie);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(TrivialPursuitPie.HistoryWedge))      // error location
+                .WithMessageContaining("\"CardID\"")                                // nested path
+                .WithMessageContaining("constraint is inapplicable")                // category
+                .WithMessageContaining("[Check.LengthIsBetween]")                   // details / explanation
+                .WithMessageContaining(nameof(String))                              // details / explanation
+                .WithMessageContaining(nameof(Char));                               // details / explanation
+        }
+
+        [TestMethod] public void LengthIsBetween_NestedReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SumoWrestler);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(SumoWrestler.DOB))                    // error location
+                .WithMessageContaining("refers to a non-scalar")                    // category
+                .WithMessageContaining("[Check.LengthIsBetween]")                   // details / explanation
+                .WithMessageContaining("\"Month\"");                                // details / explanation
         }
 
         [TestMethod] public void LengthIsBetween_FieldWithStringDataConversionTarget() {
@@ -1408,6 +1759,56 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(MesopotamianGod.Names))               // error location
+                .WithMessageContaining("path is required")                          // category
+                .WithMessageContaining("[Check.LengthIsBetween]");                  // details / explanation
+        }
+
+        [TestMethod] public void LengthIsBetween_NonExistentPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(HeatWave);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(HeatWave.Low))                        // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.LengthIsBetween]")                   // details / explanation
+                .WithMessageContaining("\"---\"");                                  // details / explanation
+        }
+
+        [TestMethod] public void LengthIsBetween_NonPrimaryKeyPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Sprachbund);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Sprachbund.Progenitor))               // error location
+                .WithMessageContaining("path*does not exist")                       // category
+                .WithMessageContaining("[Check.LengthIsBetween]")                   // details / explanation
+                .WithMessageContaining("\"Endonym\"");                              // details / explanation
+        }
+
+        [TestMethod] public void LengthIsBetween_NoPathOnReference_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Leprechaun);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Leprechaun.Shillelagh))               // error location
                 .WithMessageContaining("path is required")                          // category
                 .WithMessageContaining("[Check.LengthIsBetween]");                  // details / explanation
         }

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -221,6 +221,83 @@ namespace UT.Kvasir.Translation {
             public uint HP { get; set; }
             public byte LegendaryActions { get; set; }
         }
+
+        // Test Scenario: Non-Nullable References (✓recognized✓)
+        public class Scorpion {
+            public class TaxonomicGenus {
+                public string Family { get; set; } = "";
+                [PrimaryKey] public string Genus { get; set; } = "";
+            }
+
+            [PrimaryKey] public string CommonName { get; set; } = "";
+            public TaxonomicGenus Genus { get; set; } = new();
+            public string Species { get; set; } = "";
+            public double StingIndex { get; set; }
+            public float AverageLength { get; set; }
+            public float AverageWeight { get; set; }
+        }
+
+        // Test Scenario: Nullable References (✓recognized✓)
+        public class Ferry {
+            [Flags] public enum Kind { Passenger = 1, Cargo = 2, State = 4 }
+
+            public class Port {
+                [PrimaryKey] public Guid PortID { get; set; }
+                [PrimaryKey] public string PortName { get; set; } = "";
+                public double TaxRate { get; set; }
+                public ushort NumDocks { get; set; }
+            }
+
+            [PrimaryKey] public Guid RegistrationNumber { get; set; }
+            public ulong? PassengerCapacity { get; set; }
+            public Kind Type { get; set; }
+            public Port? Embarcation { get; set; }
+            public Port? Destination { get; set; }
+        }
+
+        // Test Scenario: References Nested Within Aggregates (✓recognized✓)
+        public class WeekendUpdate {
+            public class Actor {
+                [PrimaryKey] public string FirstName { get; set; } = "";
+                [PrimaryKey] public string LastName { get; set; } = "";
+            }
+            public class Date {
+                public enum MonthOfYear { JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV, DEC }
+                [PrimaryKey] public MonthOfYear Month { get; set; }
+                [PrimaryKey] public byte Day { get; set; }
+                [PrimaryKey] public short Year { get; set; }
+            }
+            public record struct Character(string Name, Actor Portrayal);
+
+            [PrimaryKey] public Guid ID { get; set; }
+            public Date Airing { get; set; } = new();
+            public Actor Anchor { get; set; } = new();
+            public Character? FirstSegment { get; set; }
+            public Character? SecondSegment { get; set; }
+            public sbyte NumJokes { get; set; }
+        }
+
+        // Test Scenario: References Nested Within References (✓recognized✓)
+        public class DannyPhantomGhost {
+            public enum Ability { Intangibiblity, Blast, Overshadowing, Duplication, Telekinesis }
+
+            public class Season {
+                [PrimaryKey] public ushort Number { get; set; }
+                public DateTime Premiere { get; set; }
+                public double Rating { get; set; }
+            }
+            public class Episode {
+                public Season Season { get; set; } = new();
+                [PrimaryKey] public short Overall { get; set; }
+                public byte Runtime { get; set; }
+                public DateTime AirDate { get; set; }
+            }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            public Ability Powers { get; set; }
+            public int Appearances { get; set; }
+            public Episode Debut { get; set; } = new();
+        }
     }
 
     internal static class EntityShapes {
@@ -652,6 +729,21 @@ namespace UT.Kvasir.Translation {
             public ulong NumCreditors { get; set; }
         }
 
+        // Test Scenario: Non-Nullable Reference Property Marked as [Nullable] (✓cascades as nullable✓)
+        public class Jukebox {
+            public class Song {
+                [PrimaryKey] public string Title { get; set; } = "";
+                [PrimaryKey] public string Singer { get; set; } = "";
+                public double Length { get; set; }
+            }
+
+            [PrimaryKey] public Guid ProductID { get; set; }
+            public ushort NumSongs { get; set; }
+            [Nullable] public Song MostPlayed { get; set; } = new();
+            public decimal CostPerPlay { get; set; }
+            public bool IsDigital { get; set; }
+        }
+
         // Test Scenario: Nullable Scalar Property Marked as [NonNullable] (✓becomes non-nullable✓)
         public class Bone {
             [PrimaryKey] public uint TA2 { get; set; }
@@ -670,6 +762,24 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid ID { get; set; }
             public string Name { get; set; } = "";
             [NonNullable] public Instruments? Composition { get; set; }
+        }
+
+        // Test Scenario: Nullable Reference Property Marked as [NonNullabe] (✓becomes non-nullable)
+        public class Bodhisattva {
+            public enum Denomination { Nikaya, Theravada, Mahayana }
+
+            public class Bhumi {
+                [PrimaryKey] public string English { get; set; } = "";
+                public string? Sanskrit { get; set; }
+                public string Description { get; set; } = "";
+            }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            public Denomination Buddhism { get; set; }
+            [NonNullable] public Bhumi? LastBhumi { get; set; }
+            public DateTime DateOfBirth { get; set; }
+            public DateTime DateOfDeath { get; set; }
+
         }
 
         // Test Scenario: Nullable Scalar Property Marked as [Nullable] (✓redundant✓)
@@ -830,7 +940,7 @@ namespace UT.Kvasir.Translation {
             public bool IsDriveable { get; set; }
         }
 
-        // Test Scenario: Change Nested Field Name to New Value (✓renamed✓)
+        // Test Scenario: Change Aggregate-Nested Field Name to New Value (✓renamed✓)
         public class Ziggurat {
             public record struct Civilization(string Name, string Location);
 
@@ -879,6 +989,60 @@ namespace UT.Kvasir.Translation {
             public double SheerAngle { get; set; }
             public bool IsUNESCO { get; set; }
             public string PrimaryStone { get; set; } = "";
+        }
+
+        // Test Scenario: Change Reference Field Name (✓renamed✓)
+        public class Ballerina {
+            public class Ballet {
+                [PrimaryKey] public Guid BalletID { get; set; }
+                public string Title { get; set; } = "";
+                public ulong Length { get; set; }
+            }
+
+            [PrimaryKey] public uint SSN { get; set; }
+            public string FirstName { get; set; } = "";
+            public string LastName { get; set; } = "";
+            public double Height { get; set; }
+            public byte ShoeSize { get; set; }
+            [Name("DebutBallet")] public Ballet Debut { get; set; } = new();
+        }
+
+        // Test Scenario: Change Reference-Nested Field Name to New Value (✓renamed✓)
+        public class DMZ {
+            public enum LineType { Latitude, Longitude }
+            public enum Direction { North, South, East, West }
+
+            public class Location {
+                [PrimaryKey] public double Measurement { get; set; }
+                [PrimaryKey] public LineType LatLong { get; set; }
+                [PrimaryKey] public Direction Dir { get; set; }
+            }
+
+            [PrimaryKey] public string DMZName { get; set; } = "";
+            public double Length { get; set; }
+            [Name("Value", Path = "Measurement"), Name("Definition.Lat_or_Long", Path = "LatLong")] public Location Definition { get; set; } = new();
+            public string OverseenBy { get; set; } = "";
+            public DateTime Established { get; set; }
+        }
+
+        // Test Scenario: Change Nested Reference Name (✓renamed✓)
+        public class Carnival {
+            public class Carny {
+                [PrimaryKey] public int ID { get; set; }
+                [PrimaryKey] public string Title { get; set; } = "";
+                public double Height { get; set; }
+                public decimal Salary { get; set; }
+                public uint YearsExperience { get; set; }
+            }
+            public record struct Staff(Carny HeadCarny, Carny Zookeeper, Carny Janitor, Carny Spokesperson);
+
+            [PrimaryKey] public Guid CarnivalID { get; set; }
+            public string CarnivalName { get; set; } = "";
+            public string City { get; set; } = "";
+            public bool IsTravelling { get; set; }
+            [Name("SanitationLord", Path = "Janitor")] public Staff CarnivalStaff { get; set; }
+            public decimal PopcornCost { get; set; }
+            public ushort NumTents { get; set; }
         }
 
         // Test Scenario: Swap Names of Fields (✓renamed✓)
@@ -995,6 +1159,64 @@ namespace UT.Kvasir.Translation {
             public ushort Height { get; set; }
             public ushort Width { get; set; }
         }
+
+        // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+        public class CapitolBuilding {
+            public class Person {
+                [PrimaryKey] public int SSN { get; set; }
+                public string FirstName { get; set; } = "";
+                public string LastName { get; set; } = "";
+            }
+
+            [PrimaryKey] public string Location { get; set; } = "";
+            [PrimaryKey] public bool IsActive { get; set; }
+            public DateTime Opened { get; set; }
+            public ulong Capacity { get; set; }
+            public uint NumSteps { get; set; }
+            [Name("SocialSecurity", Path = "---")] public Person Architect { get; set; } = new();
+        }
+
+        // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+        public class Rabbi {
+            public enum Judaism { Reform, Conservative, Orthodox, Reconstructionist, Haredi }
+
+            public class Synagogue {
+                [PrimaryKey] public Guid TempleID { get; set; }
+                public string Name { get; set; } = "";
+                public string Address { get; set; } = "";
+                public Judaism Denomination { get; set; }
+                public ulong Membership { get; set; }
+            }
+
+            [PrimaryKey] public string FirstName { get; set; } = "";
+            [PrimaryKey] public char MiddleInitial { get; set; }
+            [PrimaryKey] public string LastName { get; set; } = "";
+            public DateTime Ordained { get; set; }
+            public ulong SermonsDelivered { get; set; }
+            public ulong WeddingsPerformed { get; set; }
+            public ulong BneiMitzvotOfficiated { get; set; }
+            public ulong BabiesNamed { get; set; }
+            public ulong ConversionsOverseen { get; set; }
+            [Name("Type", Path = "Denomination")] public Synagogue? CurrentTemple { get; set; }
+        }
+
+        // Test Scenario: <Path> on Reference Refers to Aggregate Housing (Part of) Primary Key (✓renamed✓)
+        public class CarAccident {
+            public class Car {
+                public record struct Registration(Guid ID, DateTime Approved, bool International);
+
+                [PrimaryKey(Path = "ID")] public Registration Reg { get; set; }
+                public string Make { get; set; } = "";
+                public string Model { get; set; } = "";
+                public ulong Milage { get; set; }
+                public byte NumDoors { get; set; }
+            }
+
+            [PrimaryKey] public Guid AccidentReportID { get; set; }
+            public ushort Casualties { get; set; }
+            public Car Instigator { get; set; } = new();
+            [Name("Registration", Path = "Reg")] public Car? Other { get; set; }
+        }
     }
 
     internal static class DefaultValues {
@@ -1079,7 +1301,7 @@ namespace UT.Kvasir.Translation {
             public bool ProvenHoax { get; set; }
         }
 
-        // Test Scenario: Default on Nested Field (✓valid✓)
+        // Test Scenario: Default on Aggregate-Nested Field (✓valid✓)
         public class Salsa {
             public struct Pepper {
                 public string Name { get; set; }
@@ -1092,7 +1314,7 @@ namespace UT.Kvasir.Translation {
             public sbyte ClovesGarlic { get; set; }
         }
 
-        // Test Scenario: Default on Nested Field that Already Has a Default (✓overrides✓)
+        // Test Scenario: Default on Aggregate-Nested Field that Already Has a Default (✓overrides✓)
         public class Bicycle {
             public struct Alloy {
                 public string Metal1 { get; set; }
@@ -1110,6 +1332,56 @@ namespace UT.Kvasir.Translation {
             public Wheel? SpareWheel { get; set; }
             public ushort Gears { get; set; }
             public float TopSpeed { get; set; }
+        }
+
+        // Test Scenario: Original Default on Reference-Nested Field (✓not propagated✓)
+        public class Arch {
+            public class Coordinate {
+                [PrimaryKey] public float Latitude { get; set; }
+                [PrimaryKey, Default(0.0f)] public float Longitude { get; set; }
+            }
+
+            [PrimaryKey] public Guid ArchID { get; set; }
+            public string Material { get; set; } = "";
+            public double Height { get; set; }
+            public double Diameter { get; set; }
+            public Coordinate Location { get; set; } = new();
+            public Guid KeystoneID { get; set; }
+        }
+
+        // Test Scenario: Default on Reference-Nested Field (✓valid✓)
+        public class Kite {
+            public class String {
+                public double Length { get; set; }
+                [PrimaryKey] public Guid BallSource { get; set; }
+                [PrimaryKey] public ushort CutNumber { get; set; }
+                public float Weight { get; set; }
+            }
+
+            [PrimaryKey] public Guid KiteID { get; set; }
+            [Default((ushort)31, Path = "CutNumber")] public String KiteString { get; set; } = new();
+            public double MajorAxis { get; set; }
+            public double MinorAxis { get; set; }
+            public string Material { get; set; } = "";
+            public double TopSpeed { get; set; }
+        }
+
+        // Test Scenario: Default on Reference-Nested Field that Already Has a Default (✓overrides✓)
+        public class EscapeRoom {
+            public enum Style { Mathematical, Musical, Physical, Logical, Scientific, Linguistic, Botanical }
+
+            public class Puzzle {
+                [PrimaryKey] public string Description { get; set; } = "";
+                [PrimaryKey, Default(Style.Logical)] public Style PuzzleType { get; set; }
+                public ushort AverageCompletionTime { get; set; }
+                public double ChallengeRating { get; set; }
+            }
+
+            [PrimaryKey] public Guid RoomID { get; set; }
+            public ushort TimeLimit { get; set; }
+            public ushort BestTime { get; set; }
+            [Default(Style.Linguistic, Path = "PuzzleType")] public Puzzle FirstPuzzle { get; set; } = new();
+            [Default(Style.Logical, Path = "PuzzleType")] public Puzzle FinalPuzzle { get; set; } = new();
         }
 
         // Test Scenario: `null` Default for Non-Nullable Field (✗invalid✗)
@@ -1177,6 +1449,26 @@ namespace UT.Kvasir.Translation {
             public bool BuildABear { get; set; }
             [Default(136L, Path = "Stuffing")] public Construction Description { get; set; }
             public double Weight { get; set; }
+        }
+
+        // Test Scenario: Applied to Nested Reference (✗invalid✗)
+        public class PoetLaureate {
+            public enum Type { Country, State, Province, City, Emirate, Oblast, District, County, Constituent, Island }
+
+            public class State {
+                [PrimaryKey] public string Endonym { get; set; } = "";
+                [PrimaryKey] public string Exoynym { get; set; } = "";
+                public ulong Population { get; set; }
+                public ulong Area { get; set; }
+            }
+            public record struct Polity(State Entity, Type Type);
+
+            [PrimaryKey] public string FirstName { get; set; } = "";
+            [PrimaryKey] public string LastName { get; set; } = "";
+            public DateTime TermBegin { get; set; }
+            public DateTime TermEnd { get; set; }
+            [Default('x', Path = "Entity")] public Polity Of { get; set; }
+            public string InauguralPoemTitle { get; set; } = "";
         }
 
         // Test Scenario: Single-Element Array Default (✗invalid✗)
@@ -1341,6 +1633,57 @@ namespace UT.Kvasir.Translation {
             public string FirstFilmAppearance { get; set; } = "";
             public string FirstComicsAppearance { get; set; } = "";
         }
+
+        // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+        public class Hepatitis {
+            public class Medication {
+                [PrimaryKey] public Guid FDA_ID { get; set; }
+                public string Name { get; set; } = "";
+                public string Formula { get; set; } = "";
+                public bool OTC { get; set; }
+                public decimal PrescriptionPrice { get; set; }
+                public double LethalDose { get; set; }
+            }
+
+            [PrimaryKey] public char Strain { get; set; }
+            public ulong Prevalence { get; set; }
+            public bool IsComplicatedbyCirrhosis { get; set; }
+            [Default(1541923.558, Path = "---")] public Medication Treatment { get; set; } = new();
+            public double MortailtyRate { get; set; }
+        }
+
+        // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+        public class Calculator {
+            public class MakeAndModel {
+                [PrimaryKey] public string Manufacturer { get; set; } = "";
+                [PrimaryKey] public string Make { get; set; } = "";
+                [PrimaryKey] public string Model { get; set; } = "";
+                public bool IsInCirculation { get; set; }
+            }
+
+            [PrimaryKey] public Guid ProductID { get; set; }
+            [Default(true, Path = "IsInCirculation")] public MakeAndModel MakeModel { get; set; } = new();
+            public bool IsGraphing { get; set; }
+            public bool IsACTLegal { get; set; }
+            public short BatteryLife { get; set; }
+            public string LastCalculation { get; set; } = "";
+        }
+
+        // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+        public class PopTart {
+            public class Color {
+                [PrimaryKey] public byte Red { get; set; }
+                [PrimaryKey] public byte Green { get; set; }
+                [PrimaryKey] public byte Blue { get; set; }
+            }
+
+            [PrimaryKey] public string Flavor { get; set; } = "";
+            public bool Discontinued { get; set; }
+            public DateTime FirstReleased { get; set; }
+            public double RecommendedToasterTime { get; set; }
+            [Default(null)] public Color FrostingColor { get; set; } = new();
+            public bool IsChocolatey { get; set; }
+        }
     }
 
     internal static class ColumnOrdering {
@@ -1376,6 +1719,41 @@ namespace UT.Kvasir.Translation {
             [Column(7)] public Boat? Secondary { get; set; }
             public Boat? Tertiary { get; set; }
             public double VictoryPercentage { get; set; }
+        }
+
+        // Test Scenario: Reference Fields are Manually Ordered (✓ordered✓)
+        public class EdibleArrangement {
+            public class Basket {
+                [PrimaryKey, Column(1)] public Guid FactoryID { get; set; }
+                [PrimaryKey, Column(2)] public string Brand { get; set; } = "";
+                [PrimaryKey, Column(0)] public int Item { get; set; }
+                public double Weight { get; set; }
+                public bool IsWicker { get; set; }
+            }
+
+            [PrimaryKey] public Guid ID { get; set; }
+            public decimal Price { get; set; }
+            public int Strawberries { get; set; }
+            public int Bananas { get; set; }
+            public int Grapes { get; set; }
+            public int Cantaloupe { get; set; }
+            public int OtherFruit { get; set; }
+            [Column(5)] public Basket Vessel { get; set; } = new();
+        }
+
+        // Test Scenario: Reference's Primary Keys are Non-Consecutive (✓collapsed✓)
+        public class MassExtinction {
+            public class GeologicPeriod {
+                [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+                [PrimaryKey, Column(3)] public ulong MYA { get; set; }
+                public string StandardSpecies { get; set; } = "";
+                public string GeologicEra { get; set; } = "";
+            }
+
+            [PrimaryKey] public int Index { get; set; }
+            public GeologicPeriod ExitBoundary { get; set; } = new();
+            public GeologicPeriod EntryBoundary { get; set; } = new();
+            public double Severity { get; set; }
         }
 
         // Test Scenario: Two Scalar Fields Ordered to Same Index (✗duplication✗)
@@ -1428,6 +1806,22 @@ namespace UT.Kvasir.Translation {
             [Column(18)] public string Language { get; set; } = "";
         }
 
+        // Test Scenario: Ordering of Reference Leaves Gaps (✗non-consecutive✗)
+        public class Origami {
+            public class Paper {
+                [PrimaryKey] public string Brand { get; set; } = "";
+                [PrimaryKey] public float Height { get; set; }
+                [PrimaryKey] public float Width { get; set; }
+                [PrimaryKey] public bool IsCardStock { get; set; }
+            }
+
+            [PrimaryKey] public Guid OrigamiObjectID { get; set; }
+            public string Shape { get; set; } = "";
+            [Column(9)] public Paper Material { get; set; } = new();
+            public ushort Folds { get; set; }
+            public double NetWeight { get; set; }
+        }
+
         // Test Scenario: Field Manually Ordered to Negative Index (✗invalid✗)
         public class NationalPark {
             [PrimaryKey] public string Name { get; set; } = "";
@@ -1466,7 +1860,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Spec Specification { get; set; }
         }
 
-        // Test Scenario: Nested Scalar Property Marked as [PrimaryKey] (✓identified✓)
+        // Test Scenario: Aggregate-Nested Scalar Property Marked as [PrimaryKey] (✓identified✓)
         public class Tepui {
             public enum Direction { North, South, East, West }
             public record struct Coordinate(float Latitude, Direction LatDir, float Longitude, Direction LongDir);
@@ -1490,6 +1884,53 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey(Path = "Name")] public Ingredient Ingredient2 { get; set; }
             [PrimaryKey(Path = "Name")] public Ingredient Ingredient3 { get; set; }
             [PrimaryKey(Path = "Name")] public Ingredient Ingredient4 { get; set; }
+        }
+
+        // Test Scenario: Reference Property Marked as [PrimaryKey] (✓identified✓)
+        public class Etiology {
+            public class Culture {
+                [PrimaryKey] public string Name { get; set; } = "";
+                [PrimaryKey] public string Abbreviation { get; set; } = "";
+                public DateTime? Started { get; set; }
+                public DateTime? Ended { get; set; }
+            }
+
+            [PrimaryKey] public Culture Source { get; set; } = new();
+            public string? Author { get; set; }
+            public string? FullText { get; set; }
+            public string ExplanationOf { get; set; } = "";
+        }
+
+        // Test Scenario: Reference-Nested Scalar Property Marked as [PrimaryKey] (✓identified✓)
+        public class PoirotMystery {
+            public class Identifier {
+                [PrimaryKey] public Guid ValuePart1 { get; set; }
+                [PrimaryKey] public Guid ValuePart2 { get; set; }
+                public string Style { get; set; } = "";
+            }
+
+            [PrimaryKey(Path = "ValuePart1")] public Identifier ISBN { get; set; } = new();
+            public string Title { get; set; } = "";
+            public ulong Pages { get; set; }
+            public ulong WordCount { get; set; }
+            public double GoodReads { get; set; }
+            public string Killer { get; set; } = "";
+        }
+
+        // Test Scenario: Nested Reference Property Marked as [PrimaryKey] (✓identified✓)
+        public class Prophecy {
+            public class Person {
+                [PrimaryKey] public string FirstName { get; set; } = "";
+                [PrimaryKey] public char MiddleInitial { get; set; }
+                [PrimaryKey] public string LastName { get; set; } = "";
+            }
+            public record struct People(Person P1, Person? P2);
+
+            [PrimaryKey] public Guid ProphecyID { get; set; }
+            public string Prophesizer { get; set; } = "";
+            public DateTime MadeOn { get; set; }
+            [PrimaryKey(Path = "P1")] public People Subjects { get; set; }
+            public bool SelfFulfilling { get; set; }
         }
 
         // Test Scenario: All Properties Marked as [PrimaryKey] (✓identified✓)
@@ -1736,6 +2177,68 @@ namespace UT.Kvasir.Translation {
             public double UpperBound { get; set; }
             [PrimaryKey(Path = "---")] public MarginOfError PlusMinus { get; set; }
         }
+
+        // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+        public class PhoneBooth {
+            public enum Color { Red, Orange, Yellow, Green, Blue, Purple, White, Black, Gray, Gold, Brown, Silver, Pink };
+
+            public class Company {
+                [PrimaryKey] public Guid CompanyID { get; set; }
+                public string Name { get; set; } = "";
+                public decimal AnnualRevenue { get; set; }
+                public string CEO { get; set; } = "";
+                public string Headquarteres { get; set; } = "";
+            }
+
+            [PrimaryKey] public Guid PhoneBoothID { get; set; }
+            public double Length { get; set; }
+            public double Width { get; set; }
+            public double Height { get; set; }
+            public ulong CallsMade { get; set; }
+            public decimal CostPerCall { get; set; }
+            [PrimaryKey(Path = "---")] public Company Manufacturer { get; set; } = new();
+            public bool UsedBySuperman { get; set; }
+            public bool IsTARDIS { get; set; }
+        }
+
+        // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+        public class ScientificExperiment {
+            public enum Branch { Physics, Chemistry, Biology, Geology, Astronomy, EarthScience, ComputerScience, Medicine };
+
+            public class Subject {
+                [PrimaryKey] public string Description { get; set; } = "";
+                public int Quantity { get; set; }
+                public bool Animate { get; set; }
+            }
+
+            [PrimaryKey] public string Experimenter { get; set; } = "";
+            [PrimaryKey] public string Title { get; set; } = "";
+            public DateTime Conducted { get; set; }
+            public Branch Science { get; set; }
+            public Subject ExperimentalGroup { get; set; } = new();
+            [PrimaryKey(Path = "Animate")] public Subject ControlGroup { get; set; } = new();
+            public string Hypothesis { get; set; } = "";
+            public string Conclusion { get; set; } = "";
+        }
+
+        // Test Scenario: <Path> on Reference Refers to Aggregate Housing (Part of) Primary Key (✗non-existent path✗)
+        public class Cryochamber {
+            public enum Scale { Fahrenheit, Celsius, Kelvin }
+
+            public class Temperature {
+                public record struct Temp(double Value, Scale Unit);
+
+                [PrimaryKey] public Temp Measurement { get; set; }
+                public double FeelsLike { get; set; }
+            }
+
+            public Guid ID { get; set; }
+            public string Model { get; set; } = "";
+            [PrimaryKey(Path = "Temp")] public Temperature MinTemperature { get; set; } = new();
+            public Temperature MaxTemperature { get; set; } = new();
+            public DateTime LastInspected { get; set; }
+            public ushort FrostbiteIncidents { get; set; }
+        }
     }
 
     internal static class PrimaryKeyNaming {
@@ -1882,7 +2385,7 @@ namespace UT.Kvasir.Translation {
             public bool IsHeritageSite { get; set; }
         }
 
-        // Test Scenario: Nested Scalar Fields in Candidate Key (✓recognized✓)
+        // Test Scenario: Aggregate-Nested Scalar Fields in Candidate Key (✓recognized✓)
         public class SpiderMan {
             public record struct Person(string FirstName, string? MiddleName, string LastName);
 
@@ -1918,6 +2421,74 @@ namespace UT.Kvasir.Translation {
             public Credentialization Credentials { get; set; }
             public ushort MeetingLength { get; set; }
             public ushort NumParticipants { get; set; }
+        }
+
+        // Test Scenario: Reference Field in Candidate Key with No Other Fields (✓recognized✓)
+        public class Luau {
+            public enum Hawaii { BigIsland, Oahu, Maui, Molokai, Kauai, Lanai, Niihau, Kahoolawe, Non }
+
+            public class Pig {
+                [PrimaryKey] public Guid BatchID { get; set; }
+                [PrimaryKey] public int LotNumber { get; set; }
+                public ulong Weight { get; set; }
+                public string? Name { get; set; }
+            }
+
+            [PrimaryKey] public Guid LuauID { get; set; }
+            public DateTime Date { get; set; }
+            [Unique] public Pig SucklingPig { get; set; } = new();
+            public ushort Ukeleles { get; set; }
+            public ushort TikiTorches { get; set; }
+            public Hawaii HawaiianIsland { get; set; }
+        }
+
+        // Test Scenario: Reference Field in Candidate Key with Other Fields (✓recognized✓)
+        public class GreatOldOne {
+            public class Epithet {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public string LanguageOfOrigin { get; set; } = "";
+                public string Meaning { get; set; } = "";
+                public bool InActiveUse { get; set; }
+            }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            [Unique("Identity", Path = "Name")] public Epithet PrimaryEpithet { get; set; } = new();
+            [Unique("Identity")] public int PantheonNumber { get; set; }
+            public bool IsDead { get; set; }
+            public ushort Appearances { get; set; }
+            public bool CouldDefeatCthulhuInFight { get; set; }
+        }
+
+        // Test Scenario: Reference-Nested Scalar Fields in Candidate Key (✓recognized✓)
+        public class JapaneseEmperor {
+            public class Era {
+                [PrimaryKey] public string EnglishEraName { get; set; } = "";
+                [PrimaryKey] public string JapaneseEraName { get; set; } = "";
+                public DateTime Start { get; set; }
+                public DateTime End { get; set; }
+            }
+
+            [PrimaryKey] public string RegnalName { get; set; } = "";
+            public string PersonalName { get; set; } = "";
+            [Unique("Eras", Path = "JapaneseEraName")] public Era StartEra { get; set; } = new();
+            [Unique("Eras", Path = "EnglishEraName")] public Era EndEra { get; set; } = new();
+        }
+
+        // Test Scenario: Nested Reference Fields in Candidate Key (✓not propagated✓)
+        public class HonestTrailer {
+            public class YouTube {
+                [PrimaryKey] public string Channel { get; set; } = "";
+                [PrimaryKey, Unique] public string VideoHash { get; set; } = "";
+                public string VideoTitle { get; set; } = "";
+                public ulong Length { get; set; }
+                public ulong Views { get; set; }
+            }
+
+            [PrimaryKey] public string SourceFilm { get; set; } = "";
+            public YouTube YouTubeVideo { get; set; } = new();
+            public string HonestTitle { get; set; } = "";
+            public bool EpicVoiceGuy { get; set; }
+            public byte BewbsCount { get; set; }
         }
 
         // Test Scenario: Scalar Fields in Same Candidate Key as Nested Fields (✓recognized✓)
@@ -2016,6 +2587,63 @@ namespace UT.Kvasir.Translation {
             public string? PrimaryCultCity { get; set; }
             public string Domain { get; set; } = "";
         }
+
+        // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+        public class Bachelorette {
+            public class Bachelor {
+                [PrimaryKey] public string FirstName { get; set; } = "";
+                [PrimaryKey] public string LastName { get; set; } = "";
+                public double Height { get; set; }
+                public double Weight { get; set; }
+                public float Attractiveness { get; set; }
+            }
+
+            [PrimaryKey] public string FirstName { get; set; } = "";
+            [PrimaryKey] public string LastName { get; set; } = "";
+            public double Height { get; set; }
+            public double Weight { get; set; }
+            public float Attractiveness { get; set; }
+            public byte Season { get; set; }
+            public bool Engaged { get; set; }
+            [Unique(Path = "---")] public Bachelor FinalRose { get; set; } = new();
+        }
+
+        // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+        public class Sherpa {
+            public class Mountain {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public ulong Height { get; set; }
+                public bool IsFourteener { get; set; }
+                public ulong TotalAscents { get; set; }
+            }
+
+            [PrimaryKey] public Guid MountaineeringID { get; set; }
+            public string Name { get; set; } = "";
+            public ulong TotalAscents { get; set; }
+            public DateTime FirstAscent { get; set; }
+            [Unique("MOUNTAIN", Path = "TotalAscents")] public Mountain MainMountain { get; set; } = new();
+        }
+
+        // Test Scenario: <Path> on Reference Refers to Aggregate Housing (Part of) Primary Key (✓recognized✓)
+        public class LawFirm {
+            public enum Type { Family, Civil, Malpractice, Criminal, FirstAmendment, Mergers, Divorce, Other }
+
+            public class Lawyer {
+                public record struct Licensing(Guid BarNumber, DateTime AsOf);
+
+                [PrimaryKey(Path = "BarNumber")] public Licensing License { get; set; }
+                public string FirstName { get; set; } = "";
+                public string LastName { get; set; } = "";
+                [PrimaryKey] public string LawSchool { get; set; } = "";
+            }
+            public record struct Partnering(Lawyer FoundingPartner, Lawyer? Associate, Lawyer? Emeritus);
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            public ulong Clients { get; set; }
+            [Unique(Path = "FoundingPartner")] public Partnering Partners { get; set; }
+            public ulong LawyerCount { get; set; }
+            public double WinPercentage { get; set; }
+        }
     }
 
     internal static class DataConverters {
@@ -2094,6 +2722,30 @@ namespace UT.Kvasir.Translation {
             [DataConverter(typeof(ToInt<Person>))] public Person KnightB { get; set; }
             public double Odds { get; set; }
             public bool Fatal { get; set; }
+        }
+
+        // Test Scenario: [DataConverter] Applied to Reference Field (✗impermissible✗)
+        public class Decathlon {
+            public class Athlete {
+                [PrimaryKey] public ulong Number { get; set; }
+                public string FirstName { get; set; } = "";
+                public string LastName { get; set; } = "";
+                public float Height { get; set; }
+                public double Weight { get; set; }
+            }
+
+            [PrimaryKey] public Guid RaceID { get; set; }
+            [DataConverter(typeof(ToInt<Athlete>))] public Athlete Winner { get; set; } = new();
+            public double BestMeters110 { get; set; }
+            public double BestLongJump { get; set; }
+            public double BestShotPut { get; set; }
+            public double BestHighJump { get; set; }
+            public double BestMeters400 { get; set; }
+            public double BestHurdles110 { get; set; }
+            public double BestDiscusThrow { get; set; }
+            public double BestPoleVault { get; set; }
+            public double BestJavelinThrow { get; set; }
+            public double BestMeters1500 { get; set; }
         }
 
         // Test Scenario: Data Conversion Source Type is Non-Nullable on Nullable Field (✓applied✓)
@@ -2262,6 +2914,24 @@ namespace UT.Kvasir.Translation {
             public Hole Hole18 { get; set; }
         }
 
+        // Test Scenario: [Numeric] Applied to Reference Field (✗impermissible✗)
+        public class SlamBallMatch {
+            public class SlamBallTeam {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public string Coach { get; set; } = "";
+                public string Handler { get; set; } = "";
+                public string Gunner { get; set; } = "";
+                public string Stopper { get; set; } = "";
+            }
+
+            [PrimaryKey] public Guid MatchID { get; set; }
+            public SlamBallTeam Victor { get; set; } = new();
+            [Numeric] public SlamBallTeam Defeated { get; set; } = new();
+            public uint TotalPoints { get; set; }
+            public uint TotalBlocks { get; set; }
+            public uint TotalFouls { get; set; }
+        }
+
         // Test Scenario: [AsString] Applied to Boolean Field (✗impermissible✗)
         public class BondGirl {
             [PrimaryKey] public string Name { get; set; } = "";
@@ -2321,6 +2991,21 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public float Longitude { get; set; }
             public uint Height { get; set; }
             [AsString] public EnergyOutput EnergyGenerated { get; set; }
+        }
+
+        // Test Scenario: [AsString] Applied to Reference Field (✗impermissible✗)
+        public class Chakra {
+            public class Yogini {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public DateTime DateOfBirth { get; set; }
+                public DateTime DateOfDeath { get; set; }
+            }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            [AsString] public Yogini? AssociatedYogini { get; set; }
+            public string Location { get; set; } = "";
+            public string Color { get; set; } = "";
+            public long? NumPetals { get; set; }
         }
 
         // Test Scenario: Property Marked with [DataConverter] and [Numeric] (✗conflicting✗)
@@ -2444,7 +3129,7 @@ namespace UT.Kvasir.Translation {
                 [Check.IsPositive] public Resolution Rating { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Numeric Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested Numeric Scalar (✓constrained✓)
             public class IceAge {
                 public struct Timespan {
                     public short Length { get; set; }
@@ -2459,7 +3144,7 @@ namespace UT.Kvasir.Translation {
                 public bool Global { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-Numeric Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-Numeric Scalar (✗impermissible✗)
             public class GoldenRaspberry {
                 public record struct Nominee(string Name, string Movie);
 
@@ -2486,6 +3171,57 @@ namespace UT.Kvasir.Translation {
                 [Check.IsPositive(Path = "Bottom")] public Square LowerLeft { get; set; }
                 public Square LowerCenter { get; set; }
                 public Square LowerRight { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Numeric Scalar (✓constrained✓)
+            public class Runway {
+                public class Airport {
+                    [PrimaryKey] public uint ID { get; set; }
+                    public string Name { get; set; } = "";
+                    public string Servicing { get; set; } = "";
+                    public DateTime Constructed { get; set; }
+                    public ulong Employees { get; set; }
+                    public bool IsHub { get; set; }
+                }
+
+                [PrimaryKey] public Guid RunwayID { get; set; }
+                [Check.IsPositive(Path = "ID")] public Airport Host { get; set; } = new();
+                public byte Number { get; set; }
+                public double Heading { get; set; }
+                public ulong Length { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-Numeric Scalar (✗impermissible✗)
+            public class CaesareanSection {
+                public class Person {
+                    [PrimaryKey] public string FirstName { get; set; } = "";
+                    [PrimaryKey] public string LastName { get; set; } = "";
+                    public ulong SSN { get; set; }
+                }
+
+                [PrimaryKey] public DateTime Timestamp { get; set; }
+                public Person Mother { get; set; } = new();
+                [Check.IsPositive(Path = "LastName")] public Person Doctor { get; set; } = new();
+                public byte PregnancyNumber { get; set; }
+                public double BloodLoss { get; set; }
+                public double ScarLength { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class Lamp {
+                public class Unit {
+                    public string FullName { get; set; } = "";
+                    [PrimaryKey] public string Symbol { get; set; } = "";
+                    public string Formula { get; set; } = "";
+                    public bool IsSI { get; set; }
+                }
+                public record struct Output(ushort Amount, Unit Unit);
+
+                [PrimaryKey] public Guid ProductID { get; set; }
+                public double Height { get; set; }
+                public sbyte NumBulbs { get; set; }
+                public bool IsLED { get; set; }
+                [Check.IsPositive(Path = "Unit")] public Output Power { get; set; }
             }
 
             // Test Scenario: Applied to Field Data-Converted to Numeric Type (✓constrained✓)
@@ -2558,6 +3294,54 @@ namespace UT.Kvasir.Translation {
                 public DateTime DateOfBirth { get; set; }
                 public DateTime? DateOfDeath { get; set; }
                 public ushort Publications { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+            public class HappyHour {
+                public class Bar {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public string Address { get; set; } = "";
+                    public string Proprietor { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid ID { get; set; }
+                public DateTime Start { get; set; }
+                public DateTime End { get; set; }
+                [Check.IsPositive(Path = "---")] public Bar Location { get; set; } = new();
+                public decimal DrinkPrice { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class Aquifer {
+                public enum Continent { NorthAmerica, SouthAmerica, Europe, Asia, Africa, Oceania, Antarctica }
+
+                public class Person {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public DateTime Birthdate { get; set; }
+                    public string? Qualifications { get; set; } = "";
+                }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                public Continent WhichContinent { get; set; }
+                public ulong Area { get; set; }
+                public ulong WaterOutput { get; set; }
+                [Check.IsPositive(Path = "Qualifications")] public Person DiscoveringGeologist { get; set; } = new();
+                public ulong PeopleServiced { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+            public class FactCheck {
+                public class Statement {
+                    [PrimaryKey] public Guid ID { get; set; }
+                    public string Claim { get; set; } = "";
+                    public string Claimant { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid ID { get; set; }
+                [Check.IsPositive] public Statement Fact { get; set; } = new();
+                public string Checker { get; set; } = "";
+                public bool JudgedTrue { get; set; }
+                public uint? Pinocchios { get; set; }
             }
 
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
@@ -2661,7 +3445,7 @@ namespace UT.Kvasir.Translation {
                 public bool FBIMostWanted { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Signed Numeric Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested Signed Numeric Scalar (✓constrained✓)
             public class Flood {
                 public record struct Date(sbyte Day, sbyte Month, ushort Year);
 
@@ -2673,7 +3457,7 @@ namespace UT.Kvasir.Translation {
                 public decimal Damage { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-Signed-Numeric Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-Signed-Numeric Scalar (✗impermissible✗)
             public class TrolleyProblem {
                 public record struct Option(string Label, double PcntChoice, int PotentialVictims);
 
@@ -2695,6 +3479,61 @@ namespace UT.Kvasir.Translation {
                 public string GreatRoyalWife { get; set; } = "";
                 public ushort TotalWives { get; set; }
                 public string? BurialPyramid { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Signed Numeric Scalar (✓constrained✓)
+            public class HawaiianGod {
+                public class MaoriGod {
+                    [PrimaryKey] public short DeityID { get; set; }
+                    public string Name { get; set; } = "";
+                    public int NumChildren { get; set; }
+                }
+
+                [PrimaryKey] public Guid ID { get; set; }
+                public string Name { get; set; } = "";
+                public string Domain { get; set; } = "";
+                public string Form { get; set; } = "";
+                [Check.IsNegative(Path = "DeityID")] public MaoriGod? MaoriEquivalent { get; set; }
+                public bool IsAumakua { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-Signed-Numeric Scalar (✗impermissible✗)
+            public class OceanCurrent {
+                public class Ocean {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public ulong Area { get; set; }
+                    public ulong TotalVolume { get; set; }
+                    public ulong DeepestDepth { get; set; }
+                }
+
+                [PrimaryKey] public Guid ID { get; set; }
+                public string CommonIdentifier { get; set; } = "";
+                [Check.IsNegative(Path = "Name")] public Ocean WhichOcean { get; set; } = new();
+                public bool IsTradeWind { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class AirBNB {
+                public class Politician {
+                    [PrimaryKey] public Guid ID { get; set; }
+                    public string FirstName { get; set; } = "";
+                    public string LastName { get; set; } = "";
+                    public bool Democrat { get; set; }
+                }
+                public class State {
+                    [PrimaryKey] public string Abbreviation { get; set; } = "";
+                    public string FullName { get; set; } = "";
+                    public DateTime AchievedStatehood { get; set; }
+                    public ulong Population { get; set; }
+                    public ulong Area { get; set; }
+                    public Politician Governor { get; set; } = new();
+                }
+                public record struct Address(uint Number, string Street, string City, State State, ulong ZipCode);
+
+                [PrimaryKey] public Guid ListingID { get; set; }
+                [Check.IsNegative(Path = "State")] public Address HouseAddress { get; set; }
+                public decimal PerNight { get; set; }
+                public Guid OwnerID { get; set; }
             }
 
             // Test Scenario: Applied to Field Data-Converted to Numeric Type (✓constrained✓)
@@ -2779,6 +3618,56 @@ namespace UT.Kvasir.Translation {
                 [Check.IsNegative] public ShipSails Sails { get; set; }
             }
 
+            // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+            public class Pharmacy {
+                public class Person {
+                    [PrimaryKey] public string FirstName { get; set; } = "";
+                    [PrimaryKey] public string LastName { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid PharmacyID { get; set; }
+                [Check.IsNegative(Path = "---")] public Person HeadPharmacist { get; set; } = new();
+                public ulong PrescriptionsFilled { get; set; }
+                public bool IsCompounding { get; set; }
+                public bool IsWalgreens { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class Popcorn {
+                public class Condiment {
+                    [PrimaryKey] public Guid ID { get; set; }
+                    public string Name { get; set; } = "";
+                    public uint Calories { get; set; }
+                    public uint Sodium { get; set; }
+                }
+
+                [PrimaryKey] public Guid ID { get; set; }
+                public string Brand { get; set; } = "";
+                public double Volume { get; set; }
+                [Check.IsNegative(Path = "Calories")] public Condiment? Topping { get; set; }
+                public bool Microwaved { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+            public class WinForm {
+                public class Button {
+                    [PrimaryKey] public Guid ComponentID { get; set; }
+                    public ushort WidthPixels { get; set; }
+                    public ushort HeightPixels { get; set; }
+                    public string Label { get; set; } = "";
+                    public ulong XPos { get; set; }
+                    public ulong YPos { get; set; }
+                }
+
+                [PrimaryKey] public Guid FormID { get; set; }
+                public string Title { get; set; } = "";
+                [Check.IsNegative] public Button? SubmitButton { get; set; }
+                public string DominantFont { get; set; } = "";
+                public ushort NumComponents { get; set; }
+                public ulong Height { get; set; }
+                public ulong Width { get; set; }
+            }
+
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
             public class SuperPAC {
                 [PrimaryKey] public Guid RegistrationID { get; set; }
@@ -2857,7 +3746,7 @@ namespace UT.Kvasir.Translation {
                 public decimal ClosingPrice { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Numeric Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested Numeric Scalar (✓constrained✓)
             public class Essay {
                 public record struct Sentence(string Text, int WordCount);
                 public record struct Paragraph(Sentence S1, Sentence S2, Sentence S3, Sentence S4, Sentence S5);
@@ -2872,7 +3761,7 @@ namespace UT.Kvasir.Translation {
                 [Check.IsNonZero(Path = "S1.WordCount"), Check.IsNonZero(Path = "S4.WordCount")] public Paragraph P5 { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-Numeric Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-Numeric Scalar (✗impermissible✗)
             public class IDE {
                 public record struct SemVer(uint Major, uint Minor, uint Patch, string? PreRelease, string? Metadata, DateTime Released);
 
@@ -2900,6 +3789,62 @@ namespace UT.Kvasir.Translation {
                 public DateTime Taken { get; set; }
                 public string Taker { get; set; } = "";
                 public Status Result { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Numeric Scalar (✓constrained✓)
+            public class EgyptianPyramid {
+                public class Pharaoh {
+                    [PrimaryKey] public string RegnalName { get; set; } = "";
+                    [PrimaryKey] public byte RegnalNumber { get; set; }
+                    public byte Dynasty { get; set; }
+                }
+
+                [PrimaryKey] public Guid PyramidID { get; set; }
+                public float Latitude { get; set; }
+                public float Longitude { get; set; }
+                [Check.IsNonZero(Path = "RegnalNumber")] public Pharaoh? Entombed { get; set; }
+                public ulong Base { get; set; }
+                public ulong SlantHeight { get; set; }
+                public bool Excavated { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-Numeric Scalar (✗impermissible✗)
+            public class Pajamas {
+                public enum Kind { TwoPiece, Nightdress, Lingerie, Footie, OnePiece }
+
+                public class Store {
+                    [PrimaryKey] public Guid ID { get; set; }
+                    public string Name { get; set; } = "";
+                    public string? StockSymbol { get; set; }
+                    public string CEO { get; set; } = "";
+                    public ulong NumStores { get; set; }
+                }
+
+                [PrimaryKey] public Guid ProductID { get; set; }
+                [Check.IsNonZero(Path = "ID")] public Store Retailer { get; set; } = new();
+                public Kind Style { get; set; }
+                public string Material { get; set; } = "";
+                public bool DaytimeAppropriate { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class Galaxy {
+                public enum GalaxyShape { Elliptical, Lenticular, BarredSpiral, Quasar, Irregular }
+
+                public class Person {
+                    [PrimaryKey] public string FirstName { get; set; } = "";
+                    [PrimaryKey] public string LastName { get; set; } = "";
+                }
+                public record struct DiscoveryData(Person Astronomer, DateTime When, bool ImmediatelyAccepted);
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                public int MessierNumber { get; set; }
+                public GalaxyShape Shape { get; set; }
+                public double Declination { get; set; }
+                public double RedShift { get; set; }
+                public double ApparentMagnitude { get; set; }
+                public ulong SizeKiloParsecs { get; set; }
+                [Check.IsNonZero(Path = "Astronomer")] public DiscoveryData Discovery { get; set; }
             }
 
             // Test Scenario: Applied to Field Data-Converted to Numeric Type (✓constrained✓)
@@ -2974,6 +3919,72 @@ namespace UT.Kvasir.Translation {
                 public string Fruits { get; set; } = "";
                 public string Supplements { get; set; } = "";
                 public bool HasChocolate { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+            public class Antibiotic {
+                public enum AntibioticClass { BetaLactam, Cephalosporin, Carbapenem, Aminoglycoside, Sulfonamide, Quinolone, Oxazolidinone }
+
+                public class OrganicFormula {
+                    [PrimaryKey] public byte Carbon { get; set; }
+                    [PrimaryKey] public byte Oxygen { get; set; }
+                    [PrimaryKey] public byte Hydrogen { get; set; }
+                    [PrimaryKey] public byte Nitrogen { get; set; }
+                    [PrimaryKey] public byte Sulfur { get; set; }
+                }
+
+                [PrimaryKey] public Guid MedicalID { get; set; }
+                public string Name { get; set; } = "";
+                public bool IsNaturallyOccurring { get; set; }
+                [Check.IsNonZero(Path = "---")] public OrganicFormula Formula { get; set; } = new();
+                public AntibioticClass Class { get; set; }
+                public double Efficacy { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class Chopsticks {
+                public class Chopstick {
+                    [PrimaryKey] public Guid ItemID { get; set; }
+                    public double Length { get; set; }
+                    public double Weight { get; set; }
+                    public string Material { get; set; } = "";
+                    public bool Reusable { get; set; }
+                }
+
+                [PrimaryKey] public Guid ID { get; set; }
+                public Chopstick Chopstick1 { get; set; } = new();
+                [Check.IsNonZero(Path = "Weight")] public Chopstick Chopstick2 { get; set; } = new();
+            }
+
+            // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+            public class TongueTwister {
+                public class Word {
+                    [PrimaryKey] public string Text { get; set; } = "";
+                    public ulong FrequencyRating { get; set; }
+                    public ulong NumericValue { get; set; }
+                }
+
+                [PrimaryKey] public Guid ID { get; set; }
+                public Word Word1 { get; set; } = new();
+                public Word Word2{ get; set; } = new();
+                public Word Word3 { get; set; } = new();
+                public Word Word4 { get; set; } = new();
+                public Word Word5 { get; set; } = new();
+                public Word Word6 { get; set; } = new();
+                public Word Word7 { get; set; } = new();
+                public Word Word8 { get; set; } = new();
+                public Word Word9 { get; set; } = new();
+                public Word Word10 { get; set; } = new();
+                [Check.IsNonZero] public Word? Word11 { get; set; } = new();
+                public Word? Word12 { get; set; } = new();
+                public Word? Word13 { get; set; } = new();
+                public Word? Word14 { get; set; } = new();
+                public Word? Word15 { get; set; } = new();
+                public Word? Word16 { get; set; } = new();
+                public Word? Word17 { get; set; } = new();
+                public Word? Word18 { get; set; } = new();
+                public Word? Word19 { get; set; } = new();
+                public Word? Word20 { get; set; } = new();
             }
 
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
@@ -3058,7 +4069,7 @@ namespace UT.Kvasir.Translation {
                 public uint WikipediaWords { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Orderable Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested Orderable Scalar (✓constrained✓)
             public class Opioid {
                 public record struct ChemicalFormula(int C, int H, int N, int O);
                 public record struct Entry(ChemicalFormula Formula, string DrugBank);
@@ -3070,7 +4081,7 @@ namespace UT.Kvasir.Translation {
                 public bool IsIllegalInUS { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-Orderable Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-Orderable Scalar (✗impermissible✗)
             public class Wordle {
                 public enum Result { Unknown, Correct, Incorrect, WrongLocation }
                 public record struct Letter(char Value, Result Hint);
@@ -3097,6 +4108,56 @@ namespace UT.Kvasir.Translation {
                 public DateTime EndTimestamp { get; set; }
                 public string Location { get; set; } = "";
                 [Check.IsGreaterThan('<', Path = "Leader")] public Crowd Participants { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Orderable Scalar (✓constrained✓)
+            public class Apostle {
+                public class Religion {
+                    [PrimaryKey] public string Identifier { get; set; } = "";
+                    public ulong WorldwideFollowers { get; set; }
+                    public bool Monotheistic { get; set; }
+                }
+
+                [PrimaryKey] public Guid HolyID { get; set; }
+                [Check.IsGreaterThan("Atheism", Path = "Identifier")] public Religion Adherence { get; set; } = new();
+                public DateTime Ordination { get; set; }
+                public bool OfJesus { get; set; }
+                public bool Martyred { get; set; }
+                public ulong TotalConversions { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-Orderable Scalar (✗impermissible✗)
+            public class Influenza {
+                public class Outbreak {
+                    [PrimaryKey] public Guid OutbreakID { get; set; }
+                    public DateTime Starting { get; set; }
+                    public ulong Casualties { get; set; }
+                }
+
+                [PrimaryKey] public string Virus { get; set; } = "";
+                public bool ExistsVaccine { get; set; }
+                [Check.IsGreaterThan("a522c08b-b030-4658-b6cf-c729d6366805", Path = "OutbreakID")] public Outbreak? DeadliestOutbreak { get; set; }
+                public bool IsZoonotic { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class BloodDrive {
+                public class Hospital {
+                    [PrimaryKey] public Guid HospitalID { get; set; }
+                    public string Name { get; set; } = "";
+                    public bool PrivatelyOperated { get; set; }
+                    public uint NumDoctors { get; set; }
+                    public uint NumNurses { get; set; }
+                    public bool HasOBGYN { get; set; }
+                }
+                public record struct Sponsorship(Hospital? Hospital, string? Company, string? University, bool RedCross);
+
+                [PrimaryKey] public Guid DriveID { get; set; }
+                public DateTime Scheduled { get; set; }
+                [Check.IsGreaterThan('u', Path = "Hospital")] public Sponsorship SponsoredBy { get; set; }
+                public ulong Donors { get; set; }
+                public double BloodCollected { get; set; }
+                public double PlasmaCollected { get; set; }
             }
 
             // Test Scenario: Applied to Nullable Fields with Total Orders (✓constrained✓)
@@ -3291,6 +4352,65 @@ namespace UT.Kvasir.Translation {
                 public bool ResolvedInFavorOfLabor { get; set; }
             }
 
+            // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+            public class InstallationWizard {
+                public class Software {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    [PrimaryKey] public string Publisher { get; set; } = "";
+                    public string Version { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid ID { get; set; }
+                [Check.IsGreaterThan("173dF-?", Path = "---")] public Software Program { get; set; } = new();
+                public byte NumPages { get; set; }
+                public bool Standalone { get; set; }
+                public bool RequiresWiFi { get; set; }
+                public bool UninstallsPreviousVersions { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class BugSpray {
+                public class Chemical {
+                    [PrimaryKey] public Guid ChemicalID { get; set; }
+                    public string Formula { get; set; } = "";
+                    public double LethalDose { get; set; }
+                }
+
+                [PrimaryKey] public Guid ProductID { get; set; }
+                public string Brand { get; set; } = "";
+                public double Efficacy { get; set; }
+                [Check.IsGreaterThan(1765.12, Path = "LethalDose")] public Chemical ActiveIngredient { get; set; } = new();
+                public bool IsInsecticide { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+            public class Intern {
+                public class University {
+                    [PrimaryKey] public string System { get; set; } = "";
+                    [PrimaryKey] public string Campus { get; set; } = "";
+                    public bool IsStateSchool { get; set; }
+                    public ulong UndergraduateStudents { get; set; }
+                    public ulong GraduateStudents { get; set; }
+                    public ulong Faculty { get; set; }
+                    public decimal Endowment { get; set; }
+                }
+                public class Employee {
+                    public Guid EmployeeID { get; set; }
+                    public string FirstName { get; set; } = "";
+                    public string LastName { get; set; } = "";
+                    public string Title { get; set; } = "";
+                    public decimal Salary { get; set; }
+                }
+
+                [PrimaryKey] public string FirstName { get; set; } = "";
+                [PrimaryKey] public string LastName { get; set; } = "";
+                public byte Age { get; set; }
+                public decimal WeeklySalary { get; set; }
+                public bool? ReturnOffer { get; set; }
+                public University College { get; set; } = new();
+                [Check.IsGreaterThan("1357-08-16")] public Employee Manager { get; set; } = new();
+            }
+
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
             public class DraftPick {
                 [PrimaryKey] public string League { get; set; } = "";
@@ -3373,7 +4493,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime FirstSCOTUS { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Orderable Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested Orderable Scalar (✓constrained✓)
             public class Raptor {
                 public record struct Taxonomy(string Kingdom, string Phylum, string Clas, string Order, string Family, string Genus, string Species);
                 public struct Bios {
@@ -3388,7 +4508,7 @@ namespace UT.Kvasir.Translation {
                 public byte Talons { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-Orderable Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-Orderable Scalar (✗impermissible✗)
             public class Feruchemy {
                 public enum Matrix { Physical, Cognitive, Hybrid, Spiritual }
                 public record struct Effect(Matrix Kind, string WhenStoring, string WhenTapping);
@@ -3410,6 +4530,66 @@ namespace UT.Kvasir.Translation {
                 public uint FiresFought { get; set; }
                 [Check.IsLessThan("Fahrenheit 451", Path = "ServiceArea")] public Crew Firehouse { get; set; }
                 public bool WorkedSept11 { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Orderable Scalar (✓constrained✓)
+            public class Butterfly {
+                public class TaxonomicGenus {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public string Family { get; set; } = "";
+                    public string Order { get; set; } = "";
+                    public string Class { get; set; } = "";
+                    public string Phylum { get; set; } = "";
+                    public string Kingdom { get; set; } = "";
+                    public string Domain { get; set; } = "";
+                }
+
+                [PrimaryKey] public string CommonName { get; set; } = "";
+                [Check.IsLessThan("Zojemana", Path = "Name")] public TaxonomicGenus Genus { get; set; } = new();
+                public string Species { get; set; } = "";
+                public bool Mimic { get; set; }
+                public ulong MetamorphosisDays { get; set; }
+                public double CaterpillarLength { get; set; }
+                public double Wingspan { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-Orderable Scalar (✗impermissible✗)
+            public class Cartel {
+                public enum CommodityType { Drug, Agriculture, Antique, Fashion, Technology, Energy, Other };
+
+                public class Commodity {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    [PrimaryKey] public CommodityType Kind { get; set; }
+                    public decimal StreetValue { get; set; }
+                    public bool IsIllicit { get; set; }
+                }
+
+                [PrimaryKey] public Guid CartelID { get; set; }
+                public string? CartelName { get; set; }
+                [Check.IsLessThan(CommodityType.Antique, Path = "Kind")] public Commodity Control { get; set; } = new();
+                public decimal AnnualRevenue { get; set; }
+                public string? Leader { get; set; }
+                public uint Members { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class Hallucination {
+                public class Drug {
+                    [PrimaryKey] public Guid NarcoID { get; set; }
+                    public string Name { get; set; } = "";
+                    public bool IsNarcotic { get; set; }
+                    public bool IsStimulant { get; set; }
+                    public bool IsHallucinogen { get; set; }
+                    public double LethalDose { get; set; }
+                    public string ChemicalFormula { get; set; } = "";
+                }
+                public record struct Explanation(Drug? Drug, string? Psychosis, bool Hypnosis);
+
+                [PrimaryKey] public Guid ExperienceID { get; set; }
+                public string Hallucinator { get; set; } = "";
+                [Check.IsLessThan(0UL, Path = "Drug")] public Explanation Reason { get; set; }
+                public bool Fatal { get; set; }
+                public double Duration { get; set; }
             }
 
             // Test Scenario: Applied to Nullable Fields with Total Orders (✓constrained✓)
@@ -3588,6 +4768,62 @@ namespace UT.Kvasir.Translation {
                 [Check.IsLessThan(false)] public Activity Initiation { get; set; }
             }
 
+            // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+            public class NationalMonument {
+                public enum Party { Democrat, Republican, DemocraticRepublican, Whig, Federalist, Independent, Green, Populist };
+
+                public class President {
+                    [PrimaryKey] public byte Index { get; set; }
+                    public string FirstName { get; set; } = "";
+                    public string LastName { get; set; } = "";
+                    public Party PoliticalParty { get; set; }
+                    public DateTime TermBegin { get; set; }
+                    public DateTime TermEnd { get; set; }
+                    public bool Assassinated { get; set; }
+                    public bool DiedInOffice { get; set; }
+                }
+
+                [PrimaryKey] public ulong HistoricPlaceReferenceNumber { get; set; }
+                public string Name { get; set; } = "";
+                public double Area { get; set; }
+                public DateTime Established { get; set; }
+                [Check.IsLessThan("Roosevelt", Path = "---")] public President EstablishedBy { get; set; } = new();
+                public ulong AnnualVisitors { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class YogaPosition {
+                public class SanskritWord {
+                    [PrimaryKey] public string Translation { get; set; } = "";
+                    public string Sanskrit { get; set; } = "";
+                    public string IAST { get; set; } = "";
+                }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                [Check.IsLessThan('6', Path = "Sanskrit")] public SanskritWord SanskritName { get; set; } = new();
+                public bool StandingPose { get; set; }
+                public uint MinimumAge { get; set; }
+                public DateTime? FirstAttestation { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+            public class PubCrawl {
+                public class Pub {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public ulong LiquorLicenseNumber { get; set; }
+                    public uint NumMenuItems { get; set; }
+                    public decimal Revenue { get; set; }
+                    public uint MaxCapacity { get; set; }
+                    public string? HeadBartender { get; set; }
+                }
+
+                [PrimaryKey] public Guid PubCrawlID { get; set; }
+                public string City { get; set; } = "";
+                [Check.IsLessThan(true)] public Pub FirstPub { get; set; } = new();
+                public Pub LastPub { get; set; } = new();
+                public ushort NumPubs { get; set; }
+            }
+
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
             public class ParkingGarage {
                 [PrimaryKey] public Guid GarageID { get; set; }
@@ -3665,7 +4901,7 @@ namespace UT.Kvasir.Translation {
                 public string SuzerainBonus { get; set; } = "";
             }
 
-            // Test Scenario: Applied to Nested Orderable Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested Orderable Scalar (✓constrained✓)
             public class FamilyTree {
                 public enum Gender { Male, Female, NonBinary, GenderFluid, Other }
                 public enum Direction { TopDown, BottomUp, LeftToRight, RightToLeft, Radial }
@@ -3679,7 +4915,7 @@ namespace UT.Kvasir.Translation {
                 public uint TotalIndividuals { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-Orderable Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-Orderable Scalar (✗impermissible✗)
             public class Readymade {
                 public record struct Entry(uint CopyrightNumber, bool IsFormallyRegistered);
 
@@ -3705,6 +4941,64 @@ namespace UT.Kvasir.Translation {
                 public int NumWeightMachines { get; set; }
                 public int NumDumbbells { get; set; }
                 public bool HasPool { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Orderable Scalar (✓constrained✓)
+            public class CandyBar {
+                public class ManufacturingPlant {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public Guid LicenseNumber { get; set; }
+                    public uint Employees { get; set; }
+                    public bool KosherCertfied { get; set; }
+                    public string State { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid SerialNumber { get; set; }
+                public string Brand { get; set; } = "";
+                [Check.IsGreaterOrEqualTo("Kraft-Heinz 87", Path = "Name")] public ManufacturingPlant Plant { get; set; } = new();
+                public bool ContainsChocolate { get; set; }
+                public bool ContainsNuts { get; set; }
+                public ulong Calories { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-Orderable Scalar (✗impermissible✗)
+            public class SlumberParty {
+                public enum CardinalDirection { None = 0, North, South, East, West }
+                public enum RoadType { Street, Avenue, Boulevard, Circle, Path, Terrace, Way, Junction, Road, Route }
+
+                public class Address {
+                    [PrimaryKey] public uint HouseNumber { get; set; }
+                    [PrimaryKey] public CardinalDirection Direction { get; set; }
+                    [PrimaryKey] public string StreetName { get; set; } = "";
+                    [PrimaryKey] public RoadType StreetSuffix { get; set; }
+                    [PrimaryKey] public string City { get; set; } = "";
+                    [PrimaryKey] public string State { get; set; } = "";
+                    [PrimaryKey] public uint ZipCode { get; set; }
+                }
+
+                [PrimaryKey] public DateTime Date { get; set; }
+                [PrimaryKey] public string HostFamily { get; set; } = "";
+                [Check.IsGreaterOrEqualTo(RoadType.Boulevard, Path = "StreetSuffix")] public Address Place { get; set; } = new();
+                public sbyte Attendees { get; set; }
+                public bool IsCoed { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class Barbie {
+                public class Ken {
+                    [PrimaryKey] public Guid SerialNumber { get; set; }
+                    public string Adjective { get; set; } = "";
+                    public float Height { get; set; }
+                }
+                public record struct BF(Ken Ken);
+                public record struct Family(BF Boyfriend, string? Mother, string? Father, int NumChildren);
+
+                [PrimaryKey] public Guid SerialNumber { get; set; }
+                public string Adjective { get; set; } = "";
+                public DateTime Released { get; set; }
+                public float Height { get; set; }
+                [Check.IsGreaterOrEqualTo(11.3f, Path = "Boyfriend.Ken")] public Family Relationships { get; set; } = new();
+                public bool AppearedInMovie { get; set; }
             }
 
             // Test Scenario: Applied to Nullable Fields with Total Orders (✓constrained✓)
@@ -3894,6 +5188,62 @@ namespace UT.Kvasir.Translation {
                 public bool HasKickstand { get; set; }
             }
 
+            // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+            public class Druid {
+                public enum Sizing { Tiny, Small, Medium, Large, Huge, Gargantuan }
+                public record struct Stats(byte Wisdom, byte Strength, byte Charisma, byte Constitution, byte Intelligence, byte Dexterity);
+
+                public class WildShape {
+                    [PrimaryKey] public string Creature { get; set; } = "";
+                    public ushort PHBPage { get; set; }
+                    public Sizing Size { get; set; }
+                    public string Attack1 { get; set; } = "";
+                    public string Attack2 { get; set; } = "";
+                    public string? Attack3 { get; set; }
+                    public Stats AbilityScores { get; set; }
+                }
+
+                [PrimaryKey] public string CharacterName { get; set; } = "";
+                public ushort Level { get; set; }
+                public Stats AbilityScores { get; set; }
+                public string FavoriteCantrip { get; set; } = "";
+                public WildShape WildShape1 { get; set; } = new();
+                [Check.IsGreaterOrEqualTo((byte)3, Path = "---")] public WildShape WildShape2 { get; set; } = new();
+                public WildShape WildShape3 { get; set; } = new();
+                public WildShape? WildShape4 { get; set; }
+                public WildShape? WildShape5 { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class Mirror {
+                public class Shape {
+                    [PrimaryKey] public string GeometricName { get; set; } = "";
+                    public ushort Vertices { get; set; }
+                    public ushort Sides { get; set; }
+                    public bool IsRegular { get; set; }
+                    public bool IsConcave { get; set; }
+                }
+
+                [PrimaryKey] public Guid MirrorID { get; set; }
+                [Check.IsGreaterOrEqualTo((ushort)1, Path = "Sides")] public Shape MirrorShape { get; set; } = new();
+                public double Reflectivity { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+            public class Chromosome {
+                public class Gene {
+                    [PrimaryKey] public string UniProt { get; set; } = "";
+                    public string Ensembl { get; set; } = "";
+                    public string Name { get; set; } = "";
+                }
+
+                [PrimaryKey] public string Species { get; set; } = "";
+                [PrimaryKey] public byte ChromosomeNumber { get; set; }
+                public ulong BasePairs { get; set; }
+                public float Size { get; set; }
+                [Check.IsGreaterOrEqualTo("2017-03-11")] public Gene FirstIsolatedGene { get; set; } = new();
+            }
+
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
             public class Camera {
                 [PrimaryKey] public string Model { get; set; } = "";
@@ -3972,7 +5322,7 @@ namespace UT.Kvasir.Translation {
                 public decimal Gross { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Orderable Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested Orderable Scalar (✓constrained✓)
             public class Hominin {
                 public record struct BinomialNomenclature(string Genus, string Species);
 
@@ -3984,7 +5334,7 @@ namespace UT.Kvasir.Translation {
                 public float PercentExtantDNA { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-Orderable Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-Orderable Scalar (✗impermissible✗)
             public class AmazonService {
                 public enum SubscriptionType { Free, Monthly, Yearly, PerUse, PerHour, Discretionary }
                 public record struct Subscription(bool RequiresSubscription, SubscriptionType Type, decimal AverageCost);
@@ -4008,6 +5358,56 @@ namespace UT.Kvasir.Translation {
                 public string? Scent { get; set; }
                 public bool ForWomen { get; set; }
                 [Check.IsLessOrEqualTo((byte)100, Path = "Ages")] public Instruction Directions { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Orderable Scalar (✓constrained✓)
+            public class Gatorade {
+                public class BottlingPlant {
+                    [PrimaryKey] public Guid PlantID { get; set; }
+                    [PrimaryKey] public DateTime Operational { get; set; }
+                    public ushort Employees { get; set; }
+                    public ulong AnnualVolume { get; set; }
+                    public char HealthCode { get; set; }
+                }
+
+                [PrimaryKey] public Guid SerialNumber { get; set; }
+                public string Flavor { get; set; } = "";
+                public double Volume { get; set; }
+                [Check.IsLessOrEqualTo("2566-11-15", Path = "Operational")] public BottlingPlant BottledAt { get; set; } = new();
+                public ushort NumElectrolytes { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-Orderable Scalar (✗impermissible✗)
+            public class Knife {
+                public enum Category { Cleaver, Steak, Chefs, Paring, Wilderness, Switchblade, Bread, Butter, Boning }
+
+                public class KnifeCategory {
+                    [PrimaryKey] public Category Which { get; set; }
+                    public string Listing { get; set; } = "";
+                    public ulong WorldwideCount { get; set; }
+                }
+
+                [PrimaryKey] public Guid KnifeID { get; set; }
+                public double Sharpness { get; set; }
+                public bool StainlessSteel { get; set; }
+                [Check.IsLessOrEqualTo(Category.Wilderness, Path = "Which")] public KnifeCategory Categorization { get; set; } = new();
+                public bool UsedInMurder { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class Ransomware {
+                public class Ransom {
+                    [PrimaryKey] public decimal Amount { get; set; }
+                    [PrimaryKey] public string Currency { get; set; } = "";
+                }
+                public record struct Demand(Ransom Ransom, DateTime Deadline);
+
+                [PrimaryKey] public Guid ID { get; set; }
+                public string? Claimant { get; set; }
+                public ushort MachinesAffected { get; set; }
+                [Check.IsLessOrEqualTo('_', Path = "Ransom")] public Demand Extortion { get; set; } = new();
+                public decimal Damage { get; set; }
+                public bool RansomPaid { get; set; }
             }
 
             // Test Scenario: Applied to Nullable Fields with Total Orders (✓constrained✓)
@@ -4183,6 +5583,61 @@ namespace UT.Kvasir.Translation {
                 [Check.IsLessOrEqualTo(']')] public Name For { get; set; }
             }
 
+            // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+            public class FoodPantry {
+                public class State {
+                    [PrimaryKey] public string Abbreviation { get; set; } = "";
+                    public string FullName { get; set; } = "";
+                    public ulong Population { get; set; }
+                    public ulong Area { get; set; }
+                    public DateTime Statehood { get; set; }
+                    public bool InConfederacy { get; set; }
+                }
+
+                [PrimaryKey] public Guid ID { get; set; }
+                public string StreetAddress { get; set; } = "";
+                [Check.IsLessOrEqualTo(15781293, Path = "---")] public State WhichState { get; set; } = new();
+                public string Director { get; set; } = "";
+                public ulong NumCans { get; set; }
+                public ulong NumPastaBoxes { get; set; }
+                public ulong NumCerealBoxes { get; set; }
+                public decimal TotalFoodValue { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class FittedSheet {
+                public enum Size { King, Queen, Twin, TwinXL, Full, California, Alaskan }
+
+                public class Dimension {
+                    [PrimaryKey] public float Length { get; set; }
+                    [PrimaryKey] public float Width { get; set; }
+                    public short ThreadCount { get; set; }
+                }
+                public record struct Color(byte R, byte G, byte B);
+
+                [PrimaryKey] public Guid ProductID { get; set; }
+                public Size BedSize { get; set; }
+                public Color SheetColor { get; set; }
+                public ushort AverageFoldingTime { get; set; }
+                [Check.IsLessOrEqualTo((short)-531, Path = "ThreadCount")] public Dimension Dimensions { get; set; } = new();
+            }
+
+            // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+            public class Playlist {
+                public class Song {
+                    [PrimaryKey] public string Title { get; set; } = "";
+                    [PrimaryKey] public string Artist { get; set; } = "";
+                    public ushort Length { get; set; }
+                    public ulong SpotifyStreams { get; set; }
+                    public string YouTubeLink { get; set; } = "";
+                }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                public ulong NumSongs { get; set; }
+                [Check.IsLessOrEqualTo(-0.333f)] public Song MostPlayed { get; set; } = new();
+                public ulong TotalDuration { get; set; }
+            }
+
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
             public class BowlingFrame {
                 [PrimaryKey] public Guid FrameID { get; set; }
@@ -4263,7 +5718,7 @@ namespace UT.Kvasir.Translation {
                 [Check.IsNot(Status.Ignored)] public Status Recognition { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested Scalar (✓constrained✓)
             public class SeventhInningStretch {
                 public record struct MatchUp(string HomeTeam, string AwayTeam, DateTime Date);
 
@@ -4286,6 +5741,48 @@ namespace UT.Kvasir.Translation {
                 [Check.IsNot(77.44514303f, Path = "OneDollarPayout")] public Ratio Odds { get; set; }
                 public bool PlacedOnline { get; set; }
                 public bool IsPropBet { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Scalar (✓constrained✓)
+            public class StanleyCup {
+                public enum Conf { Eastern, Western, Central }
+
+                public class HockeyTeam {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    [PrimaryKey] public string Abbreviation { get; set; } = "";
+                    [PrimaryKey] public Conf Conference { get; set; }
+                    public string AllTimeLeadingScorer { get; set; } = "";
+                    public string Arena { get; set; } = "";
+                }
+
+                [PrimaryKey] public ushort Year { get; set; }
+                [Check.IsNot("NBC", Path = "Abbreviation")] public HockeyTeam Champion { get; set; } = new();
+                [Check.IsNot(Conf.Central, Path = "Conference")] public HockeyTeam RunnerUp { get; set; } = new();
+                public ulong TotalGoals { get; set; }
+                public ulong TotalPenalties { get; set; }
+                public string MVP { get; set; } = "";
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class FishingRod {
+                public enum Style { Fly, CarbonFiber, Tenkara, SpinCast, Baitcast, Spinning, UltraLight, Ice, Telescopic }
+
+                public class Company {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public string CEO { get; set; } = "";
+                    public DateTime Founded { get; set; }
+                    public decimal Revenue { get; set; }
+                    public ulong NumEmployees { get; set; }
+                    public ulong NumFactories { get; set; }
+                }
+                public record struct Info(Company Manufacturer, Guid SerialNumber);
+
+                [PrimaryKey] public Guid UniversalID { get; set; }
+                public double Length { get; set; }
+                public double Weight { get; set; }
+                public ushort NumFishCaught { get; set; }
+                [Check.IsNot(false, Path = "Manufacturer")] public Info ManfucaturingInfo { get; set; }
+                public Style RodType { get; set; }
             }
 
             // Test Scenario: Applied to Nullable Fields (✓constrained✓)
@@ -4472,6 +5969,59 @@ namespace UT.Kvasir.Translation {
                 public Reason Call { get; set; }
             }
 
+            // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+            public class Planetarium {
+                public class Person {
+                    [PrimaryKey] public string FirstName { get; set; } = "";
+                    [PrimaryKey] public string LastName { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid BuildingID { get; set; }
+                public double DomeRadius { get; set; }
+                public ulong MaxOccupancy { get; set; }
+                public DateTime Built { get; set; }
+                [Check.IsNot(100.50f, Path = "---")] public Person Architect { get; set; } = new();
+                public bool LargeSynopticSurveyTelescope { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class LiquorStore {
+                public enum Color { Red, White, Rose, Other }
+
+                public class Wine {
+                    [PrimaryKey] public Guid InternaionalWineRegistry { get; set; }
+                    public Color Color { get; set; }
+                    public string Vineyard { get; set; } = "";
+                    public ushort Year { get; set; }
+                }
+
+                [PrimaryKey] public Guid LiquorLicense { get; set; }
+                public decimal AnnualSales { get; set; }
+                public bool SellsWhiskey { get; set; }
+                public bool SellsAbsinthe { get; set; }
+                public bool SellsBourbon { get; set; }
+                public bool SellsScotch { get; set; }
+                public bool SellsBrandy { get; set; }
+                [Check.IsNot("Calabrio Farms", Path = "Vineyard")] public Wine? BestSellingWine { get; set; }
+                public ushort NumTimesRobbed { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+            public class Waterbending {
+                public class Person {
+                    [PrimaryKey] public Guid CharacterID { get; set; }
+                    public string Name { get; set; } = "";
+                    public uint ATLAAppearances { get; set; }
+                    public uint LOKAppearances { get; set; }
+                    public string VoiceActor { get; set; } = "";
+                }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                public int FirstAppearance { get; set; }
+                [Check.IsNot("Katara")] public Person StrongestPractitioner { get; set; } = new();
+                public bool UsesIce { get; set; }
+            }
+
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
             public class RestStop {
                 [PrimaryKey] public string Highway { get; set; } = "";
@@ -4561,7 +6111,7 @@ namespace UT.Kvasir.Translation {
                 public bool Goatee { get; set; }
             }
 
-            // Test Scenario: Applied to Nested String Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested String Scalar (✓constrained✓)
             public class BarGraph {
                 public record struct Info(string XAxisLabel, string XAxisUnit, string YAxisLabel, string YAxisUnit);
 
@@ -4571,7 +6121,7 @@ namespace UT.Kvasir.Translation {
                 public bool IsStackd { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-String Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-String Scalar (✗impermissible✗)
             public class BackyardBaseballPlayer {
                 public record struct Stats(byte Batting, byte Running, byte Pitching, byte Fielding);
 
@@ -4595,6 +6145,62 @@ namespace UT.Kvasir.Translation {
                 public DateTime FirstTapped { get; set; }
                 [Check.IsNonEmpty(Path = "Place.Coordinate")] public Location Where { get; set; }
                 public bool IsNationalized { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested String Scalar (✓constrained✓)
+            public class VacuumCleaner {
+                [Flags] public enum Material { Hardwood = 1, Carpet = 2, Tile = 4, Linoleum = 8 }
+
+                public class Company {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public bool Private { get; set; }
+                    public decimal Revenue { get; set; }
+                    public string Headquarters { get; set; } = "";
+                    public ulong Employees { get; set; }
+                }
+
+                [PrimaryKey] public Guid ProductID { get; set; }
+                public string Brand { get; set; } = "";
+                public string Model { get; set; } = "";
+                public double Decibels { get; set; }
+                public Material SupportedFloors { get; set; }
+                [Check.IsNonEmpty(Path = "Name")] public Company Manufacturer { get; set; } = new();
+                public bool IsWireless { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-String Scalar (✗impermissible✗)
+            public class Limerick {
+                public class Person {
+                    [PrimaryKey] public uint SSN { get; set; }
+                    public string FirstName { get; set; } = "";
+                    public string? MiddleName { get; set; }
+                    public string LastName { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid InternationalPoetryIdentificationNumber { get; set; }
+                [Check.IsNonEmpty(Path = "SSN")] public Person Author { get; set; } = new();
+                public string Line1 { get; set; } = "";
+                public string Line2 { get; set; } = "";
+                public string Line3 { get; set; } = "";
+                public string Line4 { get; set; } = "";
+                public string Line5 { get; set; } = "";
+                public string? WhereIsTheManFrom { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class RomanBaths {
+                public class Bathroom {
+                    [PrimaryKey] public float Latitude { get; set; }
+                    [PrimaryKey] public float Longitude { get; set; }
+                    public string? Name { get; set; }
+                    public DateTime Constructed { get; set; }
+                }
+                public record struct Daria(Bathroom Frigidarium, Bathroom Caldarium, Bathroom Tepidarium);
+
+                [PrimaryKey] public Guid ArchaeologicalIndex { get; set; }
+                public string Emperor { get; set; } = "";
+                public double NetVolume { get; set; }
+                [Check.IsNonEmpty(Path = "Caldarium")] public Daria Rooms { get; set; }
             }
 
             // Test Scenario: Applied to Field Data-Converted to String Type (✓constrained✓)
@@ -4667,6 +6273,52 @@ namespace UT.Kvasir.Translation {
                 [Check.IsNonEmpty] public Measurements Size { get; set; }
                 public Side RelationToGodzilla { get; set; }
                 public uint FilmAppearances { get; set; }
+            }
+
+            // Test Scenario: <Path> on Aggregate Does Not Exist (✗non-existent path✗)
+            public class Peerage {
+                public class Title {
+                    [PrimaryKey] public string Male { get; set; } = "";
+                    [PrimaryKey] public string Female { get; set; } = "";
+                    public short Rank { get; set; }
+                }
+
+                [PrimaryKey] public string Holder { get; set; } = "";
+                [Check.IsNonEmpty(Path = "---")] public Title PeerageTitle { get; set; } = new();
+                public bool Hereditary { get; set; }
+                public DateTime Obtained { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class BountyHunter {
+                public class License {
+                    [PrimaryKey] public Guid Number { get; set; }
+                    public string IssuingAgency { get; set; } = "";
+                    public DateTime IssuedOn { get; set; }
+                    public DateTime Expiration { get; set; }
+                }
+
+                [PrimaryKey] public string FirstName { get; set; } = "";
+                [PrimaryKey] public string LastName { get; set; } = "";
+                public double Height { get; set; }
+                public double Weight { get; set; }
+                public decimal CareerEarnings { get; set; }
+                public ushort Captures { get; set; }
+                [Check.IsNonEmpty(Path = "IssuingAgency")] public License Credentials { get; set; } = new();
+            }
+
+            // Test Scenario: <Path> on Aggregate Not Specified (✗missing path✗)
+            public class Linker {
+                public class Language {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public ushort Version { get; set; }
+                }
+
+                [PrimaryKey] public string BinaryName { get; set; } = "";
+                public string Organization { get; set; } = "";
+                [Check.IsNonEmpty] public Language TargetLanguage { get; set; } = new();
+                public double HelloWorldLinkingDuration { get; set; }
+                public bool StandardsCompliant { get; set; }
             }
 
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
@@ -4755,7 +6407,7 @@ namespace UT.Kvasir.Translation {
                 public uint NumEpisodes { get; set; }
             }
 
-            // Test Scenario: Applied to Nested String Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested String Scalar (✓constrained✓)
             public class Dubbing {
                 public record struct VoiceOverArtist(string FirstName, char MiddleInitial, string LastName);
 
@@ -4768,7 +6420,7 @@ namespace UT.Kvasir.Translation {
                 public bool IsAnime { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-String Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-String Scalar (✗impermissible✗)
             public class BaseballMogul {
                 public record struct SemVer(ushort Major, ushort Minor, ushort Patch, DateTime Release);
 
@@ -4791,6 +6443,57 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Magic { get; set; } = "";
                 public Strength HardOrSoft { get; set; }
                 [Check.LengthIsAtLeast(1898400, Path = "Zeroth")] public Laws SandersonsLaws { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested String Scalar (✓constrained✓)
+            public class TEDTalk {
+                public class Person {
+                    [PrimaryKey] public string FirstName { get; set; } = "";
+                    [PrimaryKey] public string LastName { get; set; } = "";
+                    public DateTime Birthday { get; set; }
+                }
+
+                [PrimaryKey] public Guid TalkID { get; set; }
+                public DateTime Time { get; set; }
+                public bool IsTedX { get; set; }
+                [Check.LengthIsAtLeast(14, Path = "LastName")] public Person Speaker { get; set; } = new();
+                public string TalkTitle { get; set; } = "";
+                public double Duration { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-String Scalar (✗impermissible✗)
+            public class Arrondissement {
+                public class FrenchDepartment {
+                    [PrimaryKey] public string Nom { get; set; } = "";
+                    [PrimaryKey] public ulong Population { get; set; }
+                    public ushort Arrondissements { get; set; }
+                    public ulong Area { get; set; }
+                }
+
+                [PrimaryKey] public string Nom { get; set; } = "";
+                [Check.LengthIsAtLeast(189466, Path = "Population")] public FrenchDepartment Department { get; set; } = new();
+                public ushort Communes { get; set; }
+                public ulong Population { get; set; }
+                public ulong Area { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class Constellation {
+                public class Star {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    [PrimaryKey] public uint MessierNumber { get; set; }
+                    public double Declination { get; set; }
+                    public double ApparentMagnitude { get; set; }
+                    public double Distance { get; set; }
+                }
+                public record struct Asterism(string Name, Star CentralStar, int NumStars, bool NorthernHemisphere);
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                public uint NumStars { get; set; }
+                public bool InZodiac { get; set; }
+                [Check.LengthIsAtLeast(60, Path = "CentralStar")] public Asterism? MainAsterism { get; set; }
+                public double Declination { get; set; }
+                public string? MeteorShower { get; set; }
             }
 
             // Test Scenario: Applied to Field Data-Converted to String Type (✓constrained✓)
@@ -4853,7 +6556,7 @@ namespace UT.Kvasir.Translation {
 
             // Test Scenario: <Path> on Aggregate Does Not Exist (✗non-existent path✗)
             public class Cactus {
-                [Flags] public enum Desert { Sahara, Kalahari, Mojave, Gobi, Negev, Namib, Atacama, Sonoran, Arabian }
+                [Flags] public enum Desert { Sahara = 1, Kalahari = 2, Mojave = 4, Gobi = 8, Negev = 16, Namib = 32, Atacama = 64, Sonoran = 128, Arabian = 256 }
                 public record struct Taxonomy(string Genus, string Species);
 
                 [Check.LengthIsAtLeast(5, Path = "---")] public Taxonomy ScientificName { get; set; }
@@ -4877,6 +6580,60 @@ namespace UT.Kvasir.Translation {
                 [Check.LengthIsAtLeast(100)] public Slot Karpas { get; set; }
                 public Slot Matzah { get; set; }
                 public Slot? Tapuz { get; set; }
+            }
+
+            // Test Scenario: <Path> on Aggregate Does Not Exist (✗non-existent path✗)
+            public class Crusade {
+                public class Ruler {
+                    [PrimaryKey] public string RegnalName { get; set; } = "";
+                    [PrimaryKey] public uint RegnalNumber { get; set; }
+                    public DateTime ReignBegin { get; set; }
+                    public DateTime ReignEnd { get; set; }
+                    public string Polity { get; set; } = "";
+                }
+
+                [PrimaryKey] public byte Index { get; set; }
+                public Ruler CrusadersLeader { get; set; } = new();
+                [Check.LengthIsAtLeast(16, Path = "---")] public Ruler MuslimLeader { get; set; } = new();
+                public Ruler HolyLandLeader { get; set; } = new();
+                public DateTime Begin { get; set; }
+                public bool CrusadersClaimJerusalem { get; set; }
+                public ulong Casualties { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class StateOfTheUnion {
+                public class Secretary {
+                    [PrimaryKey] public string FirstName { get; set; } = "";
+                    [PrimaryKey] public string LastName { get; set; } = "";
+                    public DateTime Confirmed { get; set; }
+                    public string Department { get; set; } = "";
+                    public double ConfirmationPcnt { get; set; }
+                }
+
+                [PrimaryKey] public ushort Year { get; set; }
+                public string President { get; set; } = "";
+                public ulong Length { get; set; }
+                public ushort ApplauseBreaks { get; set; }
+                [Check.LengthIsAtLeast(31, Path = "Department")] public Secretary DesignatedSurvivor { get; set; } = new();
+            }
+
+            // Test Scenario: <Path> on Aggregate Not Specified (✗missing path✗)
+            public class Triptych {
+                public class Panel {
+                    [PrimaryKey] public string Title { get; set; } = "";
+                    public double Length { get; set; }
+                    public double Height { get; set; }
+                    public sbyte NumPeopleDepicted { get; set; }
+                }
+
+                [PrimaryKey] public string Title { get; set; } = "";
+                public string Artist { get; set; } = "";
+                public DateTime Completed { get; set; }
+                public Panel LeftPanel { get; set; } = new();
+                [Check.LengthIsAtLeast(1892400)] public Panel MiddlePanel { get; set; } = new();
+                public Panel RightPanel { get; set; } = new();
+                public decimal Appraisal { get; set; }
             }
 
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
@@ -4966,7 +6723,7 @@ namespace UT.Kvasir.Translation {
                 [Check.LengthIsAtMost(50)] public Type Classification { get; set; }
             }
 
-            // Test Scenario: Applied to Nested String Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested String Scalar (✓constrained✓)
             public class MafiaFamily {
                 public struct Person {
                     public string FirstName { get; set; }
@@ -4981,7 +6738,7 @@ namespace UT.Kvasir.Translation {
                 public ulong NumMurders { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-String Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-String Scalar (✗impermissible✗)
             public class Kayak {
                 public record struct Seat(float Depth, double Radius);
 
@@ -5004,6 +6761,55 @@ namespace UT.Kvasir.Translation {
                 [Check.LengthIsAtMost(31, Path = "Name")] public Player CoverPlayer { get; set; }
                 public decimal TotalSales { get; set; }
                 public double Rating { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested String Scalar (✓constrained✓)
+            public class Denarian {
+                public class FallenAngel {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public string Title { get; set; } = "";
+                    public ulong Age { get; set; }
+                }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                public string DemonicForm { get; set; } = "";
+                [Check.LengthIsAtMost(673, Path = "Name")] public FallenAngel Fallen { get; set; } = new();
+                public DateTime PickedUpCoin { get; set; }
+                public string FirstAppearance { get; set; } = "";
+                public ulong WordsSpoken { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-String Scalar (✗impermissible✗)
+            public class IceCreamSundae {
+                public class Flavor {
+                    [PrimaryKey] public Guid ID { get; set; }
+                    public string Name { get; set; } = "";
+                    public string MixIn { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid SundaeID { get; set; }
+                public Flavor Scoop1 { get; set; } = new();
+                public Flavor Scoop2 { get; set; } = new();
+                [Check.LengthIsAtMost(4, Path = "ID")] public Flavor Scoop3 { get; set; } = new();
+                public bool IsBananaSplit { get; set; }
+                public uint CalorieCount { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class Orgasm {
+                public enum Manner { Oral, Vaginal, Anal, Mammary, Digital, Psychological }
+
+                public class Person {
+                    [PrimaryKey] public string GivenName { get; set; } = "";
+                    [PrimaryKey] public string Surname { get; set; } = "";
+                }
+                public record struct Individual(Person Who);
+
+                [PrimaryKey] public DateTime ExactTimestamp { get; set; }
+                [Check.LengthIsAtMost(5029, Path = "Who")] public Individual Receiver { get; set; }
+                public Manner Method { get; set; }
+                public double LiquidVolume { get; set; }
+                public bool ResultedInConception { get; set; }
             }
 
             // Test Scenario: Applied to Field Data-Converted to String Type (✓constrained✓)
@@ -5068,8 +6874,8 @@ namespace UT.Kvasir.Translation {
 
             // Test Scenario: <Path> on Aggregate Does Not Exist (✗non-existent path✗)
             public class ImaginaryFriend {
-                [Flags] public enum Color { Red, Orange, Yellow, Green, Blue, Purple, White, Black, Gray, Pink }
-                [Flags] public enum Thing { Claws, Horns, OneEye, Spots, Superpowers }
+                [Flags] public enum Color { Red = 1, Orange = 2, Yellow = 4, Green = 8, Blue = 16, Purple = 32, White = 64, Black = 128, Gray = 256, Pink = 512 }
+                [Flags] public enum Thing { Claws = 1, Horns = 2, OneEye = 4, Spots = 8, Superpowers = 16 }
                 public record struct Description(Color Color, double Height, double Weight, Thing Abilities);
 
                 [PrimaryKey] public uint ID { get; set; }
@@ -5094,6 +6900,56 @@ namespace UT.Kvasir.Translation {
                 public Segment? Weather { get; set; }
                 public Segment? Traffic { get; set; }
                 public Segment? LocalInterest { get; set; }
+            }
+
+            // Test Scenario: <Path> on Aggregate Does Not Exist (✗non-existent path✗)
+            public class PhaseDiagram {
+                public class Point {
+                    [PrimaryKey] public double PressurePascals { get; set; }
+                    [PrimaryKey] public double TemperatureKelvin { get; set; }
+                }
+
+                [PrimaryKey] public string Material { get; set; } = "";
+                public Point BoilingPoint { get; set; } = new();
+                public Point FreezingPoint { get; set; } = new();
+                public Point TriplePoint { get; set; } = new();
+                [Check.LengthIsAtMost(63, Path = "---")] public Point CriticalPoint { get; set; } = new();
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class Sundial {
+                public class Coordinate {
+                    [PrimaryKey] public float Latitude { get; set; }
+                    [PrimaryKey] public float Longitude { get; set; }
+                    public string? Identifier { get; set; }
+                }
+
+                [PrimaryKey] public Guid SundialID { get; set; }
+                [Check.LengthIsAtMost(171, Path = "Identifier")] public Coordinate CenterLocation { get; set; } = new();
+                public string? Constructor { get; set; }
+                public double Accuracy { get; set; }
+                public double Radius { get; set; }
+            }
+
+            // Test Scenario: <Path> on Aggregate Not Specified (✗missing path✗)
+            public class Zoombini {
+                public enum Hair { Spikey, Ponytail, BowlCut, BabyTuft, Hat }
+                public enum Eyes { Wide, Single, Sleepy, Glasses, Sunglasses }
+                public enum Color { Orange, Green, Red, Purple, Blue }
+                public enum Legs { Feet, RollerSkates, Spring, Cycle, Twirler }
+
+                public class Level {
+                    [PrimaryKey] public byte Number { get; set; }
+                    public byte Checkpoint { get; set; }
+                    public string Name { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid ZoombiniID { get; set; }
+                public Hair Hairstyle { get; set; }
+                public Eyes KindOfEyes { get; set; }
+                public Color Nose { get; set; }
+                public Legs LegKind { get; set; }
+                [Check.LengthIsAtMost(3)] public Level? LostAt { get; set; }
             }
 
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
@@ -5184,7 +7040,7 @@ namespace UT.Kvasir.Translation {
                 public string? XMan { get; set; }
             }
 
-            // Test Scenario: Applied to Nested String Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested String Scalar (✓constrained✓)
             public class LiteraryTrope {
                 public record struct Usage(string Work, string Author);
 
@@ -5195,7 +7051,7 @@ namespace UT.Kvasir.Translation {
                 public ulong Appearances { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Non-String Scalar (✗impermissible✗)
+            // Test Scenario: Applied to Aggregate-Nested Non-String Scalar (✗impermissible✗)
             public class OvernightCamp {
                 public record struct Program(uint Sessions, ushort WeeksPerSession, ulong MaxCampers, byte NumFieldTrips);
 
@@ -5217,6 +7073,58 @@ namespace UT.Kvasir.Translation {
                 public string? Practice { get; set; }
                 public Specialty Focus { get; set; }
                 [Check.LengthIsBetween(7, 18, Path = "Doctorate")] public Degrees Qualifications { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested String Scalar (✓constrained✓)
+            public class Onomatopoeia {
+                public class Entry {
+                    [PrimaryKey] public string Dictionary { get; set; } = "";
+                    [PrimaryKey] public uint Page { get; set; }
+                    [PrimaryKey] public byte WordOnPage { get; set; }
+                    public short NumDefinitions { get; set; }
+                }
+
+                [PrimaryKey] public string Word { get; set; } = "";
+                public string SoundOf { get; set; } = "";
+                [Check.LengthIsBetween(14, 53, Path = "Dictionary")] public Entry DictionaryEntry { get; set; } = new();
+                public string Language { get; set; } = "";
+                public bool IsAnimalSound { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Non-String Scalar (✗impermissible✗)
+            public class TrivialPursuitPie {
+                public class Question {
+                    [PrimaryKey] public char CardID { get; set; }
+                    public string QuestionText { get; set; } = "";
+                    public string CorrectAnswer { get; set; } = "";
+                }
+
+                [PrimaryKey] public DateTime GameDate { get; set; }
+                [PrimaryKey] public string Player { get; set; } = "";
+                public Question? GeographyWedge { get; set; }
+                [Check.LengthIsBetween(1, 100, Path = "CardID")] public Question? HistoryWedge { get; set; }
+                public Question? SportsLeisureWedge { get; set; }
+                public Question? ScienceNatureWedge { get; set; }
+                public Question? EntertainmentWedge { get; set; }
+                public Question? ArtsLiteratureWedge { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class SumoWrestler {
+                public class Number {
+                    [PrimaryKey] public bool IsPositive { get; set; }
+                    [PrimaryKey] public ulong Integral { get; set; }
+                    [PrimaryKey] public double Decimal { get; set; }
+                }
+                public record struct Date(Number Year, Number Month, Number day);
+
+                [PrimaryKey] public Guid SumoID { get; set; }
+                public string Name { get; set; } = "";
+                [Check.LengthIsBetween(35, 192, Path = "Month")] public Date DOB { get; set; } = new();
+                public ulong CareerWins { get; set; }
+                public ulong CareerLosses { get; set; }
+                public double MaxWeight { get; set; }
+                public bool Yokozuna { get; set; }
             }
 
             // Test Scenario: Applied to Field Data-Converted to String Type (✓constrained✓)
@@ -5316,6 +7224,57 @@ namespace UT.Kvasir.Translation {
                 public bool InEpicOfGilgamesh { get; set; }
             }
 
+            // Test Scenario: <Path> on Aggregate Does Not Exist (✗non-existent path✗)
+            public class HeatWave {
+                public enum Unit { Fahrenheit, Celsius, Kelvin }
+
+                public class Temperature {
+                    [PrimaryKey] public float Magnitude { get; set; }
+                    [PrimaryKey] public Unit Unit { get; set; }
+                }
+
+                [PrimaryKey] public Guid HeatWavID { get; set; }
+                public Temperature High { get; set; } = new();
+                [Check.LengthIsBetween(2, 12, Path = "---")] public Temperature Low { get; set; } = new();
+                public DateTime Start { get; set; }
+                public DateTime End { get; set; }
+                public ulong Deaths { get; set; }
+                public bool RecordTemperature { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class Sprachbund {
+                public class Language {
+                    [PrimaryKey] public string Exonym { get; set; } = "";
+                    public string Endonym { get; set; } = "";
+                    public string Glottolog { get; set; } = "";
+                    public ulong WorldwideSpeakers { get; set; }
+                }
+
+                [PrimaryKey] public string SprachbundName { get; set; } = "";
+                public ushort LanguagesEncompassed { get; set; }
+                public ulong TotalSpeakers { get; set; }
+                public ulong LandArea { get; set; }
+                [Check.LengthIsBetween(7, 41, Path = "Endonym")] public Language? Progenitor { get; set; }
+                public string? AttributedLinguist { get; set; }
+            }
+
+            // Test Scenario: <Path> on Aggregate Not Specified (✗missing path✗)
+            public class Leprechaun {
+                public class WalkingStick {
+                    [PrimaryKey] public Guid StickID { get; set; }
+                    public double Length { get; set; }
+                    public string Material { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid LeprechaunID { get; set; }
+                public string Name { get; set; } = "";
+                public bool BornInIreland { get; set; }
+                public decimal PotOfGold { get; set; }
+                public ushort Height { get; set; }
+                [Check.LengthIsBetween(891, 39654)] public WalkingStick Shillelagh { get; set; } = new();
+            }
+
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
             public class PeanutButter {
                 [PrimaryKey] public Guid ProductID { get; set; }
@@ -5398,7 +7357,7 @@ namespace UT.Kvasir.Translation {
                 [Check.IsOneOf(ToothType.Incisor, ToothType.Molar, ToothType.Canine, ToothType.Bicuspid)] public ToothType Type { get; set; }
             }
 
-            // Test Scenario: Applied to Nested Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested Scalar (✓constrained✓)
             public class Earring {
                 public enum Kind { ClipOn, Stud, Latch }
                 public struct Composition {
@@ -5434,6 +7393,38 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public string Creator { get; set; } = "";
                 public All Alphabet { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Scalar (✓constrained✓)
+            public class FerrisWheel {
+                public class Person {
+                    [PrimaryKey] public string FirstName { get; set; } = "";
+                    [PrimaryKey] public string LastName { get; set; } = "";
+                }
+
+                [PrimaryKey] public Guid WheelID { get; set; }
+                public double Diameter { get; set; }
+                public ushort NumSeat { get; set; }
+                public ushort WeightLimit { get; set; }
+                public DateTime Opened { get; set; }
+                [Check.IsOneOf("Alexander", "Randall", "Corrine", Path = "FirstName")] public Person Designer { get; set; } = new();
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class Pulsar {
+                public class Observatory {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    [PrimaryKey] public string ChiefAstronomer { get; set; } = "";
+                    public DateTime Groundbreaking { get; set; }
+                    public ushort NumTelescopes { get; set; }
+                }
+                public record struct OBS(Observatory Observatory);
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                [Check.IsOneOf(1, -3, 18, 220, 6, Path = "Observatory")] public OBS FirstObservedAt { get; set; }
+                public double Declination { get; set; }
+                public ulong Distance { get; set; }
+                public double SpinRate { get; set; }
             }
 
             // Test Scenario: Applied to Nullable Fields (✓constrained✓)
@@ -5657,6 +7648,63 @@ namespace UT.Kvasir.Translation {
                 public string Source { get; set; } = "";
             }
 
+            // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+            public class Safari {
+                public class Animal {
+                    public string CommonName { get; set; } = "";
+                    [PrimaryKey] public string Genus { get; set; } = "";
+                    [PrimaryKey] public string Species { get; set; } = "";
+                    public ulong Viewings { get; set; }
+                }
+
+                [PrimaryKey] public Guid SafariID { get; set; }
+                public string Guide { get; set; } = "";
+                public Animal Zebras { get; set; } = new();
+                public Animal Lions { get; set; } = new();
+                public Animal Giraffes { get; set; } = new();
+                [Check.IsOneOf('x', 'p', 'L', '3', '_', '$', '/', Path = "---")] public Animal Elephants { get; set; } = new();
+                public Animal Rhinoceroses { get; set; } = new();
+                public Animal Gazelles { get; set; } = new();
+                public Animal Hippopotamuses { get; set; } = new();
+                public uint Duration { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class Adverb {
+                public enum POS { Verb, Adverb, Noun, Adjective, Interjection, Conjunction, Interrogative, Article, Pronoun }
+                public enum Kind { Pronominal, Flat, Conjunctive, Locative }
+
+                public class Suffix {
+                    [PrimaryKey] public string Chars { get; set; } = "";
+                    public POS PartOfSpeech { get; set; }
+                }
+
+                [PrimaryKey] public string Word { get; set; } = "";
+                public string AdjectivalForm { get; set; } = "";
+                [Check.IsOneOf(POS.Adverb, Path = "PartOfSpeech")] public Suffix WordSuffix { get; set; } = new();
+                public string Language { get; set; } = "";
+            }
+
+            // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+            public class Swamp {
+                public enum Water { Salt, Fresh, Brackish }
+
+                public class Tree {
+                    public string CommonName { get; set;} = "";
+                    [PrimaryKey] public string Genus { get; set; } = "";
+                    [PrimaryKey] public string Species { get; set; } = "";
+                }
+
+                [PrimaryKey] public string Name { get; set; } = "";
+                public Water WaterType { get; set; }
+                public ulong Area { get; set; }
+                public double WaterVolume { get; set; }
+                public float Latitude { get; set; }
+                public float Longitude { get; set; }
+                [Check.IsOneOf(true, false)] public Tree PredominantTree { get; set; } = new();
+                public bool IsProtectedArea { get; set; }
+            }
+
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
             public class Guillotine {
                 [PrimaryKey] public Guid ItemID { get; set; }
@@ -5737,7 +7785,7 @@ namespace UT.Kvasir.Translation {
                 public string ImageURL { get; set; } = "";
             }
 
-            // Test Scenario: Applied to Nested Scalar (✓constrained✓)
+            // Test Scenario: Applied to Aggregate-Nested Scalar (✓constrained✓)
             public class Condiment {
                 [Flags] public enum Taste { Sweet = 1, Sour = 2, Salty = 4, Umami = 16, Bitter = 32 }
                 public record struct Label(sbyte Calories, sbyte Protein, sbyte Sugar, sbyte Carbohydrates);
@@ -5762,6 +7810,40 @@ namespace UT.Kvasir.Translation {
                 [Check.IsNotOneOf(true, false, Path = "Color")] public InkDefinition Ink { get; set; }
                 public string Artist { get; set; } = "";
                 public TattooKind Kind { get; set; }
+            }
+
+            // Test Scenario: Applied to Reference-Nested Scalar (✓constrained✓)
+            public class Lifeguard {
+                public class Pool {
+                    [PrimaryKey] public uint PoolNumber { get; set; }
+                    public bool IsPublic { get; set; }
+                    public bool Indoors { get; set; }
+                    public ushort Capacity { get; set; }
+                    public ulong Volume { get; set; }
+                }
+
+                [PrimaryKey] public Guid License { get; set; }
+                public string FirstName { get; set; } = "";
+                public string LastName { get; set; } = "";
+                public int SwimLevel { get; set; }
+                [Check.IsNotOneOf(7U, 17U, 27U, 37U, Path = "PoolNumber")] public Pool? FirstJob { get; set; }
+                public ushort Savings { get; set; }
+            }
+
+            // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+            public class NurseyRhyme {
+                public class Character {
+                    [PrimaryKey] public string Name { get; set; } = "";
+                    public sbyte Mentions { get; set; }
+                }
+                public record struct One(Character Character);
+
+                [PrimaryKey] public string Title { get; set; } = "";
+                public string Text { get; set; } = "";
+                [Check.IsNotOneOf("2003-04-17", "1888-08-18", Path = "Character")] public One MainCharacter { get; set; } = new();
+                public byte LowerAg { get; set; }
+                public byte UpperAge { get; set; }
+                public bool MotherGoose { get; set; }
             }
 
             // Test Scenario: Applied to Nullable Fields (✓constrained✓)
@@ -6005,6 +8087,54 @@ namespace UT.Kvasir.Translation {
                 [Check.IsNotOneOf('u', '=', 'F')] public Page Round { get; set; }
             }
 
+            // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+            public class Pencil {
+                public class Graphite {
+                    [PrimaryKey] public Guid ID { get; set; }
+                    public double Size { get; set; }
+                    public bool Natural { get; set; }
+                }
+
+                [PrimaryKey] public Guid PencilID { get; set; }
+                public bool IsMechanical { get; set; }
+                [Check.IsNotOneOf('A', 'B', 'C', 'D', 'E', 'F', Path = "---")] public Graphite Lead { get; set; } = new();
+                public string Brand { get; set; } = "";
+                public bool BeenToSpace { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+            public class Mitzvah {
+                public class Verse {
+                    [PrimaryKey] public string Book { get; set; } = "";
+                    [PrimaryKey] public uint Chapter { get; set; }
+                    [PrimaryKey] public uint Number { get; set; }
+                    public string English { get; set; } = "";
+                    public string Hebrew { get; set; } = "";
+                }
+
+                [PrimaryKey] public ushort Number { get; set; }
+                [Check.IsNotOneOf("Bereshit Bara Elohim", Path = "Hebrew")] public Verse Commandment { get; set; } = new();
+                public bool StillApplicable { get; set; }
+            }
+
+            // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+            public class Eunuch {
+                public enum Culture { Chinese, Japanese, Vietnamese, Tibetan, Mesoamerican, European, Fictional }
+
+                public class Person {
+                    [PrimaryKey] public string FirstName { get; set; } = "";
+                    [PrimaryKey] public string LastName { get; set; } = "";
+                }
+
+                [PrimaryKey] public string FirstName { get; set; } = "";
+                [PrimaryKey] public string LastName { get; set; } = "";
+                public Culture From { get; set; }
+                public DateTime DateOfCastration { get; set; }
+                [Check.IsNotOneOf(1.337, -98174.84, 0.0)] public Person Castrator { get; set; } = new();
+                public bool IsNobleman { get; set; }
+                public bool IsServant { get; set; }
+            }
+
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
             public class Pie {
                 [PrimaryKey] public int ID { get; set; }
@@ -6036,7 +8166,7 @@ namespace UT.Kvasir.Translation {
             public bool IsChorus { get; set; }
         }
 
-        // Test Scenario: Applied to Nested Scalar (✓constrained✓)
+        // Test Scenario: Applied to Aggregate-Nested Scalar (✓constrained✓)
         public class Asteroid {
             public struct OrbitalDescription {
                 public double Aphelion { get; set; }
@@ -6067,6 +8197,43 @@ namespace UT.Kvasir.Translation {
             public string Country { get; set; } = "";
         }
 
+        // Test Scenario: Applied to Reference-Nested Scalar (✓constrained✓)
+        public class Stock {
+            public class Exchange {
+                [PrimaryKey] public Guid ExchangeID { get; set; }
+                public string GatewayTech { get; set; } = "";
+                public DateTime Opening { get; set; }
+                public decimal DailyVolume { get; set; }
+            }
+            public record struct Listing(Exchange Exchange, decimal Bid, decimal Ask, double MarketCap, ulong Shares);
+
+            [PrimaryKey] public string Symbol { get; set; } = "";
+            public string Company { get; set; } = "";
+            public Listing? Chicago { get; set; }
+            public Listing? NewYork { get; set; }
+            public Listing? London { get; set; }
+            [Check(typeof(CustomCheck), Path = "Exchange.ExchangeID")] public Listing? Sydney { get; set; }
+            public Listing? HongKong { get; set; }
+        }
+
+        // Test Scenario: Applied to Nested Reference (✗impermissible✗)
+        public class Werewolf {
+            public enum Control { Lunar, Emotional, AtWill, Injurious }
+
+            public class Lycanthropy {
+                [PrimaryKey] public string Strain { get; set; } = "";
+                public string ZoonoticOrigin { get; set; } = "";
+                public bool Curable { get; set; }
+                public Control MannerOfControl { get; set; }
+            }
+            public record struct Curse(Lycanthropy Source, DateTime Afflicted);
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            [Check(typeof(CustomCheck), Path = "Source")] public Curse Lycan { get; set; }
+            public ushort Weight { get; set; }
+            public ulong Kills { get; set; }
+        }
+
         // Test Scenario: Scalar Property Constrained Multiple Times (✓both applied✓)
         public class TarotCard {
             [PrimaryKey] public int DeckID { get; set; }
@@ -6084,6 +8251,20 @@ namespace UT.Kvasir.Translation {
             public bool IsOrdered { get; set; }
             public bool IsAssociative { get; set; }
             public bool IsContiguous { get; set; }
+        }
+
+        // Test Scenario: Applied to Name-Changed Field (✓constrained✓)
+        public class AronKodesh {
+            public struct Door {
+                public string Height { get; set; }
+                public string Width { get; set; }
+                public bool StainedGlass { get; set; }
+            }
+
+            [PrimaryKey] public Guid ArkID { get; set; }
+            public ushort NumTorahs { get; set; }
+            [Name("HeightOf", Path = "Height"), Check(typeof(CustomCheck), Path = "Height")] public Door LeftDoor { get; set; }
+            public Door RightDoor { get; set; }
         }
 
         // Test Scenario: Constraint Generator is not an `IConstraintGenerator` (✗illegal✗)
@@ -6144,7 +8325,7 @@ namespace UT.Kvasir.Translation {
 
         // Test Scenario: <Path> on Aggregate Does Not Exist (✗non-existent path✗)
         public class StarCrossedLovers {
-            [Flags] public enum Feud { Familial, Religious, Class, SportsFandom, Culinary, Corporate, Political }
+            [Flags] public enum Feud { Familial = 1, Religious = 2, Class = 4, SportsFandom = 8, Culinary = 16, Corporate = 32, Political = 64 }
             public record struct Name(string FirstName, char MiddleInitial, string LastName);
 
             public Name Lover1 { get; set; }
@@ -6165,6 +8346,64 @@ namespace UT.Kvasir.Translation {
             public Necrotization Torso { get; set; }
             [Check(typeof(CustomCheck))] public Necrotization Legs { get; set; }
             public Necrotization Arms { get; set; }
+        }
+
+        // Test Scenario: <Path> on Reference Does Not Exist (✗non-existent path✗)
+        public class Piano {
+            public class Person {
+                [PrimaryKey] public string FirstName { get; set; } = "";
+                [PrimaryKey] public string LastName { get; set; } = "";
+            }
+            public class Company {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public Person CEO { get; set; } = new();
+                public ulong Employees { get; set; }
+                public decimal Revenue { get; set; }
+            }
+
+            [PrimaryKey] public Guid PianoID { get; set; }
+            public ulong Weight { get; set; }
+            public byte BlackKeys { get; set; }
+            public byte WhiteKeys { get; set; }
+            [Check(typeof(Company), Path = "---")] public Company Manufacturer { get; set; } = new();
+            public decimal MarketValue { get; set; }
+            public bool IsReligious { get; set; }
+        }
+
+        // Test Scenario: <Path> on Reference Refers to Non-Primary-Key Field (✗non-existent path✗)
+        public class Exorcism {
+            [Flags] public enum Symptom { None = 0, Tongues = 1, Lesions = 2, NoPupils = 4, SpinningHead = 8, Levitation = 16, Necrosis = 32 }
+
+            public class Possession {
+                [PrimaryKey] public Guid ChurchRecord { get; set; }
+                public string Demon { get; set; } = "";
+                public DateTime Incipience { get; set; }
+                public Symptom Symptoms { get; set; }
+            }
+
+            [PrimaryKey] public string Possessed { get; set; } = "";
+            [PrimaryKey] public string Exorciser { get; set; } = "";
+            [PrimaryKey] public DateTime When { get; set; }
+            [Check(typeof(CustomCheck), Path = "Incipience")] public Possession Target { get; set; } = new();
+            public bool Successful { get; set; }
+            public bool Fatal { get; set; }
+        }
+
+        // Test Scenario: <Path> on Reference Not Specified (✗missing path✗)
+        public class Pond {
+            public class Coordinate {
+                [PrimaryKey] public float Latitude { get; set; }
+                [PrimaryKey] public float Longitude { get; set; }
+            }
+
+            [PrimaryKey] public Guid PondID { get; set; }
+            public string Name { get; set; } = "";
+            public double Depth { get; set; }
+            public double Area { get; set; }
+            public double AmountPondScum { get; set; }
+            public ushort NumDucks { get; set; }
+            public ushort NumFishes { get; set; }
+            [Check(typeof(CustomCheck))] public Coordinate Location { get; set; } = new();
         }
     }
 
@@ -6716,6 +8955,63 @@ namespace UT.Kvasir.Translation {
             [Check.IsNotOneOf("Winter", "Spring", "Fall", "Year-Round"), AsString] public Season SignSeason { get; set; }
             public char ZodiacSymbol { get; set; }
             public string HinduSolarEquivalent { get; set; } = "";
+        }
+    }
+
+    internal static class ReferenceCycles {
+        // Test Scenario: Self-Referential Entity with Cycle Length of 1 (✗non-acyclic✗)
+        public class Constitution {
+            [PrimaryKey] public string Country { get; set; } = "";
+            [PrimaryKey] public DateTime Ratified { get; set; }
+            public sbyte Articles { get; set; }
+            public sbyte Amendments { get; set; }
+            public Constitution? Precursor { get; set; }
+            public string FullText { get; set; } = "";
+        }
+
+        // Test Scenario: Self-Referential Entity with Cycle Length of 2 (✗non-acyclic✗)
+        public class Niqqud {
+            [Flags] public enum Feature { Front = 1, Central = 2, Back = 4, High = 8, Low = 16, Voiceless = 32, Breathy = 64, Nasal = 128, Creaky = 256 }
+
+            public class Vowel {
+                [PrimaryKey] public char IPA { get; set; }
+                public Feature Features { get; set; }
+                public Niqqud? HebrewSymbol { get; set; }
+            }
+
+            [PrimaryKey] public char Symbol { get; set; }
+            public Vowel Pronunciation { get; set; } = new();
+            public bool StilInUse { get; set; }
+            public double RelativeFrequency { get; set; }
+            public ulong TorahAppearances { get; set; }
+        }
+
+        // Test Scenario: Self-Referential Entity with Cycle Length > 2 (✗non-acyclic✗)
+        public class RefugeeCamp {
+            public class CivilWar {
+                [PrimaryKey] public Guid WarID { get; set; }
+                public string BelligerentA { get; set; } = "";
+                public string BelligerentB { get; set; } = "";
+                public RefugeeCamp LargestRefugeeCamp { get; set; } = new();
+            }
+            public class Country {
+                [PrimaryKey] public string Name { get; set; } = "";
+                public string DomainSuffix { get; set; } = "";
+                public ulong Population { get; set; }
+                public ulong Area { get; set; }
+                public CivilWar? OngoingCivilWar { get; set; }
+            }
+            public class Person {
+                [PrimaryKey] public uint SSN { get; set; }
+                public string FirstName { get; set; } = "";
+                public string LastName { get; set; } = "";
+                public Country BirthCountry { get; set; } = new();
+            }
+
+            [PrimaryKey] public Guid CampID { get; set; }
+            public ulong NumRefugees { get; set; }
+            public Person Director { get; set; } = new();
+            public bool IsWartime { get; set; }
         }
     }
 }

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -5,7 +5,9 @@ Acid
 ACT
 Actor/Actress
 Address
+Adverb
 Aes Sedai
+AirBNB
 Airline
 Airplane
 Airport
@@ -20,13 +22,19 @@ Amino Acid
 Amusement Park
 Animal
 Animation (PowerPoint)
+Antibiotic
 Apocalypse
+Apostle
 Aquarium
 Aqueduct
+Aquifer
+Arch
 Archangel
 Archbishop
 Aria
 Armada
+Aron Kodesh
+Arrondissement
 Arthurian Knight
 Artiodactyl
 Asteroid
@@ -38,15 +46,18 @@ Auction Lot
 Avatar
 Azeotrope
 Aztec God
+Bachelorette
 Backyard Baseball Player
 Bacterium
 Bagel
 Balk
+Ballerina
 Ballet
 Bank Account
 Bankruptcy
 Bar Graph
 Barbecue Sauce
+Barbie
 Baryon
 Baseball Bat
 Baseball Card
@@ -70,7 +81,9 @@ Biography
 Biological Cycle
 Birth Control
 Blender
+Blood Drive
 Blood Type
+Bodhisattva
 Bond Girl
 Bone
 Book
@@ -78,17 +91,22 @@ Bookmark (web browsing)
 Borate
 Border Crossing
 Botanical Garden
+Bounty Hunter
 Bowl Game
 Bowling Frame
 Boxer
 Brassiere
 Bread
 Bridge
+Bug Spray
 Burrito
+Butterfly
 Button (UI)
 C++ Header File
 Cabinet Department
 Cactus
+Caesarean Section
+Calculator
 Calendar
 Caliphate
 Camera
@@ -97,12 +115,17 @@ Campfire
 Canal
 Cancer
 Candle
+Candy Bar
 Cannon
 Canterbury Tale
 Canyon
 Capacitor
+Capitol Building
+Car Accident
 Carbohydrate
+Carnival
 Carousel
+Cartel
 Casino
 Castle
 Cave
@@ -112,6 +135,7 @@ Cemetery
 Cenote
 Census
 Cereal
+Chakra
 Character (text)
 Check
 Chemical Element
@@ -121,8 +145,10 @@ Chinese Character
 Chinese Dynasty
 Chocolate
 Chopped Basket
+Chopsticks
 Christian Denomination
 Christmas Carol
+Chromosome
 Church
 Cider Mill
 CinemaSins
@@ -150,6 +176,8 @@ Concert Tour
 Condiment
 Confidence Interval
 Conlang
+Constellation
+Constitution
 Constitutional Amendment
 Coral Reef
 Country
@@ -160,6 +188,8 @@ Court Case
 Credit Card
 Crossword Clue
 Cruise
+Crusade
+Cryochamber
 Cryptid
 Cryptocurrency
 Currency
@@ -173,6 +203,8 @@ Dam
 Data Structure
 Database Field
 Date
+Decathlon
+Denarian
 Dentist
 Desert
 Diamond
@@ -180,6 +212,7 @@ Directory (file system)
 Distribution (probability)
 District Attorney
 DLL
+DMZ
 Doctor (Doctor Who)
 Documentary
 Dog Show
@@ -188,13 +221,16 @@ Donut
 Draft Pick
 Dragon
 Dreidel
+Druid (D&D)
 Drum
 Dubbing
 E-Mail
 Earring
 Earthquake
 Ecumenical Council
+Edible Arrangement
 Egyptian God
+Egyptian Pyramid
 Elevator
 Emotion
 Encomienda
@@ -202,16 +238,24 @@ Encryption
 Encyclopedia
 Enumeration
 Episode
+Escape Room
 Essay
 ETF
+Etiology
+Eunuch
 Eurovision Song Contest
 Excel Range
+Exorcism
+Experiment
 Expiration
 Eyeglasses
 Facebook Post
+Fact Check
 Fairy Tale
 Family Tree
 Federal Law
+Ferris Wheel
+Ferry
 Feruchemy
 Field Goal
 Fighter Jet
@@ -219,7 +263,9 @@ Final Four
 Final Jeopardy!
 Firearm
 Firefighter
+Fishing Rod
 Fitness Center
+Fitted Sheet
 Fjord
 Flash Mob
 Flashcard
@@ -228,21 +274,25 @@ Flood
 Flower
 Font
 Food Chain
+Food Pantry
 Fortune Cookie
 Fountain
 Fractal
 Fraction
 Fraternity
 Function (programming)
+Galaxy
 Gaming Console
 Garage Sale
 Gas Station
+Gatorade
 Gene
 Generation
 Genie
 Geocache
 Geologic Epoch
 Geyser
+Ghost (Danny Phantom)
 Git Commit
 Git Hook
 Gold Rush
@@ -250,6 +300,7 @@ Golden Raspberry
 Golf Course
 Golf Hole
 Grammatical Case
+Great Old One
 Greek God
 Greek Letter
 Guillotine
@@ -257,13 +308,18 @@ Guitar
 Gymnast
 Haiku
 Hall of Fame
+Happy Hour
 Hash Function
 Hash Map
+Hawaiian God
 Headphones
 Healing Potion (D&D)
+Heat Wave
 Hebrew Letter
 Hebrew Prayer
 Helicopter
+Hepatitis
+Hercule Poirot Mystery
 Hieroglyph
 Highway
 Hindu God
@@ -275,6 +331,7 @@ Holy Roman Emperor
 Home Run Derby
 Homeric Hymn
 Hominin
+Honest Trailer
 Hormone
 Hospital
 Hot Spring
@@ -285,26 +342,32 @@ HTML Element
 HTTP Error
 Hurricane
 Ice Age
+Ice Cream Sundae
 IDE
 Igloo
 Imaginary Friend
 Immaculate Grid
 Inator
 Infinity Stone
+Influenza
 Inmate
+Installation Wizard
 Insurance Policy
 Integer
 Integer Sequence
 Integral
+Intern
 Internet Craze
 IP Address
 iPhone
 IPO
 ISO Standard
 Isthmus
+Japanese Emperor
 Jedi
 Jigsaw Puzzle
 Joust
+Jukebox
 Kaiju
 Kanji
 Kayak
@@ -313,19 +376,28 @@ Key Signature
 Keystroke
 Kinesis
 King of England
+Kite
+Knife
 Knock-Knock Joke
 Labor of Heracles
 Lake
+Lamp
 Land Card (MTG)
 Language
+Law Firm
 Lease
 Legume
 Lens
+Leprechaun
 License Plate
+Lifeguard
 Ligament
+Limerick
+Linker
 Linux Distribution
 Lipstick
 Liquor
+Liquor Store
 Literary Trope
 Locale (computing)
 Localization
@@ -333,6 +405,7 @@ Lock (computing)
 Log-In Credentials
 Longbow
 Lottery Ticket
+Luau
 Lunar Crater
 Lyric
 Madden NFL
@@ -345,6 +418,7 @@ Marble League
 Marian Apparition
 Mark-Up Symbol
 Masked Singer
+Mass Extinction
 Massacre
 MasterClass
 Mausoleum
@@ -358,6 +432,8 @@ Mezuzah
 Military Base
 Milkshake
 Mint (currency)
+Mirror
+Mitzvah
 Monopoly Property
 Month
 Moon of Jupiter
@@ -377,6 +453,7 @@ Mustache
 Mutant (X-Men)
 Mythbusting
 National Anthem
+National Monument
 National Park
 Native American Tribe
 Nazca Line
@@ -386,13 +463,16 @@ Neurotoxin
 Neurotransmitter
 Newscast
 Newspaper
+Niqqud
 Nobel Prize
 Norse God
 Norse World
 Nuclear Power Plant
 NuGet Package
+Nursery Rhyme
 Obelisk
 Obi
+Ocean Current
 Oceanic Trench
 Oceanid
 Oil (cooking)
@@ -400,14 +480,18 @@ Oil Field
 Oil Spill
 Ointment
 Olympiad
+Onomatopoeia
 Opera
 Opioid
 Orchestra
+Orgasm
+Origami
 Orisha
 Orphanage
 Overnight Camp
 Pagoda
 Painting
+Pajamas
 Parashah
 Parking Garage
 Passport
@@ -417,15 +501,21 @@ Patreon
 Paycheck
 Peace Treaty
 Peanut Butter
+Peerage
 Penalty (NFL)
+Pencil
 Peninsula
 PEP
 Pepper
 Pharaoh
+Pharmacy
+Phase Diagram
 Philosopher
 Phobia
+Phone Booth
 Phone Number
 Phonetic Alphabet
+Piano
 Pie
 Pigment (biology)
 Pillow
@@ -434,15 +524,21 @@ Pirate
 Pizza
 Plane of Existence (D&D)
 Planeswalker
+Planetarium
 Platonic Dialogue
 Playing Card
+Playlist
 PO Box
 Podcast
+Poet Laurete
 Pokémon
 Poker Hand
 Police Officer
 Polygon
 Polyhedron
+Pond
+Pop Tart
+Popcorn
 Pope
 Potato
 Pregnancy Test
@@ -451,22 +547,28 @@ Presidential Election
 Printer
 Prison
 Process (computing)
-Programming Langauge
+Programming Language
+Prophecy
 Prophet
 Proto-Indo-European Root
 Pseudonym
 Pterosaur
+Pub Crawl
 Pulley
+Pulsar
 Quadratic Equation
 Quarterback
 Quatrain
+Rabbi
 Racehorse
 Racetrack (auto racing)
 Radio Station
 Rainforest
 Random Number Generator
+Ransomware
 Raptor
 Readymade
+Refugee Camp
 Repository
 Representative
 Resistor
@@ -476,19 +578,23 @@ Retail Product
 Ring of Power
 River
 Rollercoaster
+Roman Baths
 Roman Emperor
 Rorschach Ink Blot
 Royal House
 Rube Goldberg Machine
 Rune
+Runway
 Russian Tsar
 Sabermetric
+Safari
 Saint
 Salsa
 Satellite
 Scattergories Round
 Scholarship
 Scooby-Doo Movie
+Scorpion
 Scrabble Tile
 Screwdriver
 SCUBA Dive
@@ -498,6 +604,7 @@ Secret Hitler Game
 Secret Society
 Seder Plate
 Senator
+Serial Killer
 Set Card
 Seventh Inning Stretch
 Shampoo
@@ -505,6 +612,7 @@ Shard of Adonalsium
 Shark Tank Pitch
 Shark Week
 Shen Gong Wu
+Sherpa
 Shipwreck
 Shoe
 Shogunate
@@ -514,8 +622,10 @@ Ski Slope
 Skittles
 Skyscraper
 Slack Channel
+SlamBall Match
 Slave Revolt
 Slot Machine
+Slumber Party
 Smoothie
 Smurf
 Snake
@@ -533,19 +643,25 @@ Speedometer
 Spider-Man
 Sporcle Quiz
 Sports Bet
+Sprachbund
 SQL Query
 Stadium
 Stamp
+Stanley Cup
 Star
 Star-Crossed Lovers
+State of the Union
 Steak
 Step Pyramid
+Stock
 Stratego Piece
 Strike (labor)
 Stuffed Animal
 Submarine
 Subreddit
 Sudoku Puzzle
+Sumo Wrestler
+Sundial
 Sunscreen
 Super Bowl
 SuperPAC
@@ -554,6 +670,7 @@ Surfing Maneuver
 Surgical Mask
 Survivor
 Sutra
+Swamp
 Swimming Pool
 Sword
 Symphony
@@ -562,6 +679,7 @@ Tar Pits
 Tarot Card
 Tattoo
 Tectonic Plate
+TED Talk
 Telescope
 Tendon
 Tennis Match
@@ -573,6 +691,7 @@ Tic-Tac-Toe Game
 Ticket2Ride Route
 Time Zone
 Timestamp
+Tongue Twister
 Tooth
 Toothpaste
 Top 10 List
@@ -586,6 +705,8 @@ Treasury Bond
 Tree House
 Triangle
 Trilogy
+Triptych
+Trivial Pursuit
 Trolley Problem
 Tsunami
 Tuxedo
@@ -597,6 +718,7 @@ University
 Upanishad
 URL
 UUID
+Vacuum Cleaner
 Vampire Slayer
 Verb
 Vigenère Cipher
@@ -611,11 +733,15 @@ W2 Tax Form
 Waffle
 Water Bottle
 Water Slide
+Waterbending Discipline
 Waterfall
 Web Browser
+Weekend Update
+Werewolf
 Wikipedia Page
 Wildfire
 Windmill
+WinForm
 Winter Storm
 Witch Hunt
 Wizard
@@ -626,6 +752,7 @@ World Heritage Site
 Wristwatch
 xkcd Comic
 Yacht
+Yoga Position
 YouTube Video
 Yu-Gi-Oh Monster
 Ziggurat
@@ -633,3 +760,4 @@ Zodiac Sign
 Zombie
 Zoo
 Zoom Meeting
+Zoombini


### PR DESCRIPTION
This commit implements the full solution for translating Reference-type Fields. Translating a Reference Field is basically the same as translating an Aggregate Field, except that the nested contribution is only the Fields of the Reference's Primary Key. It also requires the creation of ForeignKeys as part of the Table schema. References required no new annotations to translate, and no existing test cases had to be modified.