### PR TITLE
Add New Schema Translation Tests

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -1585,7 +1585,7 @@
             <summary>
               Create a new <see cref="T:Kvasir.Reconstitution.DefaultStructCreator"/>.
             </summary>
-            <param name="resultType">
+            <param name="type">
               The <see cref="P:Kvasir.Reconstitution.DefaultStructCreator.ResultType"/> of the new <see cref="T:Kvasir.Reconstitution.DefaultStructCreator"/>.
             </param>
         </member>

--- a/src/Kvasir/Reconstitution/DefaultStructCreator.cs
+++ b/src/Kvasir/Reconstitution/DefaultStructCreator.cs
@@ -20,7 +20,7 @@ namespace Kvasir.Reconstitution {
         /// <summary>
         ///   Create a new <see cref="DefaultStructCreator"/>.
         /// </summary>
-        /// <param name="resultType">
+        /// <param name="type">
         ///   The <see cref="ResultType"/> of the new <see cref="DefaultStructCreator"/>.
         /// </param>
         public DefaultStructCreator(Type type) {

--- a/src/Kvasir/Translation/BaseTranslations.cs
+++ b/src/Kvasir/Translation/BaseTranslations.cs
@@ -136,7 +136,18 @@ namespace Kvasir.Translation {
                     Default = Option.None<object?>(),
                     InPrimaryKey = false,
                     CandidateKeyMemberships = new HashSet<string>(),
-                    ForeignReference = Option.Some(type)
+                    ForeignReference = Option.Some(type),
+                    Constraints = new ConstraintBucket(
+                        RelativeToZero: Option.None<ComparisonOperator>(),
+                        LowerBound: Option.None<Bound>(),
+                        UpperBound: Option.None<Bound>(),
+                        MinimumLength: Option.None<Bound>(),
+                        MaximumLength: Option.None<Bound>(),
+                        AllowedValues: new HashSet<object>(),
+                        DisallowedValues: new HashSet<object>(),
+                        RestrictedImage: new HashSet<object>(descriptor.Constraints.RestrictedImage),
+                        CHECKs: new List<CheckGen>()
+                    )
                 };
             }
 

--- a/src/Kvasir/Translation/FieldAnnotations.cs
+++ b/src/Kvasir/Translation/FieldAnnotations.cs
@@ -59,11 +59,14 @@ namespace Kvasir.Translation {
                     throw Error.InvalidName(context, annotation, annotation.Name);
                 }
 
-                // It is an error for multiple [Name] attributes on a single property to apply to the same Path, though
-                // it is legal for a [Name] attribute at an outer scope to override that of one applied at an inner
-                // scope
+                // It is an error for multiple [Name] attributes on a single property to apply to the same Path, unless
+                // the name being applied is the same (making the second annotation redundant). It is, however, legal
+                // for a [Name] attribute at an outer scope to override that of one applied at an inner scope
                 if (!processed.Add(annotation.Path)) {
-                    throw Error.DuplicateAnnotation(context, annotation);
+                    if (!state.Fields[annotation.Path].Name.SequenceEqual(Enumerable.Repeat(annotation.Name, 1))) {
+                        throw Error.DuplicateAnnotation(context, annotation);
+                    }
+                    continue;
                 }
 
                 // If the Path on a [Name] attribute refers to a concrete Field (it would be a scalar or an enumeration)

--- a/test/UnitTests/Kvasir/Translation/CandidateKeys.cs
+++ b/test/UnitTests/Kvasir/Translation/CandidateKeys.cs
@@ -65,7 +65,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherCandidateKeys();
         }
 
-        [TestMethod] public void MultipleIdenticalUnnamedCandidateKeys() {
+        [TestMethod] public void MultipleDirectIdenticalUnnamedCandidateKeys() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Pigment);
@@ -76,6 +76,20 @@ namespace UT.Kvasir.Translation {
             // Assert
             translation.Principal.Table.Should()
                 .HaveAnonymousCandidateKey().OfFields(nameof(Pigment.ChemicalFormula)).And
+                .HaveNoOtherCandidateKeys();
+        }
+
+        [TestMethod] public void MultipleIndirectIdenticalUnnamedCandidateKeys() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Octopus);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveAnonymousCandidateKey().OfFields("Nomenclature.Family").And
                 .HaveNoOtherCandidateKeys();
         }
 

