### PR TITLE
Properly Detect and Report Attempted Translation of Static Class

### DIFF
--- a/src/Kvasir/Translation/TranslateEntity.cs
+++ b/src/Kvasir/Translation/TranslateEntity.cs
@@ -141,6 +141,11 @@ namespace Kvasir.Translation {
                 return Option.Some("an interface");
             }
 
+            // An Entity type cannot be a static class
+            if (type.IsAbstract && type.IsSealed) {
+                return Option.Some("a static class");
+            }
+
             // An Entity type cannot be an open generic
             if (type.IsGenericTypeDefinition) {
                 return Option.Some("an open generic");

--- a/test/UnitTests/Kvasir/Translation/EntityShapes.cs
+++ b/test/UnitTests/Kvasir/Translation/EntityShapes.cs
@@ -49,6 +49,21 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherFields();
         }
 
+        [TestMethod] public void EntityTypeIsStaticClass_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(HighHell);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining("cannot be an Entity type")                  // category
+                .WithMessageContaining("static");                                   // details / explanation
+        }
+
         [TestMethod] public void EntityTypeIsPrivate() {
             // Arrange
             var translator = new Translator();

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -454,6 +454,9 @@ namespace UT.Kvasir.Translation {
             public ushort RepublicanEVs { get; set; }
         }
 
+        // Static Class (✗not permitted✗)
+        public static class HighHell {}
+
         // Test Scenario: Private (✓allowed✓)
         private class GitCommit {
             [PrimaryKey] public string Hash { get; set; } = "";

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -398,6 +398,7 @@ Hemalurgy
 Hepatitis
 Hercule Poirot Mystery
 Hieroglyph
+High Heel
 Highway
 Hindu God
 Histogram


### PR DESCRIPTION
Static Classes in C# are implemented in the IL as abstract and sealed, a combination which is otherwise not supported. We were previously detecting an attempted translation of a Static Class and erroring out with a message indicating it was abstract; this commit makes it so that such a case is identified in the error message more precisely.

This PR closes #100 