### PR TITLE
Populate Restricted Domain when Boolean Property is Data Converted

### DIFF
--- a/src/Kvasir/Translation/FieldDescriptors/FieldDescriptor.cs
+++ b/src/Kvasir/Translation/FieldDescriptors/FieldDescriptor.cs
@@ -619,6 +619,13 @@ namespace Kvasir.Translation {
             if (conv.SourceType.IsEnum && !conv.ResultType.IsEnum) {
                 restrictedDomain_ = conv.SourceType.ValidValues().Select(e => conv.TryConvert(e, context)!).ToHashSet();
             }
+
+            // Similarly, if the CLR type of the property is `bool` but the result of the Data Converter is not, then
+            // we have to pass { true, false } through the Data Converter for the results to become the set of allowed
+            // values.
+            else if (conv.SourceType == typeof(bool) && conv.ResultType != typeof(bool)) {
+                restrictedDomain_ = new bool[] { true, false }.Select(b => conv.TryConvert(b, context)!).ToHashSet();
+            }
         }
 
         /// <summary>
@@ -653,6 +660,9 @@ namespace Kvasir.Translation {
             if (converter.SourceType.IsEnum && !converter.ResultType.IsEnum) {
                 restrictedDomain_ = converter.SourceType.ValidValues().Select(e => converter.TryConvert(e, context)!).ToHashSet();
             }
+
+            // No need for a Boolean check here, because the only annotations that can trigger this constructor are
+            // [Numeric] or [AsString], neither of which is applicable to Boolean-type properties/Fields.
         }
 
         /// <summary>

--- a/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
@@ -3196,7 +3196,7 @@ namespace UT.Kvasir.Translation {
 
             // Assert
             translation.Principal.Table.Should()
-                .HaveConstraint("Destroyed", ComparisonOperator.NE, 7).And
+                .HaveConstraint("NumPossessors", ComparisonOperator.NE, 7).And
                 .HaveNoOtherConstraints();
         }
 