--- a/test/UnitTests/Kvasir/Translation/ColumnOrdering.cs
+++ b/test/UnitTests/Kvasir/Translation/ColumnOrdering.cs
@@ -166,7 +166,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherFields();
         }
 
-        [TestMethod] public void TwoScalarFieldsOrderedToSameIndex_IsError() {
+        [TestMethod] public void TwoScalarFieldsOrderedToSameIndexInEntity_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Pizza);
@@ -175,11 +175,25 @@ namespace UT.Kvasir.Translation {
             var translate = () => translator[source];
 
             // Assert
-            // Assert
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining("two Fields pinned to column index")         // category
                 .WithMessageContaining("7");                                        // details / explanation
+        }
+
+        [TestMethod] public void TwoScalarFieldsOrderedToSameIndexInAggregate_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BiblicalPlague);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(nameof(BiblicalPlague.Translation))          // source type
+                .WithMessageContaining("two Fields pinned to column index")         // category
+                .WithMessageContaining("1");                                        // details / explanation
         }
 
         [TestMethod] public void TwoNestedFieldsOrderedToSameIndex_IsError() {

--- a/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
@@ -215,6 +215,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(Influenza.Outbreak));                 // details / explanation
         }
 
+        [TestMethod] public void IsGreaterThan_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PapalBull);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void IsGreaterThan_NestedReference_IsError() {
             // Arrange
             var translator = new Translator();
@@ -713,6 +726,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("0")                                         // details / explanation
                 .WithMessageContaining("is not in interval (0, +∞)");               // details / explanation
         }
+
+        [TestMethod] public void IsGreaterThan_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Madrasa);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Madrasa.ID.Class))                    // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("'s'")                                       // details / explanation
+                .WithMessageContaining("is not in interval ('w', +∞)");             // details / explanation
+        }
     }
 
     [TestClass, TestCategory("Constraints - Comparison")]
@@ -914,6 +945,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsLessThan]")                        // details / explanation
                 .WithMessageContaining("totally ordered")                           // details / explanation
                 .WithMessageContaining(nameof(Cartel.CommodityType));               // details / explanation
+        }
+
+        [TestMethod] public void IsLessThan_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(CVE);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void IsLessThan_NestedReference_IsError() {
@@ -1415,6 +1459,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("15.0")                                      // details / explanation
                 .WithMessageContaining("is not in interval (-∞, 10.0)");            // details / explanation
         }
+
+        [TestMethod] public void IsLessThan_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ContactLens);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(ContactLens.HexQuad.B))               // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("197")                                       // details / explanation
+                .WithMessageContaining("is not in interval (-∞, 101)");             // details / explanation
+        }
     }
 
     [TestClass, TestCategory("Constraints - Comparison")]
@@ -1614,6 +1676,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsGreaterOrEqualTo]")                // details / explanation
                 .WithMessageContaining("totally ordered")                           // details / explanation
                 .WithMessageContaining(nameof(SlumberParty.RoadType));              // details / explanation
+        }
+
+        [TestMethod] public void IsGreaterOrEqualTo_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Spa);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void IsGreaterOrEqualTo_NestedReference_IsError() {
@@ -2109,6 +2184,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("1E-05")                                     // details / explanation
                 .WithMessageContaining("is not in interval [1.3, +∞)");             // details / explanation
         }
+
+        [TestMethod] public void IsGreaterOrEqualTo_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SlapBet);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(SlapBet.Terms.Slaps))                 // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("1")                                         // details / explanation
+                .WithMessageContaining("is not in interval [3, +∞)");               // details / explanation
+        }
     }
 
     [TestClass, TestCategory("Constraints - Comparison")]
