### PR TITLE
Fix Mis-Naming of Explicit Interface Implementations

### DIFF
--- a/test/UnitTests/Kvasir/Translation/FieldClusivity.cs
+++ b/test/UnitTests/Kvasir/Translation/FieldClusivity.cs
@@ -355,6 +355,25 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherFields();
         }
 
+        [TestMethod] public void IncludeInModel_ExplicitInterfaceImplementation() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BasicDiceRoll);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(BasicDiceRoll.RollID)).OfTypeGuid().BeingNonNullable().And
+                .HaveField(nameof(IDiceRoll.NumDice)).OfTypeInt32().BeingNonNullable().And
+                .HaveField(nameof(IDiceRoll.DiceSides)).OfTypeInt32().BeingNonNullable().And
+                .HaveField(nameof(IDiceRoll.Plus)).OfTypeInt32().BeingNonNullable().And
+                .HaveField(nameof(IDiceRoll.Advantage)).OfTypeBoolean().BeingNonNullable().And
+                .HaveField(nameof(IDiceRoll.Disadvantage)).OfTypeBoolean().BeingNonNullable().And
+                .HaveNoOtherFields();
+        }
+
         [TestMethod] public void CodeOnly_InterfaceProperty_Redundant() {
             // Arrange
             var translator = new Translator();

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -746,6 +746,23 @@ namespace UT.Kvasir.Translation {
             [IncludeInModel] public override string? LowestKey { get; set; }
         }
 
+        // Test Scenario: Explicit Interface Implementation Property Marked as [IncludeInModel] (✓included✓)
+        public interface IDiceRoll {
+            int NumDice { get; set; }
+            int DiceSides { get; set; }
+            int Plus { get; set; }
+            bool Advantage { get; set; }
+            bool Disadvantage { get; set; }
+        }
+        public class BasicDiceRoll : IDiceRoll {
+            [PrimaryKey] public Guid RollID { get; set; }
+            [IncludeInModel] int IDiceRoll.NumDice { get; set; }
+            [IncludeInModel] int IDiceRoll.DiceSides { get; set; }
+            [IncludeInModel] int IDiceRoll.Plus { get; set; }
+            [IncludeInModel] bool IDiceRoll.Advantage { get; set; }
+            [IncludeInModel] bool IDiceRoll.Disadvantage { get; set; }
+        }
+
         // Test Scenario: Public Property Declared by an Interface Marked as [CodeOnly] (✓redundant✓)
         public interface IWebProtocol {
             int RFC { get; set; }

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -260,6 +260,7 @@ Denarian
 Dentist
 Desert
 Diamond
+Dice Roll
 Dinosaur
 Directory (file system)
 Discworld Guild


### PR DESCRIPTION
This commit fixes a bug in the way that Fields backed by explicit interface implementations were translated. Previously, the name of the Field defaulted to the fully-qualified name of the source interface plus a dot plus the name of the property, as this is the value of the property's Name according to the reflected PropertyInfo. This is obviously undesirable, so we now grab only the last portion of the dot-separated Name exposed by the PropertyInfo. Note that this can lead to implicitly duplicated Field names, since two different interfaces can define properties with the same name that are then both implementated; resolving this with a [Name] annotation is the responsibility of the user.

(Note that this bug affected all five varieties of property, but the unit test was written for scalars only for simplicity.)


This PR resolves #96.