### PR TITLE
Fix Incorrect Displays for Infinity, Scientific Notation Floats

### DIFF
--- a/src/Cybele/Extensions/Object.cs
+++ b/src/Cybele/Extensions/Object.cs
@@ -62,7 +62,14 @@ namespace Cybele.Extensions {
             }
             else if (self.GetType() == typeof(float) || self.GetType() == typeof(double) || self.GetType() == typeof(decimal)) {
                 var str = self.ToString()!;
-                if (!str.Contains('.')) {
+                if (str.StartsWith("1E")) {
+                    return str;
+                }
+                else if (str.EndsWith("∞") || str.EndsWith("Infinity")) {
+                    // The representation of various infinities is different on Windows vs. Ubuntu
+                    return str;
+                }
+                else if (!str.Contains('.')) {
                     return $"{str}.0";
                 }
                 else {

--- a/test/UnitTests/Cybele/Extensions/Object.cs
+++ b/test/UnitTests/Cybele/Extensions/Object.cs
@@ -102,6 +102,34 @@ namespace UT.Cybele.Extensions {
             floatDisplay.Should().Be(floatNumber.ToString() + ".0");
         }
 
+        [TestMethod] public void DisplayInfinity() {
+            // Arrange
+            var posInfinity = double.PositiveInfinity;
+            var negInfinity = double.NegativeInfinity;
+
+            // Act
+            var posInfinityDisplay = posInfinity.ForDisplay();
+            var negInfinityDisplay = negInfinity.ForDisplay();
+
+            // Assert
+            posInfinityDisplay.Should().Be(posInfinity.ToString());
+            negInfinityDisplay.Should().Be(negInfinity.ToString());
+        }
+
+        [TestMethod] public void DisplayScientificNotation() {
+            // Arrange
+            var scientificSmall = 0.0000001f;
+            var scientificLarge = 10000000000000f;
+
+            // Act
+            var scientificSmallDisplay = scientificSmall.ForDisplay();
+            var scientificLargeDisplay = scientificLarge.ForDisplay();
+
+            // Assert
+            scientificSmallDisplay.Should().Be("1E-07");
+            scientificLargeDisplay.Should().Be("1E+13");
+        }
+
         [TestMethod] public void DisplayCharacter() {
             // Arrange
             var character = '&';


### PR DESCRIPTION
This commit fixes a bug that caused positive/negative infinity and all floats represented in scientific notation to be displayed with a trailing .0. This was happening because the values would get caught up in the non-integral branch, which seeks to append the trailing .0 for floating-point values that are equivalent to integers. The fix is to have a separate carve out for these two sub-cases.