@@ -2308,6 +2401,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsLessOrEqualTo]")                   // details / explanation
                 .WithMessageContaining("totally ordered")                           // details / explanation
                 .WithMessageContaining(nameof(Knife.Category));                     // details / explanation
+        }
+
+        [TestMethod] public void IsLessOrEqualTo_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(WhiteWalker);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void IsLessOrEqualTo_NestedReference_IsError() {
@@ -2801,6 +2907,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("23")                                        // details / explanation
                 .WithMessageContaining("is not in interval (-∞, 10]");              // details / explanation
         }
+
+        [TestMethod] public void IsLessOrEqualTo_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Defenestration);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Defenestration.Window.Width))         // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("178.916")                                   // details / explanation
+                .WithMessageContaining("is not in interval (-∞, 8.9]");             // details / explanation
+        }
     }
 
     [TestClass, TestCategory("Constraints - Comparison")]
@@ -2968,6 +3092,19 @@ namespace UT.Kvasir.Translation {
                     StanleyCup.Conf.Eastern,
                     StanleyCup.Conf.Western
                 );
+        }
+
+        [TestMethod] public void IsNot_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Diet);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void IsNot_NestedReference_IsError() {
@@ -3451,6 +3588,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
                 .WithMessageContaining("153")                                       // details / explanation
                 .WithMessageContaining("is explicitly disallowed");                 // details / explanation
+        }
+
+        [TestMethod] public void IsNot_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(HearthstoneMinion);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(HearthstoneMinion.Statistics.Health)) // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("-69")                                       // details / explanation
+                .WithMessageContaining("value is explicitly disallowed");           // details / explanation
         }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/DiscretenessConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/DiscretenessConstraints.cs
@@ -217,6 +217,19 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
+        [TestMethod] public void IsOneOf_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PullRequest);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void IsOneOf_NestedRelationProperty_IsError() {
             // Arrange
             var translator = new Translator();
@@ -747,6 +760,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("13")                                        // details / explanation
                 .WithMessageContaining("{ 30, 60, 90, 120 }");                      // details / explanation
         }
+
+        [TestMethod] public void IsOneOf_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(IKEAFurniture);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(IKEAFurniture.CatalogEntry.Room))     // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("Group.Den")                                 // details / explanation
+                .WithMessageContaining("{ Group.Bedroom, Group.Bathroom }");        // details / explanation
+        }
     }
 
     [TestClass, TestCategory("Constraints - Discreteness")]
@@ -921,6 +952,19 @@ namespace UT.Kvasir.Translation {
                 .HaveConstraint("FirstJob.PoolNumber", InclusionOperator.NotIn,
                     7U, 17U, 27U, 37U
                 ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNotOneOf_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SearchWarrant);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
                 .HaveNoOtherConstraints();
         }
 
@@ -1494,6 +1538,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("default*does not satisfy constraints")      // category
                 .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
                 .WithMessageContaining("\"Anise\"")                                 // details / explanation
+                .WithMessageContaining("value is explicitly disallowed");           // details / explanation
+        }
+
+        [TestMethod] public void IsNotOneOf_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(GirlScoutCookie);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(GirlScoutCookie.Label.Calories))      // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("0.0")                                       // details / explanation
                 .WithMessageContaining("value is explicitly disallowed");           // details / explanation
         }
     }

--- a/test/UnitTests/Kvasir/Translation/FieldClusivity.cs
+++ b/test/UnitTests/Kvasir/Translation/FieldClusivity.cs
@@ -355,7 +355,7 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherFields();
         }
 
