### PR TITLE
Make AsStringAttribute and NumericAttribute Non-Nestable

### DIFF
--- a/src/Kvasir/Annotations/EnumAttributes.cs
+++ b/src/Kvasir/Annotations/EnumAttributes.cs
@@ -11,16 +11,8 @@ namespace Kvasir.Annotations {
     ///   enumeration support. The <see cref="NumericAttribute"/> can be used to override the default storage behavior
     ///   and insist that the storage be a numeric type instead.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
-    public sealed class NumericAttribute : Attribute, INestableAnnotation {
-        /// <inheritdoc/>
-        public string Path { get; init; } = "";
-
-        /// <inheritdoc/>
-        INestableAnnotation INestableAnnotation.WithPath(string path) {
-            return new NumericAttribute() { Path = path };
-        }
-    }
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed class NumericAttribute : Attribute {}
 
     /// <summary>
     ///   An annotation that specifies that the type of the Field backing a particular property should correspond to the
@@ -32,14 +24,6 @@ namespace Kvasir.Annotations {
     ///   enumeration support. the <see cref="AsStringAttribute"/> can be used to override the default storage behavior
     ///   and insist that the storage be a string type even if enumeration support is available.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
-    public sealed class AsStringAttribute : Attribute, INestableAnnotation {
-        /// <inheritdoc/>
-        public string Path { get; init; } = "";
-
-        /// <inheritdoc/>
-        INestableAnnotation INestableAnnotation.WithPath(string path) {
-            return new AsStringAttribute() { Path = path };
-        }
-    }
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed class AsStringAttribute : Attribute {}
 }

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -739,12 +739,6 @@
               and insist that the storage be a numeric type instead.
             </remarks>
         </member>
-        <member name="P:Kvasir.Annotations.NumericAttribute.Path">
-            <inheritdoc/>
-        </member>
-        <member name="M:Kvasir.Annotations.NumericAttribute.Kvasir#Annotations#INestableAnnotation#WithPath(System.String)">
-            <inheritdoc/>
-        </member>
         <member name="T:Kvasir.Annotations.AsStringAttribute">
             <summary>
               An annotation that specifies that the type of the Field backing a particular property should correspond to the
@@ -756,12 +750,6 @@
               enumeration support. the <see cref="T:Kvasir.Annotations.AsStringAttribute"/> can be used to override the default storage behavior
               and insist that the storage be a string type even if enumeration support is available.
             </remarks>
-        </member>
-        <member name="P:Kvasir.Annotations.AsStringAttribute.Path">
-            <inheritdoc/>
-        </member>
-        <member name="M:Kvasir.Annotations.AsStringAttribute.Kvasir#Annotations#INestableAnnotation#WithPath(System.String)">
-            <inheritdoc/>
         </member>
         <member name="T:Kvasir.Annotations.CodeOnlyAttribute">
             <summary>

--- a/test/UnitTests/Kvasir/Annotations/TagAttributes.cs
+++ b/test/UnitTests/Kvasir/Annotations/TagAttributes.cs
@@ -124,28 +124,11 @@ namespace UT.Kvasir.Annotations {
 
         [TestMethod] public void Numeric_Construct() {
             // Arrange
-            var path = "Nested.Path";
 
             // Act
-            var direct = new NumericAttribute();
-            var nested = new NumericAttribute() { Path = path };
+            _ = new NumericAttribute();
 
             // Assert
-            direct.Path.Should().BeEmpty();
-            nested.Path.Should().Be(path);
-        }
-
-        [TestMethod] public void Numeric_DuplicateWithPath() {
-            // Arrange
-            var path = "Nested.Path";
-            var original = new NumericAttribute();
-
-            // Act
-            var attr = (original as INestableAnnotation).WithPath(path);
-
-            // Assert
-            attr.Should().BeOfType<NumericAttribute>();
-            attr.Path.Should().Be(path);
         }
 
         [TestMethod] public void Numeric_UniqueId() {
@@ -201,28 +184,11 @@ namespace UT.Kvasir.Annotations {
 
         [TestMethod] public void AsString_Construct() {
             // Arrange
-            var path = "Nested.Path";
 
             // Act
-            var direct = new AsStringAttribute();
-            var nested = new AsStringAttribute() { Path = path };
+            _ = new AsStringAttribute();
 
             // Assert
-            direct.Path.Should().BeEmpty();
-            nested.Path.Should().Be(path);
-        }
-
-        [TestMethod] public void AsString_DuplicateWithPath() {
-            // Arrange
-            var path = "Nested.Path";
-            var original = new AsStringAttribute();
-
-            // Act
-            var attr = (original as INestableAnnotation).WithPath(path);
-
-            // Assert
-            attr.Should().BeOfType<AsStringAttribute>();
-            attr.Path.Should().Be(path);
         }
 
         [TestMethod] public void AsString_UniqueId() {


### PR DESCRIPTION
These attributes induce data conversions on the properties they annotate, so they should be non-nestable just like the DataConverterAttribute. The nestability of these annotations was not tested at all in the Translation layer.