### PR TITLE
Fix Source and Result Types of ISingleExtractor Implementations when Nullables are Involved

### DIFF
--- a/src/Kvasir/Extraction/ConvertingExtractor.cs
+++ b/src/Kvasir/Extraction/ConvertingExtractor.cs
@@ -31,8 +31,8 @@ namespace Kvasir.Extraction {
 
             extractor_ = extractor;
             converter_ = converter;
-            SourceType = extractor_.SourceType;
-            ResultType = converter_.ResultType;
+            SourceType = Nullable.GetUnderlyingType(extractor_.SourceType) ?? extractor_.SourceType;
+            ResultType = Nullable.GetUnderlyingType(converter_.ResultType) ?? converter_.ResultType;
         }
 
         /// <inheritdoc/>

--- a/src/Kvasir/Extraction/ReadPropertyExtractor.cs
+++ b/src/Kvasir/Extraction/ReadPropertyExtractor.cs
@@ -26,8 +26,8 @@ namespace Kvasir.Extraction {
             Debug.Assert(path is not null);
 
             path_ = path;
-            SourceType = path_.ReflectedType;
-            ResultType = path_.PropertyType;
+            SourceType = Nullable.GetUnderlyingType(path_.ReflectedType) ?? path_.ReflectedType;
+            ResultType = Nullable.GetUnderlyingType(path_.PropertyType) ?? path_.PropertyType;
         }
 
         /// <inheritdoc/>

--- a/test/UnitTests/Kvasir/Extraction/Extractors.cs
+++ b/test/UnitTests/Kvasir/Extraction/Extractors.cs
@@ -131,6 +131,19 @@ namespace UT.Kvasir.Extraction {
             datum.Should().BeNull();
             multiDatum.Should().BeEquivalentTo(new object?[] { datum });
         }
+
+        [TestMethod] public void ExtractionPropertyTypeIsNullable() {
+            // Arrange
+            var type = typeof(Tuple<int?, char?, double?>);
+            var path = new PropertyChain(type, "Item2");
+
+            // Act
+            var extractor = new ReadPropertyExtractor(path);
+
+            // Assert
+            extractor.SourceType.Should().Be(type);
+            extractor.ResultType.Should().Be(typeof(char));
+        }
     }
 
     [TestClass, TestCategory("ConvertingExtractor")]
@@ -244,6 +257,21 @@ namespace UT.Kvasir.Extraction {
             datum.Should().BeNull();
             multiDatum.Should().BeEquivalentTo(new object?[] { datum });
             originalExtractor.Received().ExtractFrom(source);
+        }
+
+        [TestMethod] public void ConversionTypeIsNullable() {
+            // Arrange
+            var originalExtractor = Substitute.For<ISingleExtractor>();
+            originalExtractor.SourceType.Returns(typeof(int?));
+            originalExtractor.ResultType.Returns(typeof(int));
+            var converter = DataConverter.Create<int?, int?>(p => -p, p => -p);
+
+            // Act
+            var extractor = new ConvertingExtractor(originalExtractor, converter);
+
+            // Assert
+            extractor.SourceType.Should().Be(typeof(int));
+            extractor.ResultType.Should().Be(typeof(int));
         }
     }
 


### PR DESCRIPTION
This commit fixes a bug whereby the ReadPropertyExtractor and the ConvertingExtractor were not properly unwrapping Nullable<T> to the underlying type when Nullable<T> was either the Source or Result types. Because Extraction always operates in terms of object?, the boxing/unboxing renders the Nullable<T> wrapper useless. Furthermore, by unwrapping the type for the SourceType and ResultType properties, it makes other debug checks much easier.