-        [TestMethod] public void IncludeInModel_ExplicitInterfaceImplementation() {
+        [TestMethod] public void IncludeInModel_ExplicitInterfaceImplementationScalar() {
             // Arrange
             var translator = new Translator();
             var source = typeof(BasicDiceRoll);
@@ -371,6 +371,26 @@ namespace UT.Kvasir.Translation {
                 .HaveField(nameof(IDiceRoll.Plus)).OfTypeInt32().BeingNonNullable().And
                 .HaveField(nameof(IDiceRoll.Advantage)).OfTypeBoolean().BeingNonNullable().And
                 .HaveField(nameof(IDiceRoll.Disadvantage)).OfTypeBoolean().BeingNonNullable().And
+                .HaveNoOtherFields();
+        }
+
+        [TestMethod] public void IncludeInModel_ExplicitInterfaceImplementationAggregate() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Wrestler);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(IAthlete.InternationalAthleteIdentifier)).OfTypeGuid().BeingNonNullable().And
+                .HaveField(nameof(Wrestler.BirthName)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(Wrestler.RingName)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(Wrestler.WWETitles)).OfTypeInt32().BeingNonNullable().And
+                .HaveField("Bio.Height").OfTypeDouble().BeingNonNullable().And
+                .HaveField("Bio.Weight").OfTypeDouble().BeingNonNullable().And
+                .HaveField("Bio.DOB").OfTypeDateTime().BeingNonNullable().And
                 .HaveNoOtherFields();
         }
 

--- a/test/UnitTests/Kvasir/Translation/FieldNaming.cs
+++ b/test/UnitTests/Kvasir/Translation/FieldNaming.cs
@@ -308,6 +308,22 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherFields();
         }
 
+        [TestMethod] public void NameConflictWithExplicitInterfaceImplementation_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(GroundMeat);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining("two or more Fields with name")              // category
+                .WithMessageContaining("\"CaloriesPerGram\"");                      // details / explanation
+        }
+
         [TestMethod] public void ChangeToNameOfExistingField_IsError() {
             // Arrange
             var translator = new Translator();
@@ -339,7 +355,26 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("\"Destination\"");                          // details / explanation
         }
 
-        [TestMethod] public void MultipleNameChangesOnScalarProperty_IsError() {
+        [TestMethod] public void MultipleIdenticalNameChangesOnScalarProperty() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Antiparticle);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField(nameof(Antiparticle.Name)).OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(Antiparticle.Spin)).OfTypeDouble().BeingNonNullable().And
+                .HaveField(nameof(Antiparticle.Charge)).OfTypeInt32().BeingNonNullable().And
+                .HaveField("Counterpart").OfTypeText().BeingNonNullable().And
+                .HaveField(nameof(Antiparticle.Mass)).OfTypeDecimal().BeingNonNullable().And
+                .HaveField(nameof(Antiparticle.DiscoveredBy)).OfTypeText().BeingNullable().And
+                .HaveNoOtherFields();
+        }
+
+        [TestMethod] public void MultipleDifferentNameChangesOnScalarProperty_IsError() {
             // Arrange
             var translator = new Translator();
             var source = typeof(BankAccount);
@@ -351,6 +386,22 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(BankAccount.RoutingNumber))           // error location
+                .WithMessageContaining("duplicated")                                // category
+                .WithMessageContaining("[Name]");                                   // details / explanation
+        }
+
+        [TestMethod] public void RedundantAndImpactfulNameChangesOnScalarProperty_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Billionaire);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Billionaire.FirstReached))            // error location
                 .WithMessageContaining("duplicated")                                // category
                 .WithMessageContaining("[Name]");                                   // details / explanation
         }

--- a/test/UnitTests/Kvasir/Translation/MixedConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/MixedConstraints.cs
@@ -689,5 +689,82 @@ namespace UT.Kvasir.Translation {
                 ).And
                 .HaveNoOtherConstraints();
         }