--- a/test/UnitTests/Kvasir/Translation/DataConverters.cs
+++ b/test/UnitTests/Kvasir/Translation/DataConverters.cs
@@ -130,6 +130,26 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
+        [TestMethod] public void BooleanToUnrelatedType() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(MathematicalConjecture);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Name").OfTypeText().BeingNonNullable().And
+                .HaveField("IsMillenniumPrize").OfTypeBoolean().And
+                .HaveField("Solved").OfTypeInt32().And
+                .HaveField("Equation").OfTypeText().BeingNullable().And
+                .HaveField("FirstPosited").OfTypeDateTime().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveConstraint("Solved", InclusionOperator.In, 0, 1).And
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void EnumerationToNumericBackingType() {
             // Arrange
             var translator = new Translator();

--- a/test/UnitTests/Kvasir/Translation/MixedConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/MixedConstraints.cs
@@ -619,6 +619,21 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
+        [TestMethod] public void NumericConversionWithIsOneOfNoOverlap_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(DSM);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<UnsatisfiableConstraintException>()
+                .WithLocation("`DSM` → Edition")
+                .WithProblem("all of the explicitly allowed values fail at least one other constraint")
+                .EndMessage();
+        }
+
         [TestMethod] public void AsStringConversionWithComparisons() {
             // Arrange
             var translator = new Translator();
@@ -665,6 +680,21 @@ namespace UT.Kvasir.Translation {
                     "Summer", "Autumn"
                 ).And
                 .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void AsStringConversionWithIsOneOfNoOverlap_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(ParkingTicket);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<UnsatisfiableConstraintException>()
+                .WithLocation("`ParkingTicket` → Reason")
+                .WithProblem("all of the explicitly allowed values fail at least one other constraint")
+                .EndMessage();
         }
 
         [TestMethod] public void AlteredComparisonsOnNestedField() {

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -4036,6 +4036,15 @@ namespace UT.Kvasir.Translation {
             [DataConverter(typeof(MakeDate<Variety>))] public Variety Structure { get; set; }
         }
 
+        // Test Scenario: Custom Data Conversion for Boolean Field (✓applied✓)
+        public class MathematicalConjecture {
+            [PrimaryKey] public string Name { get; set; } = "";
+            public bool IsMillenniumPrize { get; set; }
+            [DataConverter(typeof(ToInt<bool>))] public bool Solved { get; set; }
+            public string? Equation { get; set; }
+            public DateTime FirstPosited { get; set; }
+        }
+
         // Test Scenario: [Numeric] Data Conversion for Enumeration Field (✓applied✓)
         public class Quarterback {
             public enum Throws : sbyte { Left, Right }
@@ -8139,9 +8148,10 @@ namespace UT.Kvasir.Translation {
             public class RingOfPower {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public string? Holder { get; set; }
-                [DataConverter(typeof(ToInt<bool>)), Check.IsNot(7)] public bool Destroyed { get; set; }
+                public bool Destroyed { get; set; }
                 public DateTime Forged { get; set; }
                 public string CentralStone { get; set; } = "";
+                [DataConverter(typeof(ToInt<ushort>)), Check.IsNot(7)] public ushort NumPossessors { get; set; }
             }
 
             // Test Scenario: Scalar Property Constrained Multiple Times with Same Anchor (✓de-duplicated✓)
@@ -11985,6 +11995,18 @@ namespace UT.Kvasir.Translation {
             [Check.IsOneOf(0, 1, 2, 4, 8, 6, 10, 17, 186, 222), Numeric] public Variety Kind { get; set; }
         }
 
+        // Test Scenario: [Numeric] + [IsOneOf] Allowing Only Non-Domain Values (✗unsatisfiable✗)
+        public class DSM {
+            public enum Number { One, Two, Three, Four, Five }
+
+            [PrimaryKey] public ulong ISBN { get; set; }
+            public DateTime Published { get; set; }
+            [Numeric, Check.IsOneOf(6, 7, 8, 9)] public Number Edition { get; set; } 
+            public ushort DisordersCatalogued { get; set; }
+            public bool APA_Approved { get; set; }
+            public ulong WordCount { get; set; }
+        }
+
         // Test Scenario: [AsString] + <Comparisons> (✓former, evaluated against latter✓)
         public class Casino {
             public enum Game { Blackjack, Poker, Craps, Roulette, Slots, Baccarat, Pachinko, Bingo, SportsBetting }
@@ -12016,6 +12038,19 @@ namespace UT.Kvasir.Translation {
             [Check.IsNotOneOf("Winter", "Spring", "Fall", "Year-Round"), AsString] public Season SignSeason { get; set; }
             public char ZodiacSymbol { get; set; }
             public string HinduSolarEquivalent { get; set; } = "";
+        }
+
+        // Test Scenario: [AsString] + [IsOneOf] Allowing Only Non-Domain Values (✗unsatisfiable✗)
+        public class ParkingTicket {
+            public enum Classification { PermitOnly, FireHydrant, MeterExpired, DoubleParked, Weather }
+
+            [PrimaryKey] public uint TicketNumber { get; set; }
+            public Guid IssuingOfficerBadgeNumber { get; set; }
+            [AsString, Check.IsOneOf("Missing Sticker", "Flashing Lights")] public Classification Reason { get; set; }
+            public decimal Fine { get; set; }
+            public string LicensePlate { get; set; } = "";
+            public DateTime DateOfInfraction { get; set; }
+            public bool CourtDateRequired { get; set; }
         }
 
         // Test Scenario: <Comparison> on Nested Field is Altered (✓former, evaluated against latter✓)

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -301,6 +301,7 @@ Dreidel
 Drinking Fountain
 Druid (D&D)
 Drum
+DSM
 Dubbing
 Duo Push
 Dwarf
@@ -561,6 +562,7 @@ Masked Singer
 Mass Extinction
 Massacre
 MasterClass
+Mathematical Conjecture
 Mausoleum
 Mayor
 Medal of Honor
@@ -653,6 +655,7 @@ Papal Bull
 Parabola
 Parashah
 Parking Garage
+Parking Ticket
 Passport
 Pasta Sauce
 Patent


### PR DESCRIPTION
This commit adds logic to populate the restricted domain of a Field when the source type is a Boolean but a data conversion is applied to make the Field's type something different. We can do this because we know that the only valid CLR values for the property are 'true' and 'false', so they get fed through the data converter. We already did this when a Boolean field was converted to a Boolean, and when dealing with conversions from Enumerations.