### PR TITLE
Allow Extraction and Reconstitution to Work with Enumerations

### DIFF
--- a/src/Kvasir/Extraction/DataExtractionPlan.cs
+++ b/src/Kvasir/Extraction/DataExtractionPlan.cs
@@ -93,11 +93,7 @@ namespace Kvasir.Extraction {
                 var extractedParams = step.Execute(source);
                 foreach (var param in extractedParams) {
                     converterIter.MoveNext();
-
-                    // The unwrap-and-rewrap paradigm here is a little annoying, but at least this way we can leverage
-                    // the DBValue in the IExtractionStep's return content to ensure that identity conversions are
-                    // perfectly valid.
-                    yield return DBValue.Create(converterIter.Current.Convert(param.Datum));
+                    yield return DBValue.Create(converterIter.Current.Convert(param));
                 }
             }
         }

--- a/src/Kvasir/Extraction/DecomposingExtractionStep.cs
+++ b/src/Kvasir/Extraction/DecomposingExtractionStep.cs
@@ -47,17 +47,17 @@ namespace Kvasir.Extraction {
         }
 
         /// <inheritdoc/>
-        public DBData Execute(object? source) {
+        public IReadOnlyList<object?> Execute(object? source) {
             Debug.Assert(source is null || source.GetType().IsInstanceOf(ExpectedSource));
 
-            // If the source object is null, we cannot simply return a collection with 1 DBValue.NULL instance, as the
+            // If the source object is null, we cannot simply return a collection with 1 DBNull.Value instance, as the
             // postcondition of the DecomposingExtractionStep is that each invocation yield a collection with the same
             // number of items. We have no way to know a priori what this size should be, so instead we have to
             // actually perform each of the decompositions (which themselves may be complex pipelines) to produce the
-            // individual DBValue.NULL elements.
+            // individual DBNull.Value elements.
 
             var extraction = extractor_.Execute(source);
-            var results = new List<DBValue>();
+            var results = new List<object?>();
 
             foreach (var step in decomposition_) {
                 results.AddRange(step.Execute(extraction));

--- a/src/Kvasir/Extraction/IExtractionStep.cs
+++ b/src/Kvasir/Extraction/IExtractionStep.cs
@@ -1,5 +1,6 @@
 using Kvasir.Schema;
 using System;
+using System.Collections.Generic;
 
 namespace Kvasir.Extraction {
     /// <summary>
@@ -37,9 +38,9 @@ namespace Kvasir.Extraction {
         ///   its dynamic type or is a base class or interface thereof.
         /// </pre>
         /// <returns>
-        ///   An immutable, indexable, ordered sequence of <see cref="DBValue">database values</see> extracted from
+        ///   An immutable, indexable, ordered sequence of untransformed values extracted from
         ///   <paramref name="sourceObject"/>.
         /// </returns>
-        DBData Execute(object? sourceObject);
+        IReadOnlyList<object?> Execute(object? sourceObject);
     }
 }

--- a/src/Kvasir/Extraction/PrimitiveExtractionStep.cs
+++ b/src/Kvasir/Extraction/PrimitiveExtractionStep.cs
@@ -2,6 +2,7 @@ using Ardalis.GuardClauses;
 using Cybele.Extensions;
 using Kvasir.Schema;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Kvasir.Extraction {
@@ -29,11 +30,11 @@ namespace Kvasir.Extraction {
         }
 
         /// <inheritdoc/>
-        public DBData Execute(object? source) {
+        public IReadOnlyList<object?> Execute(object? source) {
             Debug.Assert(source is null || source.GetType().IsInstanceOf(ExpectedSource));
 
             if (source is null) {
-                return new DBValue[] { DBValue.NULL };
+                return new object?[] { null };
             }
 
             // If the source object is not null, then performing the extraction will produce the requisite primitive.
@@ -41,7 +42,7 @@ namespace Kvasir.Extraction {
             // this and produce DBValue.NULL. The PrimitiveExtractionStep can only ever return a collection of size 1,
             // so this heuristic is sufficient to satisfy all postconditions.
             var extraction = extractor_.Execute(source);
-            return new DBValue[] { DBValue.Create(extraction) };
+            return new object?[] { extraction };
         }
 
 

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -1419,7 +1419,7 @@
               its dynamic type or is a base class or interface thereof.
             </pre>
             <returns>
-              An immutable, indexable, ordered sequence of <see cref="T:Kvasir.Schema.DBValue">database values</see> extracted from
+              An immutable, indexable, ordered sequence of untransformed values extracted from
               <paramref name="sourceObject"/>.
             </returns>
         </member>
@@ -1579,7 +1579,7 @@
             <param name="opt">
               Whether or not the object being constructed is "optional." An optional object is one that can take on the
               value of <see langword="null"/>. Specifically, this argument controls the behavior of
-              <see cref="M:Kvasir.Reconstitution.ByConstructorCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})"/> in the event that a set of all <see cref="P:Kvasir.Schema.DBValue.NULL"/>
+              <see cref="M:Kvasir.Reconstitution.ByConstructorCreator.Execute(System.Collections.Generic.IReadOnlyList{System.Object})"/> in the event that a set of all <see cref="P:Kvasir.Schema.DBValue.NULL"/>
               is provided.
             </param>
             <pre>
@@ -1590,7 +1590,7 @@
               <paramref name="ctor"/>.
             </pre>
         </member>
-        <member name="M:Kvasir.Reconstitution.ByConstructorCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+        <member name="M:Kvasir.Reconstitution.ByConstructorCreator.Execute(System.Collections.Generic.IReadOnlyList{System.Object})">
             <inheritdoc/>
         </member>
         <member name="T:Kvasir.Reconstitution.ByKeyLookupCreator">
@@ -1611,7 +1611,7 @@
             </param>
             <param name="keyExtractor">
               The <see cref="T:Kvasir.Extraction.DataExtractionPlan"/> that produces the key for possible Entity matches against which to
-              compare the raw values upon <see cref="M:Kvasir.Reconstitution.ByKeyLookupCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">execution</see>.
+              compare the raw values upon <see cref="!:Execute(IReadOnlyList&lt;DBValue&gt;)">execution</see>.
             </param>
             <pre>
               The <see cref="P:Kvasir.Extraction.DataExtractionPlan.ExpectedSource"/> of <paramref name="keyExtractor"/> is the dynamic type
@@ -1619,7 +1619,7 @@
               thereof.
             </pre>
         </member>
-        <member name="M:Kvasir.Reconstitution.ByKeyLookupCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+        <member name="M:Kvasir.Reconstitution.ByKeyLookupCreator.Execute(System.Collections.Generic.IReadOnlyList{System.Object})">
             <inheritdoc/>
         </member>
         <member name="T:Kvasir.Reconstitution.DataReconstitutionPlan">
@@ -1730,7 +1730,7 @@
               The <see cref="T:System.Type"/> of object on which this <see cref="T:Kvasir.Reconstitution.IMutationStep"/> is expected to operate.
             </summary>
         </member>
-        <member name="M:Kvasir.Reconstitution.IMutationStep.Execute(System.Object,System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+        <member name="M:Kvasir.Reconstitution.IMutationStep.Execute(System.Object,System.Collections.Generic.IReadOnlyList{System.Object})">
             <summary>
               Execute this <see cref="T:Kvasir.Reconstitution.IMutationStep"/> to modify an existing CLR object in-place.
             </summary>
@@ -1762,7 +1762,7 @@
               The <see cref="T:System.Type"/> of CLR object created by this <see cref="T:Kvasir.Reconstitution.IObjectCreator"/>.
             </summary>
         </member>
-        <member name="M:Kvasir.Reconstitution.IObjectCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+        <member name="M:Kvasir.Reconstitution.IObjectCreator.Execute(System.Collections.Generic.IReadOnlyList{System.Object})">
             <summary>
               Execute this <see cref="T:Kvasir.Reconstitution.IObjectCreator"/> to create a brand new CLR object.
             </summary>
@@ -1790,7 +1790,7 @@
               The <see cref="T:System.Type"/> of object produced by this <see cref="T:Kvasir.Reconstitution.Reconstitutor"/>.
             </summary>
         </member>
-        <member name="M:Kvasir.Reconstitution.IReconstitutor.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+        <member name="M:Kvasir.Reconstitution.IReconstitutor.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{System.Object})">
             <summary>
               Execute this <see cref="T:Kvasir.Reconstitution.IReconstitutor"/> to create a brand new CLR object from a "row" of database
               values.
@@ -1803,7 +1803,7 @@
             </pre>
             <returns>
               A CLR object of type <see cref="P:Kvasir.Reconstitution.IReconstitutor.Target"/> that, when run through the dedicated extractor for
-              <see cref="P:Kvasir.Reconstitution.IReconstitutor.Target"/>, produces <paramref name="rawValues"/>.
+              <see cref="P:Kvasir.Reconstitution.IReconstitutor.Target"/>, produced <paramref name="rawValues"/>.
             </returns>
         </member>
         <member name="T:Kvasir.Reconstitution.IRepopulator">
@@ -1879,7 +1879,7 @@
               <paramref name="targetType"/> is a data type supported by the Framework.
             </pre>
         </member>
-        <member name="M:Kvasir.Reconstitution.PrimitiveCreator.Execute(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+        <member name="M:Kvasir.Reconstitution.PrimitiveCreator.Execute(System.Collections.Generic.IReadOnlyList{System.Object})">
             <inheritdoc/>
         </member>
         <member name="T:Kvasir.Reconstitution.Reconstitutor">
@@ -1908,7 +1908,7 @@
               <paramref name="creator"/>.
             </pre>
         </member>
-        <member name="M:Kvasir.Reconstitution.Reconstitutor.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+        <member name="M:Kvasir.Reconstitution.Reconstitutor.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{System.Object})">
             <inheritdoc/>
         </member>
         <member name="T:Kvasir.Reconstitution.ReconstitutorFacade">
@@ -1946,7 +1946,7 @@
               <paramref name="length"/> <c>&gt; 0</c>
             </pre>
         </member>
-        <member name="M:Kvasir.Reconstitution.ReconstitutorFacade.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+        <member name="M:Kvasir.Reconstitution.ReconstitutorFacade.ReconstituteFrom(System.Collections.Generic.IReadOnlyList{System.Object})">
             <inheritdoc/>
         </member>
         <member name="T:Kvasir.Reconstitution.RelationReconstitutionPlan">
@@ -2024,7 +2024,7 @@
               compatible with the property type of <paramref name="property"/>.
             </pre>
         </member>
-        <member name="M:Kvasir.Reconstitution.SetPropertyMutationStep.Execute(System.Object,System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue})">
+        <member name="M:Kvasir.Reconstitution.SetPropertyMutationStep.Execute(System.Object,System.Collections.Generic.IReadOnlyList{System.Object})">
             <inheritdoc/>
         </member>
         <member name="T:Kvasir.Relations.IRelation">

--- a/src/Kvasir/Reconstitution/ByConstructorCreator.cs
+++ b/src/Kvasir/Reconstitution/ByConstructorCreator.cs
@@ -29,7 +29,7 @@ namespace Kvasir.Reconstitution {
         /// <param name="opt">
         ///   Whether or not the object being constructed is "optional." An optional object is one that can take on the
         ///   value of <see langword="null"/>. Specifically, this argument controls the behavior of
-        ///   <see cref="Execute(IReadOnlyList{DBValue})"/> in the event that a set of all <see cref="DBValue.NULL"/>
+        ///   <see cref="Execute(IReadOnlyList{object?})"/> in the event that a set of all <see cref="DBValue.NULL"/>
         ///   is provided.
         /// </param>
         /// <pre>
@@ -52,10 +52,10 @@ namespace Kvasir.Reconstitution {
         }
 
         /// <inheritdoc/>
-        public object? Execute(DBData rawValues) {
+        public object? Execute(IReadOnlyList<object?> rawValues) {
             Guard.Against.NullOrEmpty(rawValues, nameof(rawValues));
 
-            if (constructFromNulls_ || rawValues.Any(v => v != DBValue.NULL)) {
+            if (constructFromNulls_ || rawValues.Any(v => v is not null)) {
                 var args = arguments_.Select(r => r.ReconstituteFrom(rawValues));
                 return ctor_.Invoke(args.ToArray());
             }

--- a/src/Kvasir/Reconstitution/ByKeyLookupCreator.cs
+++ b/src/Kvasir/Reconstitution/ByKeyLookupCreator.cs
@@ -40,14 +40,14 @@ namespace Kvasir.Reconstitution {
         }
 
         /// <inheritdoc/>
-        public object? Execute(DBData rawValues) {
+        public object? Execute(IReadOnlyList<object?> rawValues) {
             Guard.Against.NullOrEmpty(rawValues, nameof(rawValues));
 
-            if (rawValues.Any(v => v == DBValue.NULL)) {
-                Debug.Assert(rawValues.All(v => v == DBValue.NULL));
+            if (rawValues.Any(v => v is null)) {
+                Debug.Assert(rawValues.All(v => v is null));
                 return null;
             }
-            return Lookup.ByKey(rawValues, factory_(), keyExtractor_);
+            return Lookup.ByKey(rawValues.Select(v => DBValue.Create(v)).ToList(), factory_(), keyExtractor_);
         }
 
 

--- a/src/Kvasir/Reconstitution/DataReconstitutionPlan.cs
+++ b/src/Kvasir/Reconstitution/DataReconstitutionPlan.cs
@@ -63,15 +63,13 @@ namespace Kvasir.Reconstitution {
             Guard.Against.Null(rawValues, nameof(rawValues));
             Debug.Assert(!rawValues.IsEmpty());
 
-            List<DBValue> reversions = new List<DBValue>();
+            var reversions = new List<object?>();
             var reverterIter = reverters_.GetEnumerator();
 
             foreach (var value in rawValues) {
                 reverterIter.MoveNext();
-
-                // The unwrap-and-rewrap paradigm here is a little annoying, but at least this way we can leverage
-                // the DBValue to ensure that identity conversions are perfectly valid.
-                reversions.Add(DBValue.Create(reverterIter.Current.Revert(value.Datum)));
+                var datum = value == DBValue.NULL ? null : value.Datum;
+                reversions.Add(reverterIter.Current.Revert(datum));
             }
 
             return reconstitutor_.ReconstituteFrom(reversions)!;

--- a/src/Kvasir/Reconstitution/IMutationStep.cs
+++ b/src/Kvasir/Reconstitution/IMutationStep.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Kvasir.Reconstitution {
     /// <summary>
@@ -41,6 +42,6 @@ namespace Kvasir.Reconstitution {
         /// <pre>
         ///   <paramref name="subject"/> is an instance of <see cref="ExpectedSubject"/>.
         /// </pre>
-        void Execute(object subject, DBData rawValues);
+        void Execute(object subject, IReadOnlyList<object?> rawValues);
     }
 }

--- a/src/Kvasir/Reconstitution/IObjectCreator.cs
+++ b/src/Kvasir/Reconstitution/IObjectCreator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Kvasir.Reconstitution {
     /// <summary>
@@ -33,6 +34,6 @@ namespace Kvasir.Reconstitution {
         ///   of this <see cref="IObjectCreator"/>. If the relevant slots of <paramref name="rawValues"/> correspond to
         ///   a <see langword="null"/> object, <see langword="null"/> is returned.
         /// </returns>
-        object? Execute(DBData rawValues);
+        object? Execute(IReadOnlyList<object?> rawValues);
     }
 }

--- a/src/Kvasir/Reconstitution/IReconstitutor.cs
+++ b/src/Kvasir/Reconstitution/IReconstitutor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Kvasir.Reconstitution {
     /// <summary>
@@ -23,8 +24,8 @@ namespace Kvasir.Reconstitution {
         /// </pre>
         /// <returns>
         ///   A CLR object of type <see cref="Target"/> that, when run through the dedicated extractor for
-        ///   <see cref="Target"/>, produces <paramref name="rawValues"/>.
+        ///   <see cref="Target"/>, produced <paramref name="rawValues"/>.
         /// </returns>
-        object? ReconstituteFrom(DBData rawValues);
+        object? ReconstituteFrom(IReadOnlyList<object?> rawValues);
     }
 }

--- a/src/Kvasir/Reconstitution/PrimitiveCreator.cs
+++ b/src/Kvasir/Reconstitution/PrimitiveCreator.cs
@@ -1,6 +1,7 @@
 using Ardalis.GuardClauses;
 using Kvasir.Schema;
 using System;
+using System.Collections.Generic;
 
 namespace Kvasir.Reconstitution {
     /// <summary>
@@ -28,13 +29,9 @@ namespace Kvasir.Reconstitution {
         }
 
         /// <inheritdoc/>
-        public object? Execute(DBData values) {
+        public object? Execute(IReadOnlyList<object?> values) {
             Guard.Against.NullOrEmpty(values, nameof(values));
-
-            if (values[index_] == DBValue.NULL) {
-                return null;
-            }
-            return values[index_].Datum;
+            return values[index_];
         }
 
 

--- a/src/Kvasir/Reconstitution/Reconstitutor.cs
+++ b/src/Kvasir/Reconstitution/Reconstitutor.cs
@@ -40,7 +40,7 @@ namespace Kvasir.Reconstitution {
         }
 
         /// <inheritdoc/>
-        public object? ReconstituteFrom(DBData rawValues) {
+        public object? ReconstituteFrom(IReadOnlyList<object?> rawValues) {
             Guard.Against.NullOrEmpty(rawValues, nameof(rawValues));
 
             // Mutators cannot operate on null objects, because there would be no target on which to call the property

--- a/src/Kvasir/Reconstitution/ReconstitutorFacade.cs
+++ b/src/Kvasir/Reconstitution/ReconstitutorFacade.cs
@@ -1,5 +1,6 @@
 using Ardalis.GuardClauses;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Kvasir.Reconstitution {
@@ -46,7 +47,7 @@ namespace Kvasir.Reconstitution {
         }
 
         /// <inheritdoc/>
-        public object? ReconstituteFrom(DBData rawValues) {
+        public object? ReconstituteFrom(IReadOnlyList<object?> rawValues) {
             Guard.Against.NullOrEmpty(rawValues, nameof(rawValues));
 
             var view = rawValues.Skip(start_.Value).Take(length_).ToList();

--- a/src/Kvasir/Reconstitution/SetPropertyMutationStep.cs
+++ b/src/Kvasir/Reconstitution/SetPropertyMutationStep.cs
@@ -2,6 +2,7 @@ using Ardalis.GuardClauses;
 using Cybele.Extensions;
 using Kvasir.Extraction;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -53,7 +54,7 @@ namespace Kvasir.Reconstitution {
         }
 
         /// <inheritdoc/>
-        public void Execute(object subject, DBData rawValues) {
+        public void Execute(object subject, IReadOnlyList<object?> rawValues) {
             Guard.Against.Null(subject, nameof(subject));
             Guard.Against.NullOrEmpty(rawValues, nameof(rawValues));
             Debug.Assert(subject.GetType().IsInstanceOf(ExpectedSubject));

--- a/test/UnitTests/Kvasir/Extraction/ExtractionPlans.cs
+++ b/test/UnitTests/Kvasir/Extraction/ExtractionPlans.cs
@@ -16,7 +16,7 @@ namespace UT.Kvasir.Extraction {
             // Arrange
             var mockExtractor = Substitute.For<IExtractionStep>();
             mockExtractor.ExpectedSource.Returns(typeof(string));
-            mockExtractor.Execute(Arg.Any<string>()).Returns(Array.Empty<DBValue>());
+            mockExtractor.Execute(Arg.Any<string>()).Returns(Array.Empty<object>());
             var converter = DataConverter.Identity<int>();
 
             // Act
@@ -30,19 +30,19 @@ namespace UT.Kvasir.Extraction {
 
         [TestMethod] public void Execute() {
             // Arrange
-            var year = DBValue.Create(2012);
-            var month = DBValue.Create(12);
-            var day = DBValue.Create(31);
+            var year = 2012;
+            var month = 12;
+            var day = 31;
             var ymd = Substitute.For<IExtractionStep>();
             ymd.ExpectedSource.Returns(typeof(DateTime));
-            ymd.Execute(Arg.Any<DateTime>()).Returns(new DBValue[] { year, month, day });
+            ymd.Execute(Arg.Any<DateTime>()).Returns(new object?[] { year, month, day });
 
-            var hour = DBValue.Create(23);
-            var minute = DBValue.Create(59);
-            var second = DBValue.Create(59);
+            var hour = 23;
+            var minute = 59;
+            var second = 59;
             var hms = Substitute.For<IExtractionStep>();
             hms.ExpectedSource.Returns(typeof(DateTime));
-            hms.Execute(Arg.Any<DateTime>()).Returns(new DBValue[] { hour, minute, second });
+            hms.Execute(Arg.Any<DateTime>()).Returns(new object?[] { hour, minute, second });
 
             var offsetCnv = DataConverter.Create<int, int>(i => i - 1);
             var identityCnv = DataConverter.Identity<int>();
@@ -57,12 +57,12 @@ namespace UT.Kvasir.Extraction {
 
             // Assert
             values.Should().HaveCount(6);
-            values[0].Should().Be(DBValue.Create((int)year.Datum - 1));
-            values[1].Should().Be(DBValue.Create((int)month.Datum - 1));
-            values[2].Should().Be(DBValue.Create((int)day.Datum - 1));
-            values[3].Should().Be(hour);
-            values[4].Should().Be(minute);
-            values[5].Should().Be(second);
+            values[0].Should().Be(DBValue.Create(year - 1));
+            values[1].Should().Be(DBValue.Create(month - 1));
+            values[2].Should().Be(DBValue.Create(day - 1));
+            values[3].Should().Be(DBValue.Create(hour));
+            values[4].Should().Be(DBValue.Create(minute));
+            values[5].Should().Be(DBValue.Create(second));
             ymd.Received().Execute(source);
             hms.Received().Execute(source);
         }

--- a/test/UnitTests/Kvasir/Reconstitution/Lookups.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/Lookups.cs
@@ -84,7 +84,7 @@ namespace UT.Kvasir.Reconstitution {
             var step0 = new PrimitiveExtractionStep(new IdentityExtractor<string>());
             var mockStep = Substitute.For<IExtractionStep>();
             mockStep.ExpectedSource.Returns(typeof(string));
-            mockStep.Execute(target).Returns(new List<DBValue>() { key[1] });
+            mockStep.Execute(target).Returns(new object?[] { key[1].Datum });
             mockStep.Execute(Arg.Is<string>(s => s != target)).Returns(_ => { throw new NotSupportedException(); });
             var step1 = mockStep;
             var plan = new DataExtractionPlan(new IExtractionStep[] { step0, step1 }, new DataConverter[] { conv, conv });

--- a/test/UnitTests/Kvasir/Reconstitution/Mutators.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/Mutators.cs
@@ -28,8 +28,8 @@ namespace UT.Kvasir.Reconstitution {
             var arg = "Santa Clara";
             var mockArgRecon = Substitute.For<IReconstitutor>();
             mockArgRecon.Target.Returns(typeof(string));
-            mockArgRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(arg);
-            var data = new DBValue[] { DBValue.NULL, DBValue.Create(0), DBValue.Create('@') };
+            mockArgRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(arg);
+            var data = new object?[] { null, 0, '@' };
             var mutator = new SetPropertyMutationStep(new IdentityExtractor<PODClass>(), prop, mockArgRecon);
             object source = new PODClass();
 
@@ -47,8 +47,8 @@ namespace UT.Kvasir.Reconstitution {
             var arg = "Valparaiso";
             var mockArgRecon = Substitute.For<IReconstitutor>();
             mockArgRecon.Target.Returns(typeof(string));
-            mockArgRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(arg);
-            var data = new DBValue[] { DBValue.NULL, DBValue.Create(0), DBValue.Create('@') };
+            mockArgRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(arg);
+            var data = new object?[] { null, 0, '@' };
             var mutator = new SetPropertyMutationStep(new IdentityExtractor<PODStruct>(), prop, mockArgRecon);
             object source = new PODStruct();
 
@@ -65,8 +65,8 @@ namespace UT.Kvasir.Reconstitution {
             var prop = typeof(PODClass).GetProperty(nameof(PODClass.Character))!;
             var mockArgRecon = Substitute.For<IReconstitutor>();
             mockArgRecon.Target.Returns(typeof(char));
-            mockArgRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(null);
-            var data = new DBValue[] { DBValue.NULL, DBValue.Create(0), DBValue.Create('@') };
+            mockArgRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(null);
+            var data = new object?[] { null, 0, '@' };
             var mutator = new SetPropertyMutationStep(new IdentityExtractor<PODClass>(), prop, mockArgRecon);
             var source = new PODClass() { Character = '.' };
 

--- a/test/UnitTests/Kvasir/Reconstitution/ObjectCreators.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/ObjectCreators.cs
@@ -25,20 +25,20 @@ namespace UT.Kvasir.Reconstitution {
         [TestMethod] public void ProduceNonNull() {
             // Arrange
             var idx = new Index(1);
-            var data = new DBValue[] { DBValue.Create(7), DBValue.Create("Jefferson City") };
+            var data = new object?[] { 7, "Jefferson City" };
             var creator = new PrimitiveCreator(idx, typeof(string));
 
             // Act
             var value = creator.Execute(data);
 
             // Assert
-            value.Should().Be(data[idx].Datum);
+            value.Should().Be(data[idx]);
         }
 
         [TestMethod] public void ProduceNull() {
             // Arrange
             var idx = new Index(1);
-            var data = new DBValue[] { DBValue.Create('&'), DBValue.NULL, DBValue.Create(-4L) };
+            var data = new object?[] { '&', null, -4L };
             var creator = new PrimitiveCreator(idx, typeof(ushort));
 
             // Act
@@ -70,8 +70,8 @@ namespace UT.Kvasir.Reconstitution {
             var arg = "Fort Lauderdale";
             var mockArgRecon = Substitute.For<IReconstitutor>();
             mockArgRecon.Target.Returns(typeof(string));
-            mockArgRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(arg);
-            var data = new DBValue[] { DBValue.NULL, DBValue.Create(35L) };
+            mockArgRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(arg);
+            var data = new object?[] { null, 35L };
             var creator = new ByConstructorCreator(ctor, new IReconstitutor[] { mockArgRecon }, false);
 
             // Act
@@ -90,12 +90,12 @@ namespace UT.Kvasir.Reconstitution {
             var arg1 = new Index(2074);
             var mockArgRecon0 = Substitute.For<IReconstitutor>();
             mockArgRecon0.Target.Returns(typeof(Index));
-            mockArgRecon0.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(arg0);
+            mockArgRecon0.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(arg0);
             var mockArgRecon1 = Substitute.For<IReconstitutor>();
             mockArgRecon1.Target.Returns(typeof(Index));
-            mockArgRecon1.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(arg1);
+            mockArgRecon1.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(arg1);
             var recons = new IReconstitutor[] { mockArgRecon0, mockArgRecon1 };
-            var data = new DBValue[] { DBValue.Create('|'), DBValue.Create('>'), DBValue.Create("Eugene") };
+            var data = new object?[] { '|', '<', "Eugene" };
             var creator = new ByConstructorCreator(ctor, recons, false);
 
             // Act
@@ -111,12 +111,12 @@ namespace UT.Kvasir.Reconstitution {
             var ctor = typeof(ArgumentException).GetConstructor(new Type[] { typeof(string), typeof(Exception) })!;
             var mockArgRecon0 = Substitute.For<IReconstitutor>();
             mockArgRecon0.Target.Returns(typeof(string));
-            mockArgRecon0.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(null);
+            mockArgRecon0.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(null);
             var mockArgRecon1 = Substitute.For<IReconstitutor>();
             mockArgRecon1.Target.Returns(typeof(Exception));
-            mockArgRecon1.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(null);
+            mockArgRecon1.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(null);
             var recons = new IReconstitutor[] { mockArgRecon0, mockArgRecon1 };
-            var data = new DBValue[] { DBValue.Create('%') };
+            var data = new object?[] { '%' };
             var creator = new ByConstructorCreator(ctor, recons, false);
 
             // Act
@@ -132,9 +132,9 @@ namespace UT.Kvasir.Reconstitution {
             var ctor = typeof(DateTime).GetConstructor(new Type[] { typeof(int), typeof(int), typeof(int) })!;
             var mockArgRecon = Substitute.For<IReconstitutor>();
             mockArgRecon.Target.Returns(typeof(int));
-            mockArgRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(null);
+            mockArgRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(null);
             var recons = new IReconstitutor[] { mockArgRecon, mockArgRecon, mockArgRecon };
-            var data = new DBValue[] { DBValue.NULL, DBValue.NULL, DBValue.NULL };
+            var data = new object?[] { null, null, null };
             var creator = new ByConstructorCreator(ctor, recons, true);
 
             // Act
@@ -151,12 +151,12 @@ namespace UT.Kvasir.Reconstitution {
             string? arg1 = null;
             var mockArgRecon0 = Substitute.For<IReconstitutor>();
             mockArgRecon0.Target.Returns(typeof(int));
-            mockArgRecon0.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(arg0);
+            mockArgRecon0.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(arg0);
             var mockArgRecon1 = Substitute.For<IReconstitutor>();
             mockArgRecon1.Target.Returns(typeof(string));
-            mockArgRecon1.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(arg1);
+            mockArgRecon1.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(arg1);
             var recons = new IReconstitutor[] { mockArgRecon0, mockArgRecon1 };
-            var data = new DBValue[] { DBValue.NULL, DBValue.NULL, DBValue.Create('=') };
+            var data = new object?[] { null, null, '=' };
             var optCreator = new ByConstructorCreator(ctor, recons, true);
             var reqCreator = new ByConstructorCreator(ctor, recons, false);
 
@@ -193,7 +193,7 @@ namespace UT.Kvasir.Reconstitution {
             var plan = new DataExtractionPlan(new IExtractionStep[] { step, step }, new DataConverter[] { conv, conv });
             var entities = new string[] { "Belo Horizonte", "Gladstone", "Cluj-Napoca" };
             var target = entities[2];
-            var data = new DBValue[] { DBValue.Create(target), DBValue.Create(target) };
+            var data = new object?[] { target, target };
             var creator = new ByKeyLookupCreator(() => entities, plan);
 
             // Act
@@ -210,7 +210,7 @@ namespace UT.Kvasir.Reconstitution {
             var plan = new DataExtractionPlan(new IExtractionStep[] { step, step }, new DataConverter[] { conv, conv });
             var entities = new string[] { "Whanganui", "Valladolid", "Chișinău" };
             var target = entities[0];
-            var data = new DBValue[] { DBValue.NULL, DBValue.NULL };
+            var data = new object?[] { null, null };
             var creator = new ByKeyLookupCreator(() => entities, plan);
 
             // Act

--- a/test/UnitTests/Kvasir/Reconstitution/ReconstitutionPlans.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/ReconstitutionPlans.cs
@@ -16,7 +16,7 @@ namespace UT.Kvasir.Reconstitution {
             // Arrange
             var mockReconstitutor = Substitute.For<IReconstitutor>();
             mockReconstitutor.Target.Returns(typeof(string));
-            mockReconstitutor.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns("");
+            mockReconstitutor.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns("");
             var reverter = DataConverter.Identity<int>();
 
             // Act
@@ -39,7 +39,7 @@ namespace UT.Kvasir.Reconstitution {
 
             var reconstitutor = Substitute.For<IReconstitutor>();
             reconstitutor.Target.Returns(typeof(DateTime));
-            reconstitutor.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(new DateTime());
+            reconstitutor.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(new DateTime());
 
             var plan = new DataReconstitutionPlan(reconstitutor, reverters);
 
@@ -47,11 +47,11 @@ namespace UT.Kvasir.Reconstitution {
             _ = plan.ReconstituteFrom(values);
 
             // Assert
-            var expYear = DBValue.Create(2012);
-            var expMonth = DBValue.Create(12);
-            var expDay = DBValue.Create(31);
-            var expValues = new DBValue[] { expYear, expMonth, expDay };
-            reconstitutor.Received().ReconstituteFrom(NArg.IsSameSequence<IReadOnlyList<DBValue>>(expValues));
+            var expYear = 2012;
+            var expMonth = 12;
+            var expDay = 31;
+            var expValues = new object?[] { expYear, expMonth, expDay };
+            reconstitutor.Received().ReconstituteFrom(NArg.IsSameSequence<IReadOnlyList<object?>>(expValues));
         }
     }
 

--- a/test/UnitTests/Kvasir/Reconstitution/Reconstitutors.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/Reconstitutors.cs
@@ -27,16 +27,16 @@ namespace UT.Kvasir.Reconstitution {
             // Arrange
             var mockCreator = Substitute.For<IObjectCreator>();
             mockCreator.Target.Returns(typeof(Exception));
-            mockCreator.Execute(Arg.Any<IReadOnlyList<DBValue>>()).Returns(new Exception());
+            mockCreator.Execute(Arg.Any<IReadOnlyList<object?>>()).Returns(new Exception());
             var mockMutator0 = Substitute.For<IMutationStep>();
             mockMutator0.ExpectedSubject.Returns(typeof(Exception));
-            mockMutator0.Execute(Arg.Any<object>(), Arg.Any<IReadOnlyList<DBValue>>());
+            mockMutator0.Execute(Arg.Any<object>(), Arg.Any<IReadOnlyList<object?>>());
             var mockMutator1 = Substitute.For<IMutationStep>();
             mockMutator1.ExpectedSubject.Returns(typeof(Exception));
-            mockMutator1.Execute(Arg.Any<object>(), Arg.Any<IReadOnlyList<DBValue>>());
+            mockMutator1.Execute(Arg.Any<object>(), Arg.Any<IReadOnlyList<object?>>());
             var mutators = new IMutationStep[] { mockMutator0, mockMutator1 };
             var reconstitutor = new Reconstitutor(mockCreator, mutators);
-            var data = new DBValue[] { DBValue.Create(7), DBValue.Create('='), DBValue.NULL };
+            var data = new object?[] { 7, '=', null };
 
             // Act
             var _ = reconstitutor.ReconstituteFrom(data);
@@ -51,14 +51,14 @@ namespace UT.Kvasir.Reconstitution {
             // Arrange
             var mockCreator = Substitute.For<IObjectCreator>();
             mockCreator.Target.Returns(typeof(Exception));
-            mockCreator.Execute(Arg.Any<IReadOnlyList<DBValue>>()).Returns(null);
+            mockCreator.Execute(Arg.Any<IReadOnlyList<object?>>()).Returns(null);
             var mockMutator0 = Substitute.For<IMutationStep>();
             mockMutator0.ExpectedSubject.Returns(typeof(Exception));
             var mockMutator1 = Substitute.For<IMutationStep>();
             mockMutator1.ExpectedSubject.Returns(typeof(Exception));
             var mutators = new IMutationStep[] { mockMutator0, mockMutator1 };
             var reconstitutor = new Reconstitutor(mockCreator, mutators);
-            var data = new DBValue[] { DBValue.Create(7), DBValue.Create('='), DBValue.NULL };
+            var data = new object?[] { 7, '=', null };
 
             // Act
             var _ = reconstitutor.ReconstituteFrom(data);
@@ -90,16 +90,16 @@ namespace UT.Kvasir.Reconstitution {
             var length = 2;
             var mockRecon = Substitute.For<IReconstitutor>();
             mockRecon.Target.Returns(typeof(Lazy<string>));
-            mockRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(null);
+            mockRecon.ReconstituteFrom(Arg.Any<IReadOnlyList<object?>>()).Returns(null);
             var reconstitutor = new ReconstitutorFacade(mockRecon, start, length);
-            var data = new DBValue[] { DBValue.Create(1), DBValue.Create(2), DBValue.Create(3), DBValue.Create(4) };
+            var data = new object?[] { 1, 2, 3, 4 };
 
             // Act
             var _ = reconstitutor.ReconstituteFrom(data);
 
             // Assert
             var view = data[1..3];
-            mockRecon.Received().ReconstituteFrom(NArg.IsSameSequence<IReadOnlyList<DBValue>>(view));
+            mockRecon.Received().ReconstituteFrom(NArg.IsSameSequence<IReadOnlyList<object?>>(view));
         }
     }
 }


### PR DESCRIPTION
This commit fixes bugs in both the Extraction and Reconstitution layer related to the when data is viewed as a possibly-null object and when it is viewed as a DBValue. The key is that the latter is incapable of representing a C# enumeration, since that is not something that literally exists in the back-end database. Previously, primitives were extracted as objects and immediately wrapped in DBValue; they were then unwrapped to do data conversion before being re-wrapped. This led to a crash if an enumeration were extracted. (The same happened when reconstituting, just in the opposite direction). The solution was to make everything operate in terms of raw objects until after data conversion (or until data reversion) occurs, when it is safe to use DBValues.