+
+        [TestMethod] public void AlteredComparisonsOnNestedField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(TribeOfIsrael);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("FirstMentioned.Book", ComparisonOperator.GTE, "Bible").And
+                .HaveConstraint("FirstMentioned.Book", ComparisonOperator.LTE, "Qur'an").And
+                .HaveConstraint("FirstMentioned.Chapter", InclusionOperator.In,
+                    (byte)1, (byte)2, (byte)3
+                ).And
+                .HaveConstraint("FirstMentioned.Verse", ComparisonOperator.GT, 0L).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void AlteredSignednessOnNestedField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SecretPolice);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Statistics.Arrests", InclusionOperator.NotIn,
+                    0, 7, 196, 4410905
+                ).And
+                .HaveConstraint("Statistics.Murders", ComparisonOperator.GT, 0.0).And
+                .HaveConstraint("Statistics.Murders", ComparisonOperator.LT, 195385.96).And
+                .HaveConstraint("Statistics.Bribes", ComparisonOperator.GT, (decimal)0).And
+                .HaveConstraint("Statistics.Bribes", ComparisonOperator.NE, (decimal)80.0).And
+                .HaveConstraint("Statistics.YearsActive", InclusionOperator.In,
+                    (sbyte)10, (sbyte)20, (sbyte)30
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void AlteredLengthsOnNestedField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(SearchEngine);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("LandingPage.Domain", InclusionOperator.In,
+                    "com", "tv", "gov", "net"
+                ).And
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void AlteredDiscretenessOnNestedField() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(BeninBronze);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Dimensions.Length", InclusionOperator.In,
+                    4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0
+                ).And
+                .HaveConstraint("Dimensions.Width", InclusionOperator.NotIn,
+                    1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0
+                ).And
+                .HaveNoOtherConstraints();
+        }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/PrimaryKeys.cs
+++ b/test/UnitTests/Kvasir/Translation/PrimaryKeys.cs
@@ -517,7 +517,7 @@ namespace UT.Kvasir.Translation {
                 .HavePrimaryKey().OfFields(nameof(Polyhedron.Name));
         }
 
-        [TestMethod] public void ScalarMarkedPrimaryKeyMultipleTimes_Redundant() {
+        [TestMethod] public void ScalarMarkedPrimaryKeyMultipleTimesDirectly_Redundant() {
             // Arrange
             var translator = new Translator();
             var source = typeof(Airport);
@@ -528,6 +528,24 @@ namespace UT.Kvasir.Translation {
             // Assert
             translation.Principal.Table.Should()
                 .HavePrimaryKey().OfFields(nameof(Airport.IATA));
+        }
+
+        [TestMethod] public void ScalarMarkedPrimaryKeyMultipleTimesIndirectly_Redundant() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(CompressionFormat);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HavePrimaryKey().OfFields(
+                    nameof(CompressionFormat.Suffix),
+                    "LastStableRelease.Major",
+                    "LastStableRelease.Minor",
+                    "LastStableRelease.Patch"
+                );
         }
 
         [TestMethod] public void NullableScalarMarkedPrimaryKey_IsError() {

--- a/test/UnitTests/Kvasir/Translation/SignednessConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/SignednessConstraints.cs
@@ -235,6 +235,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("\"Unit\"");                                 // details / explanation
         }
 
+        [TestMethod] public void IsPositive_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Lycanthrope);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void IsPositive_RelationNestedApplicableScalar() {
             // Arrange
             var translator = new Translator();
@@ -516,6 +529,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("-89")                                       // details / explanation
                 .WithMessageContaining("(0, +∞)");                                  // details / explanation
         }
+
+        [TestMethod] public void IsPositive_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Cyclops);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Cyclops.Mention.Book))                // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("-9")                                        // details / explanation
+                .WithMessageContaining("(0, +∞)");                                  // details / explanation
+        }
     }
 
     [TestClass, TestCategory("Constraints - Signedness")]
@@ -757,6 +788,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("refers to a non-scalar")                    // category
                 .WithMessageContaining("[Check.IsNegative]")                        // details / explanation
                 .WithMessageContaining("\"State\"");                                // details / explanation
+        }
+
+        [TestMethod] public void IsNegative_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(DragonRider);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void IsNegative_RelationNestedApplicableScalar() {
@@ -1037,6 +1081,24 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("0")                                         // details / explanation
                 .WithMessageContaining("(-∞, 0)");                                  // details / explanation
         }
+
+        [TestMethod] public void IsNegative_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PressSecretary);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(PressSecretary.Date.Year))            // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("1563")                                      // details / explanation
+                .WithMessageContaining("(-∞, 0)");                                  // details / explanation
+        }
     }
 
     [TestClass, TestCategory("Constraints - Signedness")]
