### PR TITLE
Fix Mistranslation when DataConverter Result Type is Enumeration

### DIFF
--- a/test/UnitTests/Kvasir/Translation/DataConverters.cs
+++ b/test/UnitTests/Kvasir/Translation/DataConverters.cs
@@ -31,7 +31,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherFields();
         }
         
-        [TestMethod] public void ChangeToFieldsType() {
+        [TestMethod] public void ChangFieldsTypeToScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Comet);
@@ -48,6 +48,62 @@ namespace UT.Kvasir.Translation {
                 .HaveField(nameof(Comet.MassKg)).OfTypeUInt64().BeingNonNullable().And
                 .HaveField(nameof(Comet.Albedo)).OfTypeDouble().BeingNonNullable().And
                 .HaveField(nameof(Comet.OrbitalPeriod)).OfTypeSingle().BeingNonNullable().And
+                .HaveNoOtherFields();
+        }
+
+        [TestMethod] public void ChangeFieldsTypeToEnumeration() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(TitleOfYourSexTape);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(TitleOfYourSexTape.Title)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(TitleOfYourSexTape.CharacterSaying)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(TitleOfYourSexTape.CharacterReceiving)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(TitleOfYourSexTape.DayOfWeek)).OfTypeEnumeration(
+                    DayOfWeek.Sunday,
+                    DayOfWeek.Monday,
+                    DayOfWeek.Tuesday,
+                    DayOfWeek.Wednesday,
+                    DayOfWeek.Thursday,
+                    DayOfWeek.Friday,
+                    DayOfWeek.Saturday
+                ).BeingNonNullable().And
+                .HaveField(nameof(TitleOfYourSexTape.Season)).OfTypeInt32().BeingNonNullable().And
+                .HaveField(nameof(TitleOfYourSexTape.EpisodeNumber)).OfTypeInt32().BeingNonNullable().And
+                .HaveField(nameof(TitleOfYourSexTape.Timestamp)).OfTypeDouble().BeingNonNullable().And
+                .HaveNoOtherFields();
+        }
+
+        [TestMethod] public void ChangeFieldsTypeToDifferentEnumeration() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(VestigeOfDivergence);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(VestigeOfDivergence.Name)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(VestigeOfDivergence.Deity)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(VestigeOfDivergence.Wielder)).OfTypeText().BeingNullable().And
+                .HaveField(nameof(VestigeOfDivergence.IntroducedIn)).OfTypeEnumeration(
+                    VestigeOfDivergence.Party.VoxMachina,
+                    VestigeOfDivergence.Party.MightyNein,
+                    VestigeOfDivergence.Party.BellsHells
+                ).BeingNullable().And
+                .HaveField(nameof(VestigeOfDivergence.AttackBonus)).OfTypeUInt8().BeingNonNullable().And
+                .HaveField(nameof(VestigeOfDivergence.AverageDamage)).OfTypeInt32().BeingNonNullable().And
+                .HaveField(nameof(VestigeOfDivergence.CurrentState)).OfTypeEnumeration(
+                    VestigeOfDivergence.State.Dormant,
+                    VestigeOfDivergence.State.Awakened,
+                    VestigeOfDivergence.State.Exalted
+                ).BeingNonNullable().And
                 .HaveNoOtherFields();
         }
 

--- a/test/UnitTests/Kvasir/Translation/_Converters.cs
+++ b/test/UnitTests/Kvasir/Translation/_Converters.cs
@@ -13,6 +13,10 @@ namespace UT.Kvasir.Translation {
             public T Convert(T? source) { return source!; }
             public T? Revert(T result) { return result; }
         }
+        public class Enumify<T, E> : IDataConverter<T, E> where T : notnull where E : Enum {
+            public E Convert(T source) { return (E)new EnumToNumericConverter(typeof(E)).ConverterImpl.Revert(source)!; }
+            public T Revert(E result) { return (T)new EnumToNumericConverter(typeof(E)).ConverterImpl.Convert(result)!; }
+        }
         public class Invert : IDataConverter<bool, bool> {
             public bool Convert(bool source) { return !source; }
             public bool Revert(bool result) { return !result; }
@@ -44,6 +48,10 @@ namespace UT.Kvasir.Translation {
         public class RoundDown : IDataConverter<double, long> {
             public long Convert(double source) { return (long)source; }
             public double Revert(long result) { return (double)result + 0.25; }
+        }
+        public class SwapEnums<A, B> : IDataConverter<A, B> where A : notnull, Enum where B : Enum {
+            public B Convert(A source) { return (B)System.Convert.ChangeType(source, typeof(int)); }
+            public A Revert(B result) { return (A)System.Convert.ChangeType(result, typeof(int)); }
         }
         public class ToError<T> : IDataConverter<T?, Exception?> {
             public Exception? Convert(T? source) { return default; }

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -3577,7 +3577,7 @@ namespace UT.Kvasir.Translation {
             public decimal Longitude { get; set; }
         }
 
-        // Test Scenario: Data Conversion Changes Field's Type (✓applied✓)
+        // Test Scenario: Data Conversion Changes Field's Type to Scalar (✓applied✓)
         public class Comet {
             [PrimaryKey] public Guid AstronomicalIdentifier { get; set; }
             public double Aphelion { get; set; }
@@ -3586,6 +3586,32 @@ namespace UT.Kvasir.Translation {
             public ulong MassKg { get; set; }
             public double Albedo { get; set; }
             public float OrbitalPeriod { get; set; }
+        }
+
+        // Test Scenario: Data Conversion Changes Field's Type to Enumeration (✓applied✓)
+        public class TitleOfYourSexTape {
+            [PrimaryKey] public string Title { get; set; } = "";
+            public string CharacterSaying { get; set; } = "";
+            public string CharacterReceiving { get; set; } = "";
+            [DataConverter(typeof(Enumify<int, DayOfWeek>))] public int DayOfWeek { get; set; }
+            public int Season { get; set; }
+            public int EpisodeNumber { get; set; }
+            public double Timestamp { get; set; }
+        }
+
+        // Test Scenario: Data Conversion Changes Field's Type to Different Enumeration (✓applied✓)
+        public class VestigeOfDivergence {
+            public enum Campaign { C1, C2, C3 }
+            public enum Party { VoxMachina, MightyNein, BellsHells, DarringtonBrigade, CrownKeepers }
+            public enum State { Dormant, Awakened, Exalted }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            public string Deity { get; set; } = "";
+            public string? Wielder { get; set; }
+            [DataConverter(typeof(SwapEnums<Campaign, Party>))] public Campaign? IntroducedIn { get; set; }
+            public byte AttackBonus { get; set; }
+            public int AverageDamage { get; set; }
+            public State CurrentState { get; set; }
         }
 
         // Test Scenario: Custom Data Conversion for Enumeration Field (✓applied✓)

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -842,6 +842,7 @@ TikTok
 Time Traveler
 Time Zone
 Timestamp
+"Title of Your Sex Tape" Joke
 Tongue Twister
 Tooth
 Toothbrush
@@ -879,6 +880,7 @@ Vacuum Cleaner
 Valet
 Vampire Slayer
 Verb
+Vestige of Divergence
 Vigenère Cipher
 Vineyard
 Vitamin


### PR DESCRIPTION
This commit fixes a bug in the basic Translation layer that mishandled [DataConverter] annotations where the resutl type was an enumeration. Previously, the restricted image portion of the FieldDescriptor was not updated, leading to zero valid enumerators being available when the EnumField instance was created. This has been fixed, with the system now correctly identifying scalar-to-enumeration and enumeration-to-enumeration conversions.