### PR TITLE
Introduce PropertyCatalog

### DIFF
--- a/src/Kvasir/Translation/Descriptors.cs
+++ b/src/Kvasir/Translation/Descriptors.cs
@@ -1,6 +1,4 @@
-﻿global using FieldsListing = System.Collections.Generic.IReadOnlyDictionary<string, Kvasir.Translation.FieldDescriptor>;
-
-using Cybele.Core;
+﻿using Cybele.Core;
 using Kvasir.Schema;
 using Optional;
 using System;
@@ -42,8 +40,14 @@ namespace Kvasir.Translation {
         ConstraintBucket Constraints
     );
 
+    internal readonly record struct PropertyCatalog(
+        IReadOnlyDictionary<string, FieldDescriptor> Fields,
+        IReadOnlyDictionary<string, object> Relations
+    );
+
     internal readonly record struct TypeDescriptor(
-        FieldsListing Fields,
-        IReadOnlyList<ComplexCheckGen> CHECKs
+        IReadOnlyDictionary<string, FieldDescriptor> Fields,
+        IReadOnlyList<ComplexCheckGen> CHECKs,
+        IReadOnlyList<object> Relations
     );
 }

--- a/src/Kvasir/Translation/FieldConstraints.cs
+++ b/src/Kvasir/Translation/FieldConstraints.cs
@@ -356,7 +356,7 @@ namespace Kvasir.Translation {
             }
         }
 
-        private static void ResolveConflictingConstraints(PropertyInfo property, FieldsListing state) {
+        private static void ResolveConflictingConstraints(PropertyInfo property, IReadOnlyDictionary<string, FieldDescriptor> state) {
             Debug.Assert(property is not null);
             Debug.Assert(state is not null);
 
@@ -431,7 +431,7 @@ namespace Kvasir.Translation {
             }
         }
 
-        private static void EnsureViableDefaults(PropertyInfo property, FieldsListing state) {
+        private static void EnsureViableDefaults(PropertyInfo property, IReadOnlyDictionary<string, FieldDescriptor> state) {
             Debug.Assert(property is not null);
             Debug.Assert(state is not null);
 

--- a/src/Kvasir/Translation/TranslateProperty.cs
+++ b/src/Kvasir/Translation/TranslateProperty.cs
@@ -49,7 +49,7 @@ namespace Kvasir.Translation {
         ///   if <paramref name="property"/> cannot be translated (e.g. its CLR type is not supported, it has an invalid
         ///   annotation, etc.).
         /// </exception>
-        private FieldsListing TranslateProperty(PropertyInfo property) {
+        private PropertyCatalog TranslateProperty(PropertyInfo property) {
             Debug.Assert(property is not null);
 
             return CategoryOf(property).Match(

--- a/src/Kvasir/Translation/TranslateType.cs
+++ b/src/Kvasir/Translation/TranslateType.cs
@@ -59,7 +59,7 @@ namespace Kvasir.Translation {
             var sequences = new List<IReadOnlyList<FieldDescriptor>>();
             foreach (var property in ConstituentPropertiesOf(clr)) {
                 var members = new List<FieldDescriptor>();
-                foreach ((var path, var propertyDecriptor) in TranslateProperty(property)) {
+                foreach ((var path, var propertyDecriptor) in TranslateProperty(property).Fields) {
                     // We have to build up a new path to reflect the property's access mechanics from the
                     // perspective of the type being translated. At a minimum, we need to do this because we may
                     // have multiple scalars with the empty-string path, and they would overwrite each other in the
@@ -95,7 +95,7 @@ namespace Kvasir.Translation {
             var checks = ComplexConstraintsOf(clr).ToList();
 
             // No errors encountered
-            var descriptor = new TypeDescriptor(fields, checks);
+            var descriptor = new TypeDescriptor(fields, checks, new List<object>());
             typeCache_.Add(clr, descriptor);
             Debug.Assert(inProgress_.Peek() == clr);
             inProgress_.Pop();

--- a/src/Kvasir/Translation/Translator.cs
+++ b/src/Kvasir/Translation/Translator.cs
@@ -55,7 +55,7 @@ namespace Kvasir.Translation {
             inProgress_ = new Stack<Type>();
             typeCache_ = new Dictionary<Type, TypeDescriptor>();
             entityCache_ = new Dictionary<Type, Translation>();
-            primaryKeyCache_ = new Dictionary<Type, FieldsListing>();
+            primaryKeyCache_ = new Dictionary<Type, IReadOnlyDictionary<string, FieldDescriptor>>();
             tableNames_ = new HashSet<TableName>();
         }
 
@@ -65,7 +65,7 @@ namespace Kvasir.Translation {
         private readonly Stack<Type> inProgress_;
         private readonly Dictionary<Type, TypeDescriptor> typeCache_;
         private readonly Dictionary<Type, Translation> entityCache_;
-        private readonly Dictionary<Type, FieldsListing> primaryKeyCache_;
+        private readonly Dictionary<Type, IReadOnlyDictionary<string, FieldDescriptor>> primaryKeyCache_;
         private readonly HashSet<TableName> tableNames_;
         private const char NAME_SEPARATOR = '.';
         private const char PATH_SEPARATOR = '.';


### PR DESCRIPTION
This commit introduces the PropertyCatalog, which takes the place of the FieldListing as the active state-tracking structure for Translation. A PropertyCatalog contains a FieldListing as well as a mapping of access paths to Relation representations; that representation is currently typed as an object, as it is unused. There is no change to the actual Translation logic, but this is necessary to enabel the tracking of Relation properties across function calls and types.