@@ -1248,6 +1310,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.IsNonZero]")                         // details / explanation
                 .WithMessageContaining("numeric")                                   // details / explanation
                 .WithMessageContaining(nameof(Guid));                               // details / explanation
+        }
+
+        [TestMethod] public void IsNonZero_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(NewsAnchor);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void IsNonZero_NestedReference_IsError() {
@@ -1541,6 +1616,24 @@ namespace UT.Kvasir.Translation {
             translate.Should().ThrowExactly<KvasirException>()
                 .WithMessageContaining(source.Name)                                 // source type
                 .WithMessageContaining(nameof(Pulley.RopeTension))                  // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("0.0")                                       // details / explanation
+                .WithMessageContaining("value is explicitly disallowed");           // details / explanation
+        }
+
+        [TestMethod] public void IsNonZero_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Ceviche);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Ceviche.Citrus.Tablespoons))          // error location
                 .WithMessageContaining("default*does not satisfy constraints")      // category
                 .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
                 .WithMessageContaining("0.0")                                       // details / explanation

--- a/test/UnitTests/Kvasir/Translation/StringLengthConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/StringLengthConstraints.cs
@@ -234,6 +234,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining(nameof(UInt32));                             // details / explanation
         }
 
+        [TestMethod] public void IsNonEmpty_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(PornStar);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void IsNonEmpty_NestedReference_IsError() {
             // Arrange
             var translator = new Translator();
@@ -531,6 +544,25 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("length is 0")                               // details / explanation
                 .WithMessageContaining("is not in interval [1, +∞)");               // details / explanation
         }
+
+        [TestMethod] public void LengthIsNonEmpty_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Lollipop);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Lollipop.LollipopFlavor.Name))        // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("\"\"")                                      // details / explanation
+                .WithMessageContaining("length is 0")                               // details / explanation
+                .WithMessageContaining("is not in interval [1, +∞)");               // details / explanation
+        }
     }
 
     [TestClass, TestCategory("Constraints - String Length")]
@@ -753,6 +785,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.LengthIsAtLeast]")                   // details / explanation
                 .WithMessageContaining(nameof(String))                              // details / explanation
                 .WithMessageContaining(nameof(UInt64));                             // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtLeast_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Circus);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void LengthIsAtLeast_NestedReference_IsError() {
@@ -1086,6 +1131,25 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("length is 7")                               // details / explanation
                 .WithMessageContaining("is not in interval [289, +∞)");             // details / explanation
         }
+
+        [TestMethod] public void LengthIsAtLeast_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Briefcase);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Briefcase.Color.PantoneName))         // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("\"unknown\"")                               // details / explanation
+                .WithMessageContaining("length is 7")                               // details / explanation
+                .WithMessageContaining("is not in interval [15, +∞)");              // details / explanation
+        }
     }
 
     [TestClass, TestCategory("Constraints - String Length")]
@@ -1310,6 +1374,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.LengthIsAtMost]")                    // details / explanation
                 .WithMessageContaining(nameof(String))                              // details / explanation
                 .WithMessageContaining(nameof(Guid));                               // details / explanation
+        }
+
+        [TestMethod] public void LengthIsAtMost_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Bust);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void LengthIsAtMost_NestedReference_IsError() {
@@ -1641,6 +1718,25 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("length is 5")                               // details / explanation
                 .WithMessageContaining("is not in interval [0, 3]");                // details / explanation
         }
+
+        [TestMethod] public void LengthIsAtMost_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Speakeasy);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Speakeasy.Address.StreetName))        // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("\"Main First Prime\"")                      // details / explanation
+                .WithMessageContaining("length is 16")                              // details / explanation
+                .WithMessageContaining("is not in interval [0, 14]");               // details / explanation
+        }
     }
 
     [TestClass, TestCategory("Constraints - String Length")]
@@ -1921,6 +2017,19 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("[Check.LengthIsBetween]")                   // details / explanation
                 .WithMessageContaining(nameof(String))                              // details / explanation
                 .WithMessageContaining(nameof(Single));                             // details / explanation
