### PR TITLE
Disallow By-Ref Properties

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -10014,6 +10014,9 @@
         <member name="M:Kvasir.Translation.SyntheticType.IsArrayImpl">
             <inheritdoc/>
         </member>
+        <member name="M:Kvasir.Translation.SyntheticType.IsByRefImpl">
+            <inheritdoc/>
+        </member>
         <member name="M:Kvasir.Translation.SyntheticType.IsPointerImpl">
             <inheritdoc/>
         </member>
@@ -10105,9 +10108,6 @@
             <inheritdoc/>
         </member>
         <member name="M:Kvasir.Translation.SyntheticType.HasElementTypeImpl">
-            <inheritdoc/>
-        </member>
-        <member name="M:Kvasir.Translation.SyntheticType.IsByRefImpl">
             <inheritdoc/>
         </member>
         <member name="M:Kvasir.Translation.SyntheticType.IsCOMObjectImpl">

--- a/src/Kvasir/Translation/Categorization.cs
+++ b/src/Kvasir/Translation/Categorization.cs
@@ -22,6 +22,9 @@ namespace Kvasir.Translation {
         public static TypeCategory TranslationCategory(this Type self) {
             self = Nullable.GetUnderlyingType(self) ?? self;
 
+            if (self.IsByRef) {
+                return TypeCategory.ByRef;
+            }
             if (self == typeof(IRelation)) {
                 return TypeCategory.IRelation;
             }
@@ -120,6 +123,7 @@ namespace Kvasir.Translation {
     internal readonly struct TypeCategory : IEquatable<TypeCategory> {
         public static TypeCategory AbstractClass { get; } = new TypeCategory("an abstract class");
         public static TypeCategory Array { get; } = new TypeCategory("an array (even of an otherwise supported type)");
+        public static TypeCategory ByRef { get; } = new TypeCategory("a type by-ref");
         public static TypeCategory Class { get; } = new TypeCategory("a class or a record class");
         public static TypeCategory ClosedGeneric { get; } = new TypeCategory("a closed generic type");
         public static TypeCategory Delegate { get; } = new TypeCategory("a delegate");

--- a/src/Kvasir/Translation/Synthetics/SyntheticType.cs
+++ b/src/Kvasir/Translation/Synthetics/SyntheticType.cs
@@ -74,6 +74,11 @@ namespace Kvasir.Translation {
         }
 
         /// <inheritdoc/>
+        protected sealed override bool IsByRefImpl() {
+            return false;
+        }
+
+        /// <inheritdoc/>
         protected sealed override bool IsPointerImpl() {
             return false;
         }
@@ -360,12 +365,6 @@ namespace Kvasir.Translation {
         [ExcludeFromCodeCoverage]
         protected sealed override bool HasElementTypeImpl() {
             throw new NotSupportedException($"{nameof(SyntheticType)}.{nameof(HasElementTypeImpl)}");
-        }
-
-        /// <inheritdoc/>
-        [ExcludeFromCodeCoverage]
-        protected sealed override bool IsByRefImpl() {
-            throw new NotSupportedException($"{nameof(SyntheticType)}.{nameof(IsByRefImpl)}");
         }
 
         /// <inheritdoc/>

--- a/src/Kvasir/Translation/Utility/Display.cs
+++ b/src/Kvasir/Translation/Utility/Display.cs
@@ -84,9 +84,14 @@ namespace Kvasir.Translation {
                 return "`char`";
             }
 
+            // By-Ref
+            else if (self.IsByRef) {
+                var underlying = self.GetElementType()!.DisplayName()[1..^1];
+                return $"`ref {underlying}`";
+            }
+
             // Array
             else if (self.IsArray) {
-                var x = self.GetElementType();
                 var element = self.GetElementType()!.DisplayName()[1..^1];
                 return $"`{element}[]`";
             }

--- a/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
+++ b/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
@@ -294,6 +294,21 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void PropertyTypeIsByRef_IsError() {
+            // Arrange
+            var translator = new Translator();
+            var source = typeof(Spider);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPropertyInDataModelException>()
+                .WithLocation("`Spider` → Venomous")
+                .WithProblem("type `ref bool` is a type by-ref and cannot be the backing type of a property")
+                .EndMessage();
+        }
+
         [TestMethod] public void CodeOnly_PropertyOfUnsupportedType() {
             // Arrange
             var translator = new Translator();

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -185,6 +185,17 @@ namespace UT.Kvasir.Translation {
             public bool StateSanctioned { get; set; }
         }
 
+        // Test Scenario: By-Ref Property (✗not permitted✗)
+        public class Spider {
+            [PrimaryKey] public string Genus { get; set; } = "";
+            [PrimaryKey] public string Species { get; set; } = "";
+            public string CommonName { get; set; } = "";
+            public ref bool Venomous { get { return ref venomous_; } }
+            public ushort NumEyes { get; set; }
+
+            private bool venomous_;
+        }
+
         // Test Scenario: Property with Unsupported Type Marked as [CodeOnly] (✓excluded✓)
         public interface IArmor {}
         public class CustomBackground<T> {}

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -840,6 +840,7 @@ Space Shuttle
 Speakeasy
 Speed Limit
 Speedometer
+Spider
 Spider-Man
 Sporcle Quiz
 Sports Bet


### PR DESCRIPTION
This commit disallows properties whose return type is by-ref from being included in the Kvasir data model. This required a new TypeCategory and a new branch in the type-display logic, but otherwise was a vanilla change. These properties are disallowed because I don't know what their implications are for data changing, so I'd rather disallow them for now; I can always loosen that restriction in the future. (But honestly, I probably won't.)