+        }
+
+        [TestMethod] public void LengthIsBetween_OriginalOnReferenceNestedScalar() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Lagoon);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void LengthIsBetween_NestedRelation_IsError() {
@@ -2236,6 +2345,25 @@ namespace UT.Kvasir.Translation {
                 .WithMessageContaining("\"Smucker's\"")                             // details / explanation
                 .WithMessageContaining("length is 9")                               // details / explanation
                 .WithMessageContaining("is not in interval [4, 8]");                // details / explanation
+        }
+
+        [TestMethod] public void LengthIsBetween_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Kebab);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().ThrowExactly<KvasirException>()
+                .WithMessageContaining(source.Name)                                 // source type
+                .WithMessageContaining(nameof(Kebab.StreetVendor.Name))             // error location
+                .WithMessageContaining("default*does not satisfy constraints")      // category
+                .WithMessageContaining("one or more [Check.xxx] constraints")       // details / explanation
+                .WithMessageContaining("\"Ezekiel's Meat-on-a-Stick Emporium\"")    // details / explanation
+                .WithMessageContaining("length is 34")                              // details / explanation
+                .WithMessageContaining("is not in interval [13, 21]");              // details / explanation
         }
     }
 }

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -28,6 +28,7 @@ Animation (PowerPoint)
 Antari
 Antibiotic
 Antihistamine
+Antiparticle
 Antipope
 Apocalypse
 Apostle
@@ -89,10 +90,13 @@ Bay
 Beach
 Belt
 Ben 10 Alien
+Benin Bronze
 Bestiary
+Biblical Plague
 Bicycle
 Big Block of Cheese Day
 Billiard Ball
+Billionaire
 Binary Test
 Bingo Card
 Biography
@@ -124,9 +128,11 @@ Boycott
 Brassiere
 Bread
 Bridge
+Briefcase
 Brothel
 Bug Spray
 Burrito
+Bust
 Butterfly
 Button (UI)
 C++ Header File
@@ -170,6 +176,7 @@ Cemetery
 Cenote
 Census
 Cereal
+Ceviche
 Chakra
 Character (text)
 Check
@@ -193,6 +200,7 @@ CinemaSins
 Circle
 Circle Dance
 Circle of Hell
+Circus
 Civilization VI City State
 Civilization VI District
 Civilization VI Military Unit
@@ -215,6 +223,7 @@ ComicCon
 Command (terminal)
 Commercial
 Compiler Warning
+Compression Format
 Computer Virus
 Concentration Camp
 Concert
@@ -223,6 +232,7 @@ Condiment
 Confidence Interval
 Conlang
 Connecting Wall
+Contact Lens
 Constellation
 Constitution
 Constitutional Amendment
@@ -242,7 +252,9 @@ Cryptocurrency
 Cryptogram
 Cult
 Currency
+CVE
 Cybersite
+Cyclops
 D&D Character
 D&D Monster
 D&D Spell
@@ -255,12 +267,14 @@ Date
 Dating App
 Debit Card
 Decathlon
+Defenestration
 Delicatessen
 Denarian
 Dentist
 Desert
 Diamond
 Dice Roll
+Diet
 Dinosaur
 Directory (file system)
 Discworld Guild
@@ -276,6 +290,7 @@ Domino
 Donut
 Draft Pick
 Dragon
+Dragon Rider (Eragon)
 Dream
 Dreidel
 Drinking Fountain
@@ -362,6 +377,7 @@ Geocache
 Geologic Epoch
 Geyser
 Ghost (Danny Phantom)
+Girl Scout Cookie
 Git Commit
 Git Hook
 Gold Rush
@@ -375,6 +391,7 @@ Grand Prix
 Great Old One
 Greek God
 Greek Letter
+Ground Meat
 Guillotine
 Guitar
 Gulag
@@ -427,6 +444,7 @@ Ice Age
 Ice Cream Sundae
 IDE
 Igloo
+IKEA Furniture
 Imaginary Friend
 Immaculate Grid
 Immortal (Highlander)
@@ -461,6 +479,7 @@ Kaiju
 Kami
 Kanji
 Kayak
+Kebab
 Kentucky Derby
 Key Signature
 Keystroke
@@ -475,6 +494,7 @@ Knock-Knock Joke
 Kosher Agency
 Labor of Heracles
 Lagerstätte
+Lagoon
 Lake
 Lamp
 Land Card (MTG)
@@ -504,14 +524,17 @@ Locale (computing)
 Localization
 Lock (computing)
 Log-In Credentials
+Lollipop
 Longbow
 Lottery Ticket
 Luau
 Lunar Crater
 Lunar Eclipse
+Lycanthrope
 Lyric
 Madden NFL
 Madonna (painting)
+Madrasa
 Mafia Family
 Magazine
 Magic System
@@ -539,6 +562,7 @@ Mezuzah
 Military Base
 Milkshake
 Mime
+Minion (Hearthstone)
 Mint (currency)
 Mirror
 Missile
@@ -571,6 +595,7 @@ Nebula
 Necktie
 Neurotoxin
 Neurotransmitter
+News Anchor
 Newscast
 Newspaper
 Niqqud
@@ -587,6 +612,7 @@ Obi
 Ocean Current
 Oceanic Trench
 Oceanid
+Octopus
 Oil (cooking)
 Oil Field
 Oil Spill
@@ -608,6 +634,7 @@ Pagoda
 Painting
 Pajamas
 Panegyric
+Papal Bull
 Parabola
 Parashah
 Parking Garage
@@ -663,11 +690,13 @@ Pond
 Pop Tart
 Popcorn
 Pope
+Porn Star
 Post Office
 Potato
 Pregnancy Test
 Prescription
 Presidential Election
+Press Secretary
 Printer
 Prison
 Prisoner Exchange
@@ -681,6 +710,7 @@ Pseudonym
 Pterosaur
 Pub Crawl
 Pulitzer Prize
+Pull Request
 Pulley
 Pulsar
 Puppet Show
@@ -734,8 +764,11 @@ Screenwriter
 Screwdriver
 SCUBA Dive
 Sculpture
+Search Engine
+Search Warrant
 Season
 Secret Hitler Game
+Secret Police
 Secret Society
 Seder Plate
 Senator
@@ -761,6 +794,7 @@ Skydiver
 Skyscraper
 Slack Channel
 SlamBall Match
+Slap Bet
 Slave Revolt
 Slot Machine
 Slumber Party
@@ -776,7 +810,9 @@ Song
 Sonnet
 Sorority
 Soup
+Spa
 Space Shuttle
+Speakeasy
 Speed Limit
 Speedometer
 Spider-Man
@@ -859,6 +895,7 @@ Treasury Bond
 Treehouse
 Treehouse of Horror
 Triangle
+Tribe of Israel
 Trilogy
 Triplets
 Triptych
@@ -903,6 +940,7 @@ Web Browser
 Weekend Update
 Werewolf
 Where's Waldo?
+White Walker
 Wikipedia Page
 Wildfire
 Windmill
@@ -915,6 +953,7 @@ Wordle
 World Cup
 World Heritage Site
 Wormhole
+Wrestler
 Wristwatch
 xkcd Comic
 Yacht


### PR DESCRIPTION
This commit adds a number of tests of the Translation Layer's schema functionality that were previously missed. Many of these cases were identified during the planning for the complete refactor of that subsystem, though others were just identified via inspection. Note that these are all tests that cover missing logic, not missing lines of code, so it should have no impact on code coverage.

In particular, the new tests cover:

    * Column collisions identified in an Aggregate (rather than in an Entity)
    * Constraints that are modified by upstram annotations and applied via Paths
    * Constraints on Primary Key fields of References that should not propagate to the foreign keys
    * De-duplication of identical [Name] annotations
    * De-duplication of Primary and Candidate Key annotations from upstream applied via Paths
    * Default values that are originally valid and are later invalidated by upstream constraints
    * A few other one-off scenarios