### PR TITLE
Translation of Extraction Plans

### DIFF
--- a/src/Cybele/Core/PropertyChain.cs
+++ b/src/Cybele/Core/PropertyChain.cs
@@ -309,7 +309,7 @@ namespace Cybele.Core {
             if (source is null) {
                 throw new ArgumentNullException(nameof(source));
             }
-            else if (!ReflectedType.IsInstanceOfType(source)) {
+            else if (!source.GetType().IsInstanceOf(ReflectedType)) {
                 var msg = $"{nameof(PropertyChain)} cannot read from object of type {source.GetType().Name}, an " +
                     $"object of type {ReflectedType.Name} is expected";
                 throw new ArgumentException(msg, nameof(source));

--- a/src/Cybele/Extensions/Type.cs
+++ b/src/Cybele/Extensions/Type.cs
@@ -47,7 +47,9 @@ namespace Cybele.Extensions {
             Guard.Against.Null(ancestorType, nameof(ancestorType));
             Guard.Against.Null(derivedType, nameof(derivedType));
 
-            if (ancestorType == derivedType) {
+            if (ancestorType.Equals(derivedType) || derivedType.Equals(ancestorType)) {
+                // Use `.Equals` in case someone has derived from `Type` and overridden the function; the `operator==`
+                // cannot be overridden that way. The symmetric check is for the same reason.
                 return true;
             }
             else if (ancestorType.IsGenericType && ancestorType.GetGenericTypeDefinition() == typeof(Nullable<>)) {

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -9147,6 +9147,11 @@
               The column index, which must be non-negative and strictly less than the <see cref="P:Kvasir.Translation.FieldGroup.Size"/> of the group.
             </param>
         </member>
+        <member name="P:Kvasir.Translation.FieldGroup.Extractor">
+            <summary>
+              The <see cref="T:Kvasir.Extraction.IMultiExtractor"/> for this group.
+            </summary>
+        </member>
         <member name="M:Kvasir.Translation.FieldGroup.Clone">
             <summary>
               Clones this <see cref="T:Kvasir.Translation.FieldGroup"/>.
@@ -9329,6 +9334,9 @@
         <member name="P:Kvasir.Translation.MultiFieldGroup.Item(System.Int32)">
             <inheritdoc/>
         </member>
+        <member name="P:Kvasir.Translation.MultiFieldGroup.Extractor">
+            <inheritdoc/>
+        </member>
         <member name="P:Kvasir.Translation.MultiFieldGroup.Kind">
             <summary>
               The "kind" of the backing property (i.e. Aggregate vs. Reference vs. Relation).
@@ -9485,6 +9493,18 @@
               <see cref="T:Kvasir.Annotations.NumericAttribute">[Numeric]</see> annotation is encountered.
             </exception>
         </member>
+        <member name="M:Kvasir.Translation.MultiFieldGroup.CreateExtractor(System.Collections.Generic.IEnumerable{Kvasir.Translation.FieldGroup})">
+            <summary>
+              Create a <see cref="P:Kvasir.Translation.MultiFieldGroup.Extractor"/> for the multi-field group.
+            </summary>
+            <param name="fields">
+              The constituent <see cref="T:Kvasir.Translation.FieldGroup">FieldGroups</see>. These are not necessarily ordered.
+            </param>
+            <returns>
+              A <see cref="T:Kvasir.Extraction.IMultiExtractor"/> that, when executed, produces the recursively nested value contained by
+              the Fields represented by <paramref name="fields"/>.
+            </returns>
+        </member>
         <member name="T:Kvasir.Translation.ReferenceFieldGroup">
             <summary>
               A <see cref="T:Kvasir.Translation.MultiFieldGroup"/> backed by an Reference property (i.e. one that is an Entity).
@@ -9617,6 +9637,9 @@
         <member name="M:Kvasir.Translation.RelationFieldGroup.ProcessNativeNullability(Kvasir.Translation.Context)">
             <inheritdoc/>
         </member>
+        <member name="M:Kvasir.Translation.RelationFieldGroup.CreateExtractor(System.Collections.Generic.IEnumerable{Kvasir.Translation.FieldGroup})">
+            <inheritdoc/>
+        </member>
         <member name="T:Kvasir.Translation.SingleFieldGroup">
             <summary>
               A <see cref="T:Kvasir.Translation.FieldGroup"/> backed by a scalar or enumeration CLR property, and therefore corresponding to
@@ -9630,6 +9653,9 @@
             <inheritdoc/>
         </member>
         <member name="P:Kvasir.Translation.SingleFieldGroup.Item(System.Int32)">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Translation.SingleFieldGroup.Extractor">
             <inheritdoc/>
         </member>
         <member name="M:Kvasir.Translation.SingleFieldGroup.#ctor(Kvasir.Translation.Context,System.Reflection.PropertyInfo)">
@@ -9900,6 +9926,9 @@
               The reflection representation of a property on a <see cref="T:Kvasir.Translation.SyntheticType"/>.
             </summary>
         </member>
+        <member name="P:Kvasir.Translation.SyntheticPropertyInfo.CanRead">
+            <inheritdoc/>
+        </member>
         <member name="P:Kvasir.Translation.SyntheticPropertyInfo.DeclaringType">
             <inheritdoc/>
         </member>
@@ -9944,10 +9973,10 @@
         <member name="M:Kvasir.Translation.SyntheticPropertyInfo.GetSetMethod(System.Boolean)">
             <inheritdoc/>
         </member>
-        <member name="P:Kvasir.Translation.SyntheticPropertyInfo.Attributes">
+        <member name="M:Kvasir.Translation.SyntheticPropertyInfo.GetValue(System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)">
             <inheritdoc/>
         </member>
-        <member name="P:Kvasir.Translation.SyntheticPropertyInfo.CanRead">
+        <member name="P:Kvasir.Translation.SyntheticPropertyInfo.Attributes">
             <inheritdoc/>
         </member>
         <member name="P:Kvasir.Translation.SyntheticPropertyInfo.CanWrite">
@@ -9957,9 +9986,6 @@
             <inheritdoc/>
         </member>
         <member name="M:Kvasir.Translation.SyntheticPropertyInfo.GetCustomAttributes(System.Boolean)">
-            <inheritdoc/>
-        </member>
-        <member name="M:Kvasir.Translation.SyntheticPropertyInfo.GetValue(System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)">
             <inheritdoc/>
         </member>
         <member name="M:Kvasir.Translation.SyntheticPropertyInfo.IsDefined(System.Type,System.Boolean)">
@@ -9991,7 +10017,7 @@
         <member name="P:Kvasir.Translation.SyntheticType.UnderlyingSystemType">
             <inheritdoc/>
         </member>
-        <member name="M:Kvasir.Translation.SyntheticType.#ctor(System.String,System.String,System.Reflection.Assembly,System.Func{Kvasir.Translation.SyntheticType,System.Collections.Generic.IEnumerable{Kvasir.Translation.SyntheticPropertyInfo}})">
+        <member name="M:Kvasir.Translation.SyntheticType.#ctor(System.String,System.String,System.Reflection.Assembly,System.Func{Kvasir.Translation.SyntheticType,System.Collections.Generic.IEnumerable{Kvasir.Translation.SyntheticPropertyInfo}},System.Type)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.SyntheticType"/>.
             </summary>
@@ -10009,7 +10035,17 @@
               properties. (This is a function because of the circular definition: the SyntheticType needs to know its
               properties, and each SyntheticProperty needs to know its owning SyntheticType.)
             </param>
+            <param name="equalTo">
+              The <see cref="T:System.Type"/> that the new <see cref="T:Kvasir.Translation.SyntheticType"/> should compare equal to. This is required
+              to "lie" to the type system when performing Extraction and Reconstitution, as those subsystems expect the
+              runtime types of arguments to match the reflected types of properties. However, for Relations, the two
+              will not line up: the former will be a scalar or a key-value pair, while the latter will be the Synthetic
+              Type. The "equality façade" allows us to hijack the equality comparisons to pass all the checks.
+            </param>
             <seealso cref="M:Kvasir.Translation.SyntheticType.MakeSyntheticType(System.Type,Kvasir.Translation.RelationTracker)"/>
+        </member>
+        <member name="M:Kvasir.Translation.SyntheticType.Equals(System.Type)">
+            <inheritdoc/>
         </member>
         <member name="M:Kvasir.Translation.SyntheticType.IsArrayImpl">
             <inheritdoc/>

--- a/src/Kvasir/Translation/FieldGroups/FieldGroup.cs
+++ b/src/Kvasir/Translation/FieldGroups/FieldGroup.cs
@@ -1,5 +1,6 @@
 ﻿using Cybele.Extensions;
 using Kvasir.Annotations;
+using Kvasir.Extraction;
 using Optional;
 using System.Collections;
 using System.Collections.Generic;
@@ -40,6 +41,11 @@ namespace Kvasir.Translation {
         ///   The column index, which must be non-negative and strictly less than the <see cref="Size"/> of the group.
         /// </param>
         public abstract string this[int column] { get; }
+
+        /// <summary>
+        ///   The <see cref="IMultiExtractor"/> for this group.
+        /// </summary>
+        public abstract IMultiExtractor Extractor { get; }
 
         /// <summary>
         ///   Clones this <see cref="FieldGroup"/>.

--- a/src/Kvasir/Translation/TranslateEntity.cs
+++ b/src/Kvasir/Translation/TranslateEntity.cs
@@ -1,6 +1,7 @@
 ﻿using Cybele.Extensions;
 using Kvasir.Annotations;
 using Kvasir.Core;
+using Kvasir.Extraction;
 using Kvasir.Schema;
 using System;
 using System.Collections.Generic;
@@ -105,7 +106,8 @@ namespace Kvasir.Translation {
             }
 
             var table = new Table(tableName, fields, primaryKey, candidateKeys, foreignKeys, constraints);
-            principal = new PrincipalTableDef(table, null!, null!);
+            var extractor = new DataExtractionPlan(fieldGroups.OrderBy(g => g.Column.Unwrap()).Select(g => g.Extractor));
+            principal = new PrincipalTableDef(table, extractor, null!);
 
             principalTableCache_.Add(source, principal);
             tableNameCache_.Add(tableName, source);
@@ -168,8 +170,12 @@ namespace Kvasir.Translation {
                     throw new DuplicateNameException(context, tableName, match);
                 }
 
+                var extractRelationProperty = new ReadPropertyExtractor(property);
+                var elementExtractor = new DataExtractionPlan(Enumerable.Repeat(relationGroup.Extractor, 1));
+
                 var table = new Table(tableName, fields, primaryKey, candidateKeys, foreignKeys, constraints);
-                var def = new RelationTableDef(table, null!, null!);
+                var extractor = new RelationExtractionPlan(extractRelationProperty, elementExtractor);
+                var def = new RelationTableDef(table, extractor, null!);
 
                 tableNameCache_.Add(tableName, syntheticType);
                 relationTables.Add(def);

--- a/test/UnitTests/Kvasir/Translation/Extraction.cs
+++ b/test/UnitTests/Kvasir/Translation/Extraction.cs
@@ -1,0 +1,1104 @@
+﻿using FluentAssertions;
+using Kvasir.Core;
+using Kvasir.Relations;
+using Kvasir.Translation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+using static UT.Kvasir.Translation.DataExtraction;
+using static UT.Kvasir.Translation.TestConverters;
+
+namespace UT.Kvasir.Translation {
+    [TestClass, TestCategory("Extraction")]
+    public class DataExtractionTests {
+        [TestMethod] public void NonNullPublicInstanceScalars() {
+            // Arrange
+            var morgue = new Morgue() {
+                Name = "Central Chicago Morgue",
+                ChiefMedicalExaminer = "Dr. Andrew Q. McDaroida",
+                Capacity = 60000,
+                Budget = 8000000,
+                FederalGrade = 'B',
+                AvailableServices = Morgue.Service.Autopsy | Morgue.Service.Identification | Morgue.Service.Cremation,
+                GovernmentRun = true
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Morgue)];
+            var data = translation.Principal.Extractor.ExtractFrom(morgue);
+
+            // Assert
+            data.Should().HaveCount(7);
+            data[0].Datum.Should().Be(morgue.Name);
+            data[1].Datum.Should().Be(morgue.ChiefMedicalExaminer);
+            data[2].Datum.Should().Be(morgue.Capacity);
+            data[3].Datum.Should().Be(morgue.Budget);
+            data[4].Datum.Should().Be(morgue.FederalGrade);
+            data[5].Datum.Should().Be(ConversionOf(morgue.AvailableServices));
+            data[6].Datum.Should().Be(morgue.GovernmentRun);
+        }
+
+        [TestMethod] public void NonNullPublicStaticScalars() {
+            // Arrange
+            var interpreter = new PythonInterpreter() {
+                ProgramID = new Guid(),
+                Path = "/usr/bin/python",
+                InstalledOn = new DateTime(2022, 3, 17)
+            };
+            PythonInterpreter.MinVersion = 3.5;
+            PythonInterpreter.MaxVersion = 3.8;
+            PythonInterpreter.BackEndLanguage = PythonInterpreter.Language.CPP;
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(PythonInterpreter)];
+            var data = translation.Principal.Extractor.ExtractFrom(interpreter);
+
+            // Assert
+            data.Should().HaveCount(6);
+            data[0].Datum.Should().Be(interpreter.ProgramID);
+            data[1].Datum.Should().Be(interpreter.Path);
+            data[2].Datum.Should().Be(interpreter.InstalledOn);
+            data[3].Datum.Should().Be(PythonInterpreter.MinVersion);
+            data[4].Datum.Should().Be(PythonInterpreter.MaxVersion);
+            data[5].Datum.Should().Be(ConversionOf(PythonInterpreter.BackEndLanguage));
+        }
+
+        [TestMethod] public void NonNullNonPublicInstanceScalars() {
+            // Arrange
+            var ship = new PirateShip() {
+                ID = new Guid(),
+                ShipName = "Queen Anne's Revenge",
+                Captain = "Blackbeard",
+                Style = PirateShip.ShipKind.Frigate,
+                CarriedSlaves = false
+            };
+            ship.SetLength(103);
+            ship.SetNumCannons(30);
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(PirateShip)];
+            var data = translation.Principal.Extractor.ExtractFrom(ship);
+
+            // Assert
+            data.Should().HaveCount(7);
+            data[0].Datum.Should().Be(ship.ID);
+            data[1].Datum.Should().Be(ship.ShipName);
+            data[2].Datum.Should().Be(ship.Captain);
+            data[3].Datum.Should().Be(ship.GetLength());
+            data[4].Datum.Should().Be(ship.GetNumCannons());
+            data[5].Datum.Should().Be(ConversionOf(ship.Style));
+            data[6].Datum.Should().Be(ship.CarriedSlaves);
+        }
+
+        [TestMethod] public void NonNullNonPublicStaticScalars() {
+            // Arrange
+            var enzyme = new Enzyme() {
+                EnzymeCommissionNumber = "3.2.1.108",
+                CommonName = "Lactase"
+            };
+            Enzyme.SetIsEnzyme(true);
+            Enzyme.SetNumEnzymesTotal(75000);
+            Enzyme.Regulator = "National Academy of Human Enzymes";
+            Enzyme.FirstDiscovered = new DateTime(1906, 7, 22);
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Enzyme)];
+            var data = translation.Principal.Extractor.ExtractFrom(enzyme);
+
+            // Assert
+            data.Should().HaveCount(6);
+            data[0].Datum.Should().Be(enzyme.EnzymeCommissionNumber);
+            data[1].Datum.Should().Be(enzyme.CommonName);
+            data[2].Datum.Should().Be(Enzyme.GetIsEnzme());
+            data[3].Datum.Should().Be(Enzyme.GetNumEnzymesTotal());
+            data[4].Datum.Should().Be(Enzyme.Regulator);
+            data[5].Datum.Should().Be(Enzyme.FirstDiscovered);
+        }
+
+        [TestMethod] public void NullScalars() {
+            // Arrange
+            var ode = new Ode() {
+                Title = "Ode on a Grecian Urn",
+                Author = "John Keats",
+                Lines = 50,
+                WordCount = 373,
+                Publication = null,
+                Collection = "Annals of the Fine Arts for 1819",
+                Style = null
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Ode)];
+            var data = translation.Principal.Extractor.ExtractFrom(ode);
+
+            // Assert
+            data.Should().HaveCount(7);
+            data[0].Datum.Should().Be(ode.Title);
+            data[1].Datum.Should().Be(ode.Author);
+            data[2].Datum.Should().Be(ode.Lines);
+            data[3].Datum.Should().Be(ode.WordCount);
+            data[4].Datum.Should().Be(DBNull.Value);
+            data[5].Datum.Should().Be(ode.Collection);
+            data[6].Datum.Should().Be(DBNull.Value);
+        }
+
+        [TestMethod] public void ExplicitInterfaceImplementation() {
+            // Arrange
+            var tlatoani = new Tlatoani() {
+                ID = new Guid(),
+                Death = new DateTime(1520, 6, 30),
+                EncounteredConquistadors = true,
+                CoronationYear = 1502
+            };
+            (tlatoani as IWorldLeader).Name = "Montezuma II";
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Tlatoani)];
+            var data = translation.Principal.Extractor.ExtractFrom(tlatoani);
+
+            // Assert
+            data.Should().HaveCount(6);
+            data[0].Datum.Should().Be(tlatoani.ID);
+            data[1].Datum.Should().Be((tlatoani as IWorldLeader).Name);
+            data[2].Datum.Should().Be((tlatoani as IWorldLeader).Polity);
+            data[3].Datum.Should().Be(tlatoani.Death);
+            data[4].Datum.Should().Be(tlatoani.EncounteredConquistadors);
+            data[5].Datum.Should().Be(tlatoani.CoronationYear);
+        }
+
+        [TestMethod] public void VirtualOverride() {
+            // Arrange
+            var quarter = new StateQuarter() {
+                State = "Louisiana",
+                Denomination = 0.25,
+                Year = 2002,
+                Engraver = "John Mercanti",
+                Mintage = 764204000
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(StateQuarter)];
+            var data = translation.Principal.Extractor.ExtractFrom(quarter);
+
+            // Assert
+            data.Should().HaveCount(5);
+            data[0].Datum.Should().Be(quarter.State);
+            data[1].Datum.Should().Be(quarter.Denomination);
+            data[2].Datum.Should().Be(quarter.Year);
+            data[3].Datum.Should().Be(quarter.Engraver);
+            data[4].Datum.Should().Be(quarter.Mintage);
+        }
+
+        [TestMethod] public void Hiding() {
+            // Arrange
+            var aurora = new Aurora() {
+                AuroraID = new Guid(),
+                Name = "Aurora Borealis",
+                AKA = "Northern Lights",
+                Intensity = 173.912884f
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Aurora)];
+            var data = translation.Principal.Extractor.ExtractFrom(aurora);
+
+            // Assert
+            data.Should().HaveCount(4);
+            data[0].Datum.Should().Be(aurora.AuroraID);
+            data[1].Datum.Should().Be(aurora.Name);
+            data[2].Datum.Should().Be(aurora.AKA);
+            data[3].Datum.Should().Be(aurora.Intensity);
+        }
+
+        [TestMethod] public void ScalarDataConversion() {
+            // Arrange
+            var underworld = new Underworld() {
+                Name = "Mictlān",
+                Civilization = "Aztec Empire",
+                Lord = "Mictlāntēcutli",
+                ForMortals = true,
+                GoogleResults = 1980000
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Underworld)];
+            var data = translation.Principal.Extractor.ExtractFrom(underworld);
+
+            // Act
+            data[0].Datum.Should().Be(underworld.Name);
+            data[1].Datum.Should().Be(underworld.Civilization);
+            data[2].Datum.Should().Be(underworld.Lord);
+            data[3].Datum.Should().Be(new Invert().Convert(underworld.ForMortals));
+            data[4].Datum.Should().Be(new MakeDate<int>().Convert(underworld.GoogleResults));
+        }
+
+        [TestMethod] public void EnumerationNumericConversion() {
+            // Arrange
+            var maze = new CornMaze() {
+                MazeID = new Guid(),
+                CornType = CornMaze.Corn.Sweet,
+                MazeShape = CornMaze.Shape.Animal | CornMaze.Shape.Character | CornMaze.Shape.Person,
+                StalkCount = 48913,
+                MazeArea = 269,
+                SuccessRate = 29.56,
+                RecordTime = 196.7
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(CornMaze)];
+            var data = translation.Principal.Extractor.ExtractFrom(maze);
+
+            // Assert
+            data.Should().HaveCount(7);
+            data[0].Datum.Should().Be(maze.MazeID);
+            data[1].Datum.Should().Be((byte)maze.CornType);
+            data[2].Datum.Should().Be((ulong)maze.MazeShape);
+            data[3].Datum.Should().Be(maze.StalkCount);
+            data[4].Datum.Should().Be(maze.MazeArea);
+            data[5].Datum.Should().Be(maze.SuccessRate);
+            data[6].Datum.Should().Be(maze.RecordTime);
+        }
+
+        [TestMethod] public void EnumerationToStringConversion() {
+            // Arrange
+            var racetrack = new MarioKartRacetrack() {
+                Name = "Dino Dino Jungle",
+                FirstAppearance = "Mario Kart: Double Dash!!",
+                Series = MarioKartRacetrack.Cup.Special,
+                TrackLength = null,
+                AvailableOnline = false
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(MarioKartRacetrack)];
+            var data = translation.Principal.Extractor.ExtractFrom(racetrack);
+
+            // Assert
+            data.Should().HaveCount(5);
+            data[0].Datum.Should().Be(racetrack.Name);
+            data[1].Datum.Should().Be(racetrack.FirstAppearance);
+            data[2].Datum.Should().Be(ConversionOf(racetrack.Series));
+            data[3].Datum.Should().Be(DBNull.Value);
+            data[4].Datum.Should().Be(racetrack.AvailableOnline);
+        }
+
+        [TestMethod] public void Calculated() {
+            // Arrange
+            var lighthouse = new Lighthouse() {
+                Name = "Pemaquid Point Lighthouse",
+                Location = "Muscongus Bay in Bristol, Maine",
+                Height = 11.5,
+                FocalLength = 79
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Lighthouse)];
+            var data = translation.Principal.Extractor.ExtractFrom(lighthouse);
+
+            // Assert
+            data.Should().HaveCount(5);
+            data[0].Datum.Should().Be(lighthouse.Name);
+            data[1].Datum.Should().Be(lighthouse.Location);
+            data[2].Datum.Should().Be(lighthouse.Height);
+            data[3].Datum.Should().Be(lighthouse.FocalLength);
+            data[4].Datum.Should().Be(lighthouse.LighthouseRating);
+        }
+
+        [TestMethod] public void NonNullSingleFieldAggregate() {
+            // Arrange
+            var nucleobase = new Nucleobase {
+                Symbol = new Nucleobase.Letter() { Value = 'G' },
+                Name = "Guanine",
+                ChemicalFormula = "C5H5N5O"
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Nucleobase)];
+            var data = translation.Principal.Extractor.ExtractFrom(nucleobase);
+
+            // Assert
+            data.Should().HaveCount(3);
+            data[0].Datum.Should().Be(nucleobase.Symbol.Value);
+            data[1].Datum.Should().Be(nucleobase.Name);
+            data[2].Datum.Should().Be(nucleobase.ChemicalFormula);
+        }
+
+        [TestMethod] public void NonNullMultiFieldAggregate() {
+            // Arrange
+            var legos = new LegoSet() {
+                ItemNumber = 75912,
+                Title = "Millennium Falcon",
+                Catalog = new LegoSet.Listing() {
+                    Price = 849.99M,
+                    Stars = LegoSet.Rating.FourPointFive,
+                    URL = "https://www.lego.com/en-us/product/millennium-falcon-75192",
+                    InsiderPoints = 5525,
+                    Theme = LegoSet.Series.StarWars
+                },
+                Pieces = 7541,
+                LowerBoundAge = 16
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(LegoSet)];
+            var data = translation.Principal.Extractor.ExtractFrom(legos);
+
+            // Assert
+            data.Should().HaveCount(9);
+            data[0].Datum.Should().Be(legos.ItemNumber);
+            data[1].Datum.Should().Be(legos.Title);
+            data[2].Datum.Should().Be(legos.Catalog.Price);
+            data[3].Datum.Should().Be(ConversionOf(legos.Catalog.Stars));
+            data[4].Datum.Should().Be(legos.Catalog.URL);
+            data[5].Datum.Should().Be(legos.Catalog.InsiderPoints);
+            data[6].Datum.Should().Be(ConversionOf(legos.Catalog.Theme));
+            data[7].Datum.Should().Be(legos.Pieces);
+            data[8].Datum.Should().Be(legos.LowerBoundAge);
+        }
+
+        [TestMethod] public void AggregateWithAllNullNestedFields() {
+            // Arrange
+            var fight = new SnowballFight() {
+                FightID = new Guid(),
+                KickOff = new DateTime(2023, 12, 7),
+                FightStructure = new SnowballFight.Structure() {
+                    NumTeams = null,
+                    HitsAllowed = null,
+                    MaxBallRadius = null
+                },
+                Length = 120,
+                LowTemperature = 14.3
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(SnowballFight)];
+            var data = translation.Principal.Extractor.ExtractFrom(fight);
+
+            // Assert
+            data.Should().HaveCount(7);
+            data[0].Datum.Should().Be(fight.FightID);
+            data[1].Datum.Should().Be(fight.KickOff);
+            data[2].Datum.Should().Be(DBNull.Value);
+            data[3].Datum.Should().Be(DBNull.Value);
+            data[4].Datum.Should().Be(DBNull.Value);
+            data[5].Datum.Should().Be(fight.Length);
+            data[6].Datum.Should().Be(fight.LowTemperature);
+        }
+
+        [TestMethod] public void NullSingleFieldAggregate() {
+            // Arrange
+            var knot = new Knot() {
+                Name = "Savoy Knot",
+                Shape = null,
+                Efficiency = 0.8,
+                AshleyBookOfKnotsPage = null
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Knot)];
+            var data = translation.Principal.Extractor.ExtractFrom(knot);
+
+            // Assert
+            data.Should().HaveCount(4);
+            data[0].Datum.Should().Be(knot.Name);
+            data[1].Datum.Should().Be(DBNull.Value);
+            data[2].Datum.Should().Be(knot.Efficiency);
+            data[3].Datum.Should().Be(DBNull.Value);
+        }
+
+        [TestMethod] public void NullMultiFieldAggregate() {
+            // Arrange
+            var armory = new Armory() {
+                Name = "Sergeant Camilo's Principal Weapons Warehouse",
+                Decommissioned = false,
+                Location = null,
+                WeaponsCount = 876182491284,
+                Owner = Armory.Level.Vigilante
+            };
+
+            // Act
+            var translator = new Translator(); ;
+            var translation = translator[typeof(Armory)];
+            var data = translation.Principal.Extractor.ExtractFrom(armory);
+
+            // Assert
+            data.Should().HaveCount(6);
+            data[0].Datum.Should().Be(armory.Name);
+            data[1].Datum.Should().Be(armory.Decommissioned);
+            data[2].Datum.Should().Be(DBNull.Value);
+            data[3].Datum.Should().Be(DBNull.Value);
+            data[4].Datum.Should().Be(armory.WeaponsCount);
+            data[5].Datum.Should().Be(ConversionOf(armory.Owner));
+        }
+
+        [TestMethod] public void NestedAggregate() {
+            // Arrange
+            var question = new MillionaireQuestion() {
+                QuestionID = new Guid(),
+                Category = "European Ruins",
+                Question = "The ruins of Urquhart Castle stand on the banks of which loch?",
+                Answers = new MillionaireQuestion.Options() {
+                    A = new MillionaireQuestion.Option() {
+                        Text = "Loch Lomond",
+                        FiftyFiftyEliminated = true,
+                        AudiencePercentage = 0.08,
+                        IsCorrect = false,
+                    },
+                    B = new MillionaireQuestion.Option() {
+                        Text = "Loch Ness",
+                        FiftyFiftyEliminated = false,
+                        AudiencePercentage = 0.81,
+                        IsCorrect = true
+                    },
+                    C = new MillionaireQuestion.Option() {
+                        Text = "Loch Broom",
+                        FiftyFiftyEliminated = false,
+                        AudiencePercentage = 0.03,
+                        IsCorrect = false
+                    },
+                    D = new MillionaireQuestion.Option() {
+                        Text = "Loch Maree",
+                        FiftyFiftyEliminated = true,
+                        AudiencePercentage = 0.08,
+                        IsCorrect = false
+                    }
+                }
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(MillionaireQuestion)];
+            var data = translation.Principal.Extractor.ExtractFrom(question);
+
+            // Assert
+            data.Should().HaveCount(19);
+            data[0].Datum.Should().Be(question.QuestionID);
+            data[1].Datum.Should().Be(question.Category);
+            data[2].Datum.Should().Be(question.Question);
+            data[3].Datum.Should().Be(question.Answers.A.Text);
+            data[4].Datum.Should().Be(question.Answers.A.FiftyFiftyEliminated);
+            data[5].Datum.Should().Be(question.Answers.A.AudiencePercentage);
+            data[6].Datum.Should().Be(question.Answers.A.IsCorrect);
+            data[7].Datum.Should().Be(question.Answers.B.Text);
+            data[8].Datum.Should().Be(question.Answers.B.FiftyFiftyEliminated);
+            data[9].Datum.Should().Be(question.Answers.B.AudiencePercentage);
+            data[10].Datum.Should().Be(question.Answers.B.IsCorrect);
+            data[11].Datum.Should().Be(question.Answers.C.Text);
+            data[12].Datum.Should().Be(question.Answers.C.FiftyFiftyEliminated);
+            data[13].Datum.Should().Be(question.Answers.C.AudiencePercentage);
+            data[14].Datum.Should().Be(question.Answers.C.IsCorrect);
+            data[15].Datum.Should().Be(question.Answers.D.Text);
+            data[16].Datum.Should().Be(question.Answers.D.FiftyFiftyEliminated);
+            data[17].Datum.Should().Be(question.Answers.D.AudiencePercentage);
+            data[18].Datum.Should().Be(question.Answers.D.IsCorrect);
+        }
+
+        [TestMethod] public void AggregateNestedDataConversion() {
+            // Arrange
+            var game = new GroceryGame() {
+                Name = "No Carts Allowed",
+                Description = "Contestants must shop for ingredients without their carts, carrying everything by hand",
+                FirstAppearance = new GroceryGame.Episode() {
+                    Season = 1,
+                    Number = 4,
+                    Judge1 = "Melissa d'Arabian",
+                    Judge2 = "Troy Johnson",
+                    Judge3 = "Lorena Garcia"
+                },
+                NumTimesPlayed = 11
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(GroceryGame)];
+            var data = translation.Principal.Extractor.ExtractFrom(game);
+
+            // Assert
+            data.Should().HaveCount(8);
+            data[0].Datum.Should().Be(game.Name);
+            data[1].Datum.Should().Be(game.Description);
+            data[2].Datum.Should().Be(new ToInt<byte>().Convert(game.FirstAppearance.Season));
+            data[3].Datum.Should().Be(new ToInt<byte>().Convert(game.FirstAppearance.Number));
+            data[4].Datum.Should().Be(game.FirstAppearance.Judge1);
+            data[5].Datum.Should().Be(game.FirstAppearance.Judge2);
+            data[6].Datum.Should().Be(game.FirstAppearance.Judge3);
+            data[7].Datum.Should().Be(game.NumTimesPlayed);
+        }
+
+        [TestMethod] public void NonNullReferenceSingleFieldPrimaryKey() {
+            // Arrange
+            var conclave = new PapalConclave() {
+                Date = new DateTime(2013, 3, 12),
+                Ballots = 5,
+                ElectedPope = new PapalConclave.Cardinal() {
+                    Name = "Jorge Mario Bergoglio",
+                    Country = "Argentina",
+                    Age = 76
+                },
+                NumElectors = 115,
+                Dean = new PapalConclave.Cardinal() {
+                    Name = "Angelo Sodano",
+                    Country = "Italy",
+                    Age = 85
+                }
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(PapalConclave)];
+            var data = translation.Principal.Extractor.ExtractFrom(conclave);
+
+            // Assert
+            data.Should().HaveCount(5);
+            data[0].Datum.Should().Be(conclave.Date);
+            data[1].Datum.Should().Be(conclave.Ballots);
+            data[2].Datum.Should().Be(conclave.ElectedPope.Name);
+            data[3].Datum.Should().Be(conclave.NumElectors);
+            data[4].Datum.Should().Be(conclave.Dean.Name);
+        }
+
+        [TestMethod] public void NonNullReferenceMultiFieldPrimaryKey() {
+            // Arrange
+            var cytonic = new Cytonic() {
+                Name = "Doomslug",
+                CallSign = null,
+                SelfSpecies = new Cytonic.Species() {
+                    Grouping = 498,
+                    Name = "Taynix",
+                    SubNumber = 3,
+                    PrimaryIntelligence = false,
+                },
+                Abilities = Cytonic.Power.Hyperjump,
+                Appearances = Cytonic.Book.Skyward | Cytonic.Book.Starsight | Cytonic.Book.Cytonic | Cytonic.Book.Defiant
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Cytonic)];
+            var data = translation.Principal.Extractor.ExtractFrom(cytonic);
+
+            // Assert
+            data.Should().HaveCount(6);
+            data[0].Datum.Should().Be(cytonic.Name);
+            data[1].Datum.Should().Be(DBNull.Value);
+            data[2].Datum.Should().Be(cytonic.SelfSpecies.Grouping);
+            data[3].Datum.Should().Be(cytonic.SelfSpecies.SubNumber);
+            data[4].Datum.Should().Be(ConversionOf(cytonic.Abilities));
+            data[5].Datum.Should().Be(ConversionOf(cytonic.Appearances));
+        }
+
+        [TestMethod] public void NullReferenceSingleFieldPrimaryKey() {
+            // Arrange
+            var soapOpera = new SoapOpera() {
+                Title = "Days of Our Lives",
+                IsStillAiring = true,
+                Premiere = new DateTime(1965, 11, 8),
+                NumSeasons = 59,
+                NumEpisodes = 14430,
+                NumCastMembers = 69,
+                OwningNetwork = null,
+                IsTelenovela = false
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(SoapOpera)];
+            var data = translation.Principal.Extractor.ExtractFrom(soapOpera);
+
+            // Assert
+            data.Should().HaveCount(8);
+            data[0].Datum.Should().Be(soapOpera.Title);
+            data[1].Datum.Should().Be(soapOpera.IsStillAiring);
+            data[2].Datum.Should().Be(soapOpera.Premiere);
+            data[3].Datum.Should().Be(soapOpera.NumSeasons);
+            data[4].Datum.Should().Be(soapOpera.NumEpisodes);
+            data[5].Datum.Should().Be(soapOpera.NumCastMembers);
+            data[6].Datum.Should().Be(DBNull.Value);
+            data[7].Datum.Should().Be(soapOpera.IsTelenovela);
+        }
+
+        [TestMethod] public void NullReferenceMultiFieldPrimaryKey() {
+            // Arrange
+            var library = new Library() {
+                LibraryID = new Guid(),
+                NumBooks = 716284,
+                HeadLibrarian = null,
+                Endowment = 7000000,
+                Branches = 40
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Library)];
+            var data = translation.Principal.Extractor.ExtractFrom(library);
+
+            // Assert
+            data.Should().HaveCount(6);
+            data[0].Datum.Should().Be(library.LibraryID);
+            data[1].Datum.Should().Be(library.NumBooks);
+            data[2].Datum.Should().Be(DBNull.Value);
+            data[3].Datum.Should().Be(DBNull.Value);
+            data[4].Datum.Should().Be(library.Endowment);
+            data[5].Datum.Should().Be(library.Branches);
+        }
+
+        [TestMethod] public void ReferenceNestedDataConversion() {
+            // Arrange
+            var match = new CurlingMatch() {
+                ID = new Guid(),
+                TeamA = new CurlingMatch.OlympicOrganization() {
+                    Code = "ita",
+                    Country = "Italy",
+                    Recognized = 1915
+                },
+                TeamB = new CurlingMatch.OlympicOrganization() {
+                    Code = "",
+                    Country = "Norway",
+                    Recognized = 1861
+                },
+                ScoreA = 8,
+                ScoreB = 5,
+                Date = new DateTime(2022, 2, 8),
+                Olympiad = 24,
+                HammerForA = true
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(CurlingMatch)];
+            var data = translation.Principal.Extractor.ExtractFrom(match);
+
+            // Assert
+            data.Should().HaveCount(8);
+            data[0].Datum.Should().Be(match.ID);
+            data[1].Datum.Should().Be(new AllCaps().Convert(match.TeamA.Code));
+            data[2].Datum.Should().Be(new AllCaps().Convert(match.TeamB.Code));
+            data[3].Datum.Should().Be(match.ScoreA);
+            data[4].Datum.Should().Be(match.ScoreB);
+            data[5].Datum.Should().Be(match.Date);
+            data[6].Datum.Should().Be(match.Olympiad);
+            data[7].Datum.Should().Be(match.HammerForA);
+        }
+
+        [TestMethod] public void NonNullRelationWithZeroElements() {
+            // Arrange
+            var pretzel = new Pretzel() {
+                PretzelID = new Guid(),
+                Name = "Plain Pretzel",
+                Toppings = new(),
+                RetailPrice = 2.75M,
+                DoughSource = "Flour"
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Pretzel)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(pretzel);
+
+            // Assert
+            data.Insertions.Should().BeEmpty();
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().BeEmpty();
+        }
+
+        [TestMethod] public void NonNullSequenceRelationWithOnlyNewElements() {
+            // Arrange
+            var teppanyaki = new Teppanyaki() {
+                GrillID = new Guid(),
+                GrillSurfaceArea = 88.5,
+                AuthorizedChefs = new() {
+                    "Daisuke Orinaka",
+                    "Kaidon Hotosata",
+                    "Hideki Iwanatsuo",
+                },
+                SupportedFoods = new() {
+                    "Chicken",
+                    "Beef",
+                    "Onion",
+                    "Egg",
+                    "Shrimp",
+                    "Daikon",
+                    "Fried Rice"
+                },
+                MaxTemperature = 140,
+                Restaurant = null,
+                IsHibachi = false
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Teppanyaki)];
+            var setData = translation.Relations[0].Extractor.ExtractFrom(teppanyaki);
+            var listData = translation.Relations[1].Extractor.ExtractFrom(teppanyaki);
+
+            // Assert
+            listData.Insertions.Should().HaveCount(7);
+            listData.Insertions.Should().ContainRow("Chicken");
+            listData.Insertions.Should().ContainRow("Beef");
+            listData.Insertions.Should().ContainRow("Onion");
+            listData.Insertions.Should().ContainRow("Egg");
+            listData.Insertions.Should().ContainRow("Shrimp");
+            listData.Insertions.Should().ContainRow("Daikon");
+            listData.Insertions.Should().ContainRow("Fried Rice");
+            listData.Modifications.Should().BeEmpty();
+            listData.Deletions.Should().BeEmpty();
+            setData.Insertions.Should().HaveCount(3);
+            setData.Insertions.Should().ContainRow("Daisuke Orinaka");
+            setData.Insertions.Should().ContainRow("Kaidon Hotosata");
+            setData.Insertions.Should().ContainRow("Hideki Iwanatsuo");
+            setData.Modifications.Should().BeEmpty();
+            setData.Deletions.Should().BeEmpty();
+        }
+
+        [TestMethod] public void NonNullMapRelationWithOnlyNewElements() {
+            // Arrange
+            var spellingBee = new SpellingBee() {
+                Year = 2023,
+                NumRounds = 13,
+                Champion = "Dev Shah",
+                EliminationWords = new() {
+                    { 46, "chthonic" },
+                    { 119, "querken" },
+                    { 6, "pataca" },
+                    { 122, "pharetone" }
+                }
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(SpellingBee)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(spellingBee);
+
+            // Assert
+            data.Insertions.Should().HaveCount(4);
+            data.Insertions.Should().ContainRow(46U, "chthonic");
+            data.Insertions.Should().ContainRow(119U, "querken");
+            data.Insertions.Should().ContainRow(6U, "pataca");
+            data.Insertions.Should().ContainRow(122U, "pharetone");
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().BeEmpty();
+        }
+
+        [TestMethod] public void NonNullOrderedListRelationWithOnlyNewElements() {
+            // Arrange
+            var troupe = new ImprovTroupe() {
+                Name = "Players of Locura",
+                Created = new DateTime(2015, 9, 19),
+                NumShows = 496,
+                Lineup = {
+                    "Amanda Corningsweather",
+                    "Randy Cappaco",
+                    "Edith Sumak",
+                    "Nicole d'Francia",
+                    "Aaron Goliin",
+                    "Harrison B. Tarmalonz"
+                },
+                URL = "https://locuraplayers.org/"
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(ImprovTroupe)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(troupe);
+
+            // Assert
+            data.Insertions.Should().HaveCount(6);
+            data.Insertions.Should().ContainRow(0U, "Amanda Corningsweather");
+            data.Insertions.Should().ContainRow(1U, "Randy Cappaco");
+            data.Insertions.Should().ContainRow(2U, "Edith Sumak");
+            data.Insertions.Should().ContainRow(3U, "Nicole d'Francia");
+            data.Insertions.Should().ContainRow(4U, "Aaron Goliin");
+            data.Insertions.Should().ContainRow(5U, "Harrison B. Tarmalonz");
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().BeEmpty();
+        }
+
+        [TestMethod] public void NonNullRelationWithOnlySavedElements() {
+            // Arrange
+            var tip = new NedsDeclassifiedTip() {
+                ID = new Guid(),
+                Category = "Photo Day",
+                Tip = "Bring a hair brush to fix your hair before the picture",
+                For = {
+                    "Jennifer Mosely",
+                    "Suzie Crabgrass",
+                    "Bitsy Johnson"
+                }
+            };
+            (tip.For as IRelation).Canonicalize();
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(NedsDeclassifiedTip)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(tip);
+
+            // Assert
+            data.Insertions.Should().BeEmpty();
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().BeEmpty();
+        }
+
+        [TestMethod] public void NonNullRelationWithAtLeastOneModifiedElement() {
+            // Arrange
+            var territory = new PendragonTerritory() {
+                Name = "Zadaa",
+                Travellers = {
+                    "Osa",
+                    "Loor"
+                },
+                FirstAppearance = "The Lost City of Faar",
+                Capital = "Xhaxhu"
+            };
+            (territory.Travellers as IRelation).Canonicalize();
+            territory.Travellers[0] = "Loor";
+            territory.Travellers[1] = "Osa";
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(PendragonTerritory)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(territory);
+
+            // Assert
+            data.Insertions.Should().BeEmpty();
+            data.Modifications.Should().HaveCount(2);
+            data.Modifications.Should().ContainRow(0U, "Loor");
+            data.Modifications.Should().ContainRow(1U, "Osa");
+        }
+
+        [TestMethod] public void NonNullRelationWithAtLeastOneDeletedElement() {
+            // Arrange
+            var caucus = new IowaCaucus() {
+                Year = 2008,
+                Party = IowaCaucus.PoliticalParty.Democratic,
+                Date = new DateTime(2008, 1, 3),
+                DelegatesEarned = {
+                    { "Barack Obama", 16.0 },
+                    { "John Edwards", 14.0 },
+                    { "Hillary Clinton", 15.0 },
+                    { "Bill Richardson", 0.0 },
+                    { "Joe Biden", 0.0 },
+                    { "uncommitted", 0.0 },
+                    { "Christopher Dodd", 0.0 }
+                },
+                Bellwether = true
+            };
+            (caucus.DelegatesEarned as IRelation).Canonicalize();
+            caucus.DelegatesEarned.Remove("uncommitted");
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(IowaCaucus)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(caucus);
+
+            // Assert
+            data.Insertions.Should().BeEmpty();
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().HaveCount(1);
+            data.Deletions.Should().ContainRow("uncommitted", 0.0);
+        }
+
+        [TestMethod] public void NullRelation() {
+            // Arrange
+            var existentialist = new Existentialist() {
+                Name = "Jean-Paul Sartre",
+                DoctoralTheses = null,
+                DateOfBirth = new DateTime(1905, 6, 21),
+                DateOfDeath = new DateTime(1980, 4, 15),
+                ExistentialSchool = "Phenomenlogy"
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Existentialist)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(existentialist);
+
+            // Assert
+            data.Insertions.Should().BeEmpty();
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().BeEmpty();
+        }
+
+        [TestMethod] public void NonNullRelationBecomesNull() {
+            // Arrange
+            var orogene = new Orogene() {
+                FulcrumName = "Alabaster",
+                BirthName = null,
+                BirthComm = null,
+                Rings = 10,
+                Appearances = new RelationMap<Orogene.Book, bool>() {
+                    { Orogene.Book.FifthSeason, true },
+                    { Orogene.Book.ObeliskGate, true },
+                    { Orogene.Book.StoneSky, false }
+                },
+                AtNodeStation = false
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Orogene)];
+            var _ = translation.Relations[0].Extractor.ExtractFrom(orogene);
+            orogene.Appearances = null;
+            var data = translation.Relations[0].Extractor.ExtractFrom(orogene);
+
+            // Assert
+            data.Insertions.Should().BeEmpty();
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().BeEmpty();
+        }
+
+        [TestMethod] public void RelationNestedAggregate() {
+            // Arrange
+            var boon = new OlympianBoon() {
+                BoonName = "Curse of Pain",
+                Benefactor = OlympianBoon.Deity.Ares,
+                AbilityAffected = OlympianBoon.Ability.Special,
+                Progressions = new() {
+                    new OlympianBoon.Benefit() { ParameterName = "Damage", ParameterValue = 60 },
+                    new OlympianBoon.Benefit() { ParameterName = "Damage", ParameterValue = 80 },
+                    new OlympianBoon.Benefit() { ParameterName = "Damage", ParameterValue = 100 },
+                    new OlympianBoon.Benefit() { ParameterName = "Damage", ParameterValue = 120 }
+                },
+                Likelihood = 0.2
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(OlympianBoon)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(boon);
+
+            // Assert
+            data.Insertions.Should().HaveCount(4);
+            data.Insertions.Should().ContainRow(0U, "Damage", 60.0);
+            data.Insertions.Should().ContainRow(1U, "Damage", 80.0);
+            data.Insertions.Should().ContainRow(2U, "Damage", 100.0);
+            data.Insertions.Should().ContainRow(3U, "Damage", 120.0);
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().BeEmpty();
+        }
+
+        [TestMethod] public void RelationNestedReference() {
+            // Arrange
+            var impeachment = new Impeachment() {
+                Official = "Samuel Chase",
+                Position = "Associate Justice of the U.S. Supreme Court",
+                Commenced = new DateTime(1804, 3, 12),
+                Counts = new() {
+                    new Impeachment.Count() {
+                        ID = new Guid(),
+                        Claim = new Impeachment.Charge() {
+                            Claim = "Improper Conduct during the Trial of John Fries",
+                            Severity = Impeachment.Charge.Category.Misdemeanor
+                        },
+                        Guilty = false
+                    },
+                    new Impeachment.Count() {
+                        ID = new Guid(),
+                        Claim = new Impeachment.Charge() {
+                            Claim = "Improper Conduct during the Trial of James T. Callendar",
+                            Severity = Impeachment.Charge.Category.Misdemeanor
+                        },
+                        Guilty = false
+                    },
+                    new Impeachment.Count() {
+                        ID = new Guid(),
+                        Claim = new Impeachment.Charge() {
+                            Claim = "Conduct Unbecoming in front of a Baltimore Grand Jury",
+                            Severity = Impeachment.Charge.Category.Misdemeanor
+                        },
+                        Guilty = false
+                    }
+                }
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Impeachment)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(impeachment);
+
+            // Assert
+            data.Insertions.Should().HaveCount(3);
+            data.Insertions.Should().ContainRow(impeachment.Counts[0].ID, false);
+            data.Insertions.Should().ContainRow(impeachment.Counts[1].ID, false);
+            data.Insertions.Should().ContainRow(impeachment.Counts[2].ID, false);
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().BeEmpty();
+        }
+
+        [TestMethod] public void RelationReferencesOwningEntity() {
+            // Arrange
+            var god = new MaoriGod() {
+                Name = "Tangaroa",
+                Domain = "Sea",
+                Family = new(),
+                IsAtua = true,
+                EncounteredMaui = true
+            };
+            god.Family[god] = MaoriGod.Relation.Self;
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(MaoriGod)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(god);
+
+            // Assert
+            data.Insertions.Should().HaveCount(1);
+            data.Insertions.Should().ContainRow(god.Name, ConversionOf(MaoriGod.Relation.Self));
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().BeEmpty();
+        }
+
+        [TestMethod] public void RelationNestedDataConversion() {
+            // Arrange
+            var horoscope = new Horoscope() {
+                Sign = Horoscope.Zodiac.Gemini,
+                Readings = new() {
+                    {
+                        new DateTime(2024, 2, 3),
+                        new Horoscope.Listing() {
+                            Prediction = "[gobbledy gook]",
+                            Sex = 'q',
+                            Hustle = '!',
+                            Vibe = 'B',
+                            Success = '9'
+                        }
+                    }
+                },
+                RangeLower = new DateTime(2024, 5, 21),
+                RangeUpper = new DateTime(2024, 6, 20)
+            };
+
+            // Act
+            var translator = new Translator();
+            var translation = translator[typeof(Horoscope)];
+            var data = translation.Relations[0].Extractor.ExtractFrom(horoscope);
+
+            // Assert
+            data.Insertions.Should().HaveCount(1);
+            data.Insertions.Should().ContainRow(new DateTime(2024, 2, 3), "[gobbledy gook]", (int)'q', (int)'!', (int)'B', (int)'9');
+            data.Modifications.Should().BeEmpty();
+            data.Deletions.Should().BeEmpty();
+        }
+
+
+        private static string ConversionOf<T>(T enumerator) where T : Enum {
+            var converter = new EnumToStringConverter(typeof(T)).ConverterImpl;
+            return (string)converter.Convert(enumerator)!;
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/_Converters.cs
+++ b/test/UnitTests/Kvasir/Translation/_Converters.cs
@@ -1,9 +1,14 @@
 ﻿using Kvasir.Core;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace UT.Kvasir.Translation {
     internal static class TestConverters {
+        public class AllCaps : IDataConverter<string, string> {
+            public string Convert(string source) { return source.ToUpper(); }
+            public string Revert(string result) { return new CultureInfo("en-US", false).TextInfo.ToTitleCase(result); }
+        }
         public class ChangeBase : IDataConverter<int, int> {
             public ChangeBase(int _) {}
             public int Convert(int source) { return source; }

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -3,6 +3,7 @@ using Kvasir.Relations;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 using static UT.Kvasir.Translation.TestConstraints;
 using static UT.Kvasir.Translation.TestConverters;
@@ -12242,6 +12243,519 @@ namespace UT.Kvasir.Translation {
             public double Duration { get; set; }
             public Politician Instigator { get; set; } = new();
             public bool Successful { get; set; }
+        }
+    }
+
+    internal static class DataExtraction {
+        // Scenario: Non-Null, Public, Instance Scalars and Enumerations (✓values extracted✓)
+        public class Morgue {
+            [Flags] public enum Service { Autopsy = 1, Identification = 2, Cremation = 4, Refrigeration = 8, Sequestration = 16 }
+
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            [Column(1)] public string ChiefMedicalExaminer { get; set; } = "";
+            [Column(2)] public uint Capacity { get; set; }
+            [Column(3)] public decimal Budget { get; set; }
+            [Column(4)] public char FederalGrade { get; set; }
+            [Column(5)] public Service AvailableServices { get; set; }
+            [Column(6)] public bool GovernmentRun { get; set; }
+        }
+
+        // Scenario: Non-Null, Public, Static Scalars and Enumerations (✓values extracted✓)
+        public class PythonInterpreter {
+            public enum Language { C, CPP, Python, Rust, Java }
+
+            [PrimaryKey, Column(0)] public Guid ProgramID { get; set; }
+            [Column(1)] public string Path { get; set; } = "";
+            [Column(2)] public DateTime InstalledOn { get; set; }
+            [IncludeInModel, Column(3)] public static double MinVersion { get; set; }
+            [IncludeInModel, Column(4)] public static double MaxVersion { get; set; }
+            [IncludeInModel, Column(5)] public static Language BackEndLanguage { get; set; }
+        }
+
+        // Scenario: Non-Null, Non-Public, Instance Scalars and Enumerations (✓values extracted✓)
+        public class PirateShip {
+            public enum ShipKind { Sloop, Schooner, Frigate, Brigantine, Galleon, Barque, Carrack, Other }
+
+            [PrimaryKey, Column(0)] public Guid ID { get; set; }
+            [Column(1)] public string ShipName { get; set; } = "";
+            [Column(2)] public string Captain { get; set; } = "";
+            [IncludeInModel, Column(3)] private double Length { get; set; }
+            [IncludeInModel, Column(4)] protected int NumCannons { get; set; }
+            [IncludeInModel, Column(5)] internal ShipKind Style { get; set; }
+            [IncludeInModel, Column(6)] protected internal bool CarriedSlaves { get; set; }
+
+            public void SetLength(double length) => Length = length;
+            public double GetLength() => Length;
+            public void SetNumCannons(int numCannons) => NumCannons = numCannons;
+            public int GetNumCannons() => NumCannons;
+        }
+
+        // Scenario: Non-Null, Non-Public, Static Scalars and Enumerations (✓values extracted✓)
+        public class Enzyme {
+            [PrimaryKey, Column(0)] public string EnzymeCommissionNumber { get; set; } = "";
+            [Column(1)] public string CommonName { get; set; } = "";
+            [IncludeInModel, Column(2)] private static bool IsEnzyme { get; set; }
+            [IncludeInModel, Column(3)] protected static double NumEnzymesTotal { get; set; }
+            [IncludeInModel, Column(4)] internal static string Regulator { get; set; } = "";
+            [IncludeInModel, Column(5)] protected internal static DateTime FirstDiscovered { get; set; }
+
+            public static void SetIsEnzyme(bool isEnzyme) => IsEnzyme = isEnzyme;
+            public static bool GetIsEnzme() => IsEnzyme;
+            public static void SetNumEnzymesTotal(double numEnzymesTotal) => NumEnzymesTotal = numEnzymesTotal;
+            public static double GetNumEnzymesTotal() => NumEnzymesTotal;
+        }
+
+        // Scenario: Null Scalars and Enumerations (✓null extracted✓)
+        public class Ode {
+            public enum Kind { Victory, Eulogy, Musical, Romantic, Other }
+
+            [PrimaryKey, Column(0)] public string Title { get; set; } = "";
+            [PrimaryKey, Column(1)] public string Author { get; set; } = "";
+            [Column(2)] public ushort Lines { get; set; }
+            [Column(3)] public ushort WordCount { get; set; }
+            [Column(4)] public DateTime? Publication { get; set; }
+            [Column(5)] public string? Collection { get; set; }
+            [Column(6)] public Kind? Style { get; set; }
+        }
+
+        // Scenario: Explicit Interface Implementation Property (✓values extracted✓)
+        public interface IWorldLeader {
+            string Name { get; set; }
+            string Polity { get; set; }
+        }
+        public class Tlatoani : IWorldLeader {
+            [PrimaryKey, Column(0)] public Guid ID { get; set; }
+            [IncludeInModel, Column(1)] string IWorldLeader.Name { get; set; } = "";
+            [IncludeInModel, Column(2)] string IWorldLeader.Polity { get; set; } = "Aztec Empire";
+            [Column(3)] public DateTime Death { get; set; }
+            [Column(4)] public bool EncounteredConquistadors { get; set; }
+            [Column(5)] public ushort CoronationYear { get; set; }
+        }
+
+        // Scenario: Virtual Override Property (✓most-derived values extracted✓)
+        public abstract class Coin {
+            public virtual double Denomination { get; set; } = 2.0;
+        }
+        public sealed class StateQuarter : Coin {
+            [PrimaryKey, Column(0)] public string State { get; set; } = "";
+            [IncludeInModel, Column(1)] public sealed override double Denomination { get; set; }
+            [Column(2)] public ushort Year { get; set; }
+            [Column(3)] public string Engraver { get; set; } = "";
+            [Column(4)] public ulong Mintage { get; set; }
+        }
+
+        // Scenario: Hiding Property (✓hiding values extracted✓)
+        public abstract class Light {
+            public double Intensity { get; set; }
+            public byte Red { get; set; }
+            public byte Green { get; set; }
+            public byte Blue { get; set; }
+            public byte? Alpha { get; set; }
+        }
+        public class Aurora : Light {
+            [PrimaryKey, Column(0)] public Guid AuroraID { get; set; }
+            [Column(1)] public string Name { get; set; } = "";
+            [Column(2)] public string? AKA { get; set; }
+            [Column(3)] public new float Intensity { get; set; }
+        }
+
+        // Scenario: [DataConverter] Applied to Scalar Property (✓converted values extracted✓)
+        public class Underworld {
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            [Column(1)] public string Civilization { get; set; } = "";
+            [Column(2)] public string Lord { get; set; } = "";
+            [Column(3), DataConverter(typeof(Invert))] public bool ForMortals { get; set; }
+            [Column(4), DataConverter(typeof(MakeDate<int>))] public int GoogleResults { get; set; }
+        }
+
+        // Scenario: [Numeric] Applied to Enumeration Property (✓converted values extracted✓)
+        public class CornMaze {
+            public enum Corn : byte { Field, Sweet, Flint, BlackAztec, BloodyButcher, Blue, PaintedMountain, Other }
+            [Flags] public enum Shape : ulong { Animal = 1, Geometry = 2, Character = 4, Vehicle = 8, Person = 16, Object = 32, Foodstuff = 64, Weapon = 128, Geography = 256, Other = 2048 }
+
+            [PrimaryKey, Column(0)] public Guid MazeID { get; set; }
+            [Numeric, Column(1)] public Corn CornType { get; set; }
+            [Numeric, Column(2)] public Shape MazeShape { get; set; }
+            [Column(3)] public ulong StalkCount { get; set; }
+            [Column(4)] public ulong MazeArea { get; set; }
+            [Column(5)] public double SuccessRate { get; set; }
+            [Column(6)] public double RecordTime { get; set; }
+        }
+
+        // Scenario: [AsString] Applied to Enumeration Property (✓converted values extracted✓)
+        public class MarioKartRacetrack {
+            public enum Cup { Mushroom, Flower, Star, Special, Shell, Banana, Leaf, Lightning, Battle, RetroBattle }
+
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            [Column(1)] public string FirstAppearance { get; set; } = "";
+            [AsString, Column(2)] public Cup Series { get; set; }
+            [Column(3)] public ulong? TrackLength { get; set; }
+            [Column(4)] public bool AvailableOnline { get; set; }
+        }
+
+        // Scenario: [Calculated] Property (✓values extracted✓)
+        public class Lighthouse {
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            [Column(1)] public string Location { get; set; } = "";
+            [Column(2)] public double Height { get; set; }
+            [Column(3)] public ushort FocalLength { get; set; }
+            [Calculated, Column(4)] public ulong LighthouseRating => (ulong)(Math.Sqrt(Height) + 137.54) * FocalLength;
+        }
+
+        // Scenario: Non-Null Aggregate Property with Single Scalar/Enumeration Nested Fields (✓values extracted✓)
+        public class Nucleobase {
+            public struct Letter {
+                [Column(0)] public char Value { get; set; }
+            }
+
+            [PrimaryKey(Path = "Value"), Column(0)] public Letter Symbol { get; set; }
+            [Column(1)] public string Name { get; set; } = "";
+            [Column(2)] public string ChemicalFormula { get; set; } = "";
+        }
+
+        // Scenario: Non-Null Aggregate Property with Multiple Scalar/Enumeration Nested Fields (✓values extracted✓)
+        public class LegoSet {
+            public enum Rating { One, OnePointFive, Two, TwoPointFive, Three, ThreePointFive, Four, FourPointFive, Five }
+            public enum Series { Architecture, Batman, Brikz, City, Classic, Creator, DC, Disney, HarryPotter, Ideas, Jurassic, IndianaJones, SuperMario, LOTR, Marvel, Minecraft, Ninjago, StarWars, Technic }
+
+            public struct Listing {
+                [Column(0)] public decimal Price { get; set; }
+                [Column(1)] public Rating Stars { get; set; }
+                [Column(2)] public string URL { get; set; }
+                [Column(3)] public ulong InsiderPoints { get; set; }
+                [Column(4)] public Series Theme { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public uint ItemNumber { get; set; }
+            [Column(1)] public string Title { get; set; } = "";
+            [Column(2)] public Listing Catalog { get; set; }
+            [Column(7)] public ulong Pieces { get; set; }
+            [Column(8)] public byte LowerBoundAge { get; set; }
+        }
+
+        // Scenario: Non-Null Aggregate Property with All Null Nested Fields (✓null values extracted✓)
+        public class SnowballFight {
+            public struct Structure {
+                [Column(0)] public byte? NumTeams { get; set; }
+                [Column(1)] public byte? HitsAllowed { get; set; }
+                [Column(2)] public double? MaxBallRadius { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public Guid FightID { get; set; }
+            [Column(1)] public DateTime KickOff { get; set; }
+            [Column(2)] public Structure FightStructure { get; set; }
+            [Column(5)] public ulong Length { get; set; }
+            [Column(6)] public double LowTemperature { get; set; }
+        }
+
+        // Scenario: Null Aggregate Property with One Nested Field (✓null values extracted✓)
+        public class Knot {
+            public struct Geometry {
+                [Column(0)] public Double ConwayNotation { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            [Column(1)] public Geometry? Shape { get; set; }
+            [Column(2)] public double Efficiency { get; set; }
+            [Column(3)] public ushort? AshleyBookOfKnotsPage { get; set; }
+        }
+
+        // Scenario: Null Aggregate Property with Multiple Nested Fields (✓null values extracted✓)
+        public class Armory {
+            public enum Level { International, Federal, State, Local, Private, Vigilante }
+
+            public struct Coordinate {
+                [Column(0)] public float Latitude { get; set; }
+                [Column(1)] public float Longitude { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            [Column(1)] public bool Decommissioned { get; set; }
+            [Column(2)] public Coordinate? Location { get; set; }
+            [Column(4)] public ulong WeaponsCount { get; set; }
+            [Column(5)] public Level Owner { get; set; }
+        }
+
+        // Scenario: Nested Aggregate Property (✓values extracted✓)
+        public class MillionaireQuestion {
+            public struct Option {
+                [Column(0)] public string Text { get; set; }
+                [Column(1)] public bool FiftyFiftyEliminated { get; set; }
+                [Column(2)] public double AudiencePercentage { get; set; }
+                [Column(3)] public bool IsCorrect { get; set; }
+            }
+            public struct Options {
+                [Column(0)] public Option A { get; set; }
+                [Column(4)] public Option B { get; set; }
+                [Column(8)] public Option C { get; set; }
+                [Column(12)] public Option D { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public Guid QuestionID { get; set; }
+            [Column(1)] public string Category { get; set; } = "";
+            [Column(2)] public string Question { get; set; } = "";
+            [Column(3)] public Options Answers { get; set; }
+        }
+
+        // Scenario: Data Conversion Applied to Aggregate-Nested Fields (✓converted values extracted✓)
+        public class GroceryGame {
+            public struct Episode {
+                [Column(0), DataConverter(typeof(ToInt<byte>))] public byte Season { get; set; }
+                [Column(1), DataConverter(typeof(ToInt<byte>))] public byte Number { get; set; }
+                [Column(2)] public string Judge1 { get; set; }
+                [Column(3)] public string Judge2 { get; set; }
+                [Column(4)] public string Judge3 { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            [Column(1)] public string Description { get; set; } = "";
+            [Column(2)] public Episode FirstAppearance { get; set; }
+            [Column(7)] public ulong NumTimesPlayed { get; set; }
+        }
+
+        // Scenario: Non-Null Reference Property with Single-Field Primary Key (✓values extracted✓)
+        public class PapalConclave {
+            public class Cardinal {
+                [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+                [Column(1)] public string Country { get; set; } = "";
+                [Column(2)] public byte Age { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public DateTime Date { get; set; }
+            [Column(1)] public byte Ballots { get; set; }
+            [Column(2)] public Cardinal ElectedPope { get; set; } = new();
+            [Column(3)] public ushort NumElectors { get; set; }
+            [Column(4)] public Cardinal Dean { get; set; } = new();
+        }
+
+        // Scenario: Non-Null Reference Property with Multi-Field Primary Key (✓values extracted✓)
+        public class Cytonic {
+            [Flags] public enum Power { Hyperjump = 1, Cytosense = 2, Mindblade = 4, Bolts = 8, Inhibition = 16, Illusions = 32 }
+            [Flags] public enum Book { Skyward = 1, Starsight = 2, Cytonic = 4, Defiant = 8 }
+
+            public class Species {
+                [PrimaryKey, Column(0)] public int Grouping { get; set; }
+                [Column(1)] public string Name { get; set; } = "";
+                [PrimaryKey, Column(2)] public int SubNumber { get; set; }
+                [Column(3)] public bool PrimaryIntelligence { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            [Column(1)] public string? CallSign { get; set; }
+            [Column(2)] public Species SelfSpecies { get; set; } = new();
+            [Column(4)] public Power Abilities { get; set; }
+            [Column(5)] public Book Appearances { get; set; }
+        }
+
+        // Scenario: Null Reference Property with Single-Field Primary Key (✓null values extracted✓)
+        public class SoapOpera {
+            public class Network {
+                [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+                [Column(1)] public string StockSymbol { get; set; } = "";
+                [Column(2)] public ulong NumEmployees { get; set; }
+                [Column(3)] public DateTime Founded { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public string Title { get; set; } = "";
+            [Column(1)] public bool IsStillAiring { get; set; }
+            [Column(2)] public DateTime Premiere { get; set; }
+            [Column(3)] public ushort NumSeasons { get; set; }
+            [Column(4)] public ushort NumEpisodes { get; set; }
+            [Column(5)] public ushort NumCastMembers { get; set; }
+            [Column(6)] public Network? OwningNetwork { get; set; }
+            [Column(7)] public bool IsTelenovela { get; set; }
+        }
+
+        // Scenario: Null Reference Property with Multi-Field Primary Key (✓null values extracted✓)
+        public class Library {
+            public class Person {
+                [PrimaryKey, Column(0)] public string FirstName { get; set; } = "";
+                [PrimaryKey, Column(1)] public string LastName { get; set; } = "";
+                [Column(2)] public DateTime DOB { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public Guid LibraryID { get; set; }
+            [Column(1)] public ulong NumBooks { get; set; }
+            [Column(2)] public Person? HeadLibrarian { get; set; }
+            [Column(4)] public decimal Endowment { get; set; }
+            [Column(5)] public ushort Branches { get; set; }
+        }
+
+        // Scenario: Data Conversion Applied to Reference-Nested Field (✓converted values extracted✓)
+        public class CurlingMatch {
+            public class OlympicOrganization {
+                [PrimaryKey, DataConverter(typeof(AllCaps)), Column(0)] public string Code { get; set; } = "";
+                [Column(1)] public string Country { get; set; } = "";
+                [Column(2)] public short Recognized { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public Guid ID { get; set; }
+            [Column(1)] public OlympicOrganization TeamA { get; set; } = new();
+            [Column(2)] public OlympicOrganization TeamB { get; set; } = new();
+            [Column(3)] public sbyte ScoreA { get; set; }
+            [Column(4)] public sbyte ScoreB { get; set; }
+            [Column(5)] public DateTime Date { get; set; }
+            [Column(6)] public ushort? Olympiad { get; set; }
+            [Column(7)] public bool HammerForA { get; set; }
+        }
+
+        // Scenario: Non-Null Relation Property with Zero Elements (✓no values extracted✓)
+        public class Pretzel {
+            [PrimaryKey, Column(0)] public Guid PretzelID { get; set; }
+            [Column(1)] public string Name { get; set; } = "";
+            public RelationSet<string> Toppings { get; set; } = new();
+            [Column(2)] public decimal RetailPrice { get; set; }
+            [Column(3)] public string DoughSource { get; set; } = "";
+        }
+
+        // Scenario: Non-Null List/Set Relation Property with Only New Elements (✓values extracted per element✓)
+        public class Teppanyaki {
+            [PrimaryKey, Column(0)] public Guid GrillID { get; set; }
+            [Column(1)] public double GrillSurfaceArea { get; set; }
+            public RelationSet<string> AuthorizedChefs { get; set; } = new();
+            public RelationList<string> SupportedFoods { get; set; } = new();
+            [Column(2)] public float MaxTemperature { get; set; }
+            [Column(3)] public string? Restaurant { get; set; }
+            [Column(4)] public bool IsHibachi { get; set; }
+        }
+
+        // Scenario: Non-Null Map Relation Property with Only New Elements (✓values extracted per element✓)
+        public class SpellingBee {
+            [PrimaryKey, Column(0)] public ushort Year { get; set; }
+            [Column(1)] public byte NumRounds { get; set; }
+            [Column(2)] public string Champion { get; set; } = "";
+            public RelationMap<uint, string> EliminationWords { get; set; } = new();
+        }
+
+        // Scenario: Non-Null Ordered List Relation Property with Only New Elements (✓values extracted per element✓)
+        public class ImprovTroupe {
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            [Column(1)] public DateTime Created { get; set; }
+            [Column(2)] public uint NumShows { get; set; }
+            public RelationOrderedList<string> Lineup { get; set; } = new();
+            [Column(3)] public string Location { get; set; } = "";
+            [Column(4)] public string URL { get; set; } = "";
+        }
+
+        // Scenario: Non-Null Relation Property with Only Saved Elements (✓no values extracted✓)
+        public class NedsDeclassifiedTip {
+            [PrimaryKey] public Guid ID { get; set; }
+            public string Category { get; set; } = "";
+            public string Tip { get; set; } = "";
+            public RelationSet<string> For { get; set; } = new();
+        }
+
+        // Scenario: Non-Null Relation Property with At Least One Modified Element (✓values extracted per element✓)
+        public class PendragonTerritory {
+            [PrimaryKey] public string Name { get; set; } = "";
+            public RelationOrderedList<string> Travellers { get; set; } = new();
+            public string FirstAppearance { get; set; } = "";
+            public string Capital { get; set; } = "";
+        }
+
+        // Scenario: Non-Null Relation Property with At Least One Deleted Element (✓values extracted per element✓)
+        public class IowaCaucus {
+            public enum PoliticalParty { Republican, Democratic }
+
+            [PrimaryKey] public ushort Year { get; set; }
+            [PrimaryKey] public PoliticalParty Party { get; set; }
+            public DateTime Date { get; set; }
+            public RelationMap<string, double> DelegatesEarned { get; set; } = new();
+            public bool Bellwether { get; set; }
+        }
+
+        // Scenario: Null Relation Property (✓no values extracted✓)
+        public class Existentialist {
+            public class Thesis {
+                [PrimaryKey, Column(0)] public string Title { get; set; } = "";
+                [Column(1)] public ushort YearSubmitted { get; set; }
+                [Column(2)] public ushort PageCount { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            public RelationOrderedList<Thesis>? DoctoralTheses { get; set; }
+            [Column(1)] public DateTime DateOfBirth { get; set; }
+            [Column(2)] public DateTime? DateOfDeath { get; set; }
+            [Column(3)] public string ExistentialSchool { get; set; } = "";
+        }
+
+        // Scenario: Non-Null Relation Property becomes Null (✓no values extracted✓)
+        public class Orogene {
+            public enum Book { FifthSeason, ObeliskGate, StoneSky }
+
+            [PrimaryKey, Column(0)] public string FulcrumName { get; set; } = "";
+            [Column(1)] public string? BirthName { get; set; }
+            [Column(2)] public string? BirthComm { get; set; }
+            [Column(3)] public byte Rings { get; set; }
+            public RelationMap<Book, bool>? Appearances { get; set; }
+            [Column(4)] public bool AtNodeStation { get; set; }
+        }
+
+        // Scenario: Non-Null Relation Property with Nested Aggregate and At Least One Element (✓values extracted✓)
+        public class OlympianBoon {
+            public enum Deity { Ares, Athena, Aphrodite, Artemis, Demeter, Dionysus, Hermes, Poseidon, Zeus }
+            public enum Ability { Attack, Special, Cast, Dash, Upper, Call }
+
+            public struct Benefit {
+                [Column(0)] public string ParameterName { get; set; }
+                [Column(1)] public double ParameterValue { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public string BoonName { get; set; } = "";
+            [Column(1)] public Deity Benefactor { get; set; }
+            [Column(2)] public Ability AbilityAffected { get; set; }
+            public RelationOrderedList<Benefit> Progressions { get; set; } = new();
+            [Column(3)] public double Likelihood { get; set; }
+        }
+
+        // Scenario: Non-Null Relation Property with Nested Reference and At Least One Element (✓values extracted✓)
+        public class Impeachment {
+            public struct Charge {
+                public enum Category { HighCrime, Misdemeanor, Treason }
+
+                [Column(0)] public string Claim { get; set; }
+                [Column(1)] public Category Severity { get; set; }
+            }
+            public class Count {
+                [PrimaryKey, Column(0)] public Guid ID { get; set; }
+                [Column(1)] public Charge Claim { get; set; }
+                [PrimaryKey, Column(3)] public bool Guilty { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public string Official { get; set; } = "";
+            [Column(1)] public string Position { get; set; } = "";
+            [PrimaryKey, Column(2)] public DateTime Commenced { get; set; }
+            public RelationList<Count> Counts { get; set; } = new();
+            [Calculated, Column(3)] public bool Convicted => Counts.Any(c => c.Guilty);
+        }
+
+        // Scenario: Non-Null Relation Property with Owning Entity in Element (✓values extracted✓)
+        public class MaoriGod {
+            public enum Relation { Self, Parent, Grandparent, Child, Grandchild, Sibling, Cousing, Nibling, AuntUncle };
+
+            [PrimaryKey, Column(0)] public string Name { get; set; } = "";
+            [Column(1)] public string Domain { get; set; } = "";
+            public RelationMap<MaoriGod, Relation> Family { get; set; } = new();
+            [Column(2)] public bool IsAtua { get; set; }
+            [Column(3)] public bool EncounteredMaui { get; set; }
+        }
+
+        // Scenario: Data Conversion Applied to Relation-Nested Field (✓converted values extracted✓)
+        public class Horoscope {
+            public enum Zodiac { Aries, Taurus, Gemini, Cancer, Leo, Virgo, Libra, Scorpio, Saggitarius, Capricorn, Aquarius, Pisces }
+
+            public struct Listing {
+                [Column(0)] public string Prediction { get; set; }
+                [Column(1), DataConverter(typeof(ToInt<char>))] public char Sex { get; set; }
+                [Column(2), DataConverter(typeof(ToInt<char>))] public char Hustle { get; set; }
+                [Column(3), DataConverter(typeof(ToInt<char>))] public char Vibe { get; set; }
+                [Column(4), DataConverter(typeof(ToInt<char>))] public char Success { get; set; }
+            }
+
+            [PrimaryKey, Column(0)] public Zodiac Sign { get; set; }
+            public RelationMap<DateTime, Listing> Readings { get; set; } = new();
+            [Column(1)] public DateTime RangeLower { get; set; }
+            [Column(2)] public DateTime RangeUpper { get; set; }
         }
     }
 }

--- a/test/UnitTests/_FluentExtensions/DataRowAssertions.cs
+++ b/test/UnitTests/_FluentExtensions/DataRowAssertions.cs
@@ -1,0 +1,26 @@
+﻿using Kvasir.Schema;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FluentAssertions {
+    internal static partial class AssertionExtensions {
+        public static DataRowsAssertion Should(this IEnumerable<IReadOnlyList<DBValue>> self) {
+            return new DataRowsAssertion(self);
+        }
+
+        public class DataRowsAssertion : Collections.GenericCollectionAssertions<IReadOnlyList<DBValue>> {
+            public new IEnumerable<IReadOnlyList<DBValue>> Subject { get; }
+            public DataRowsAssertion(IEnumerable<IReadOnlyList<DBValue>> subject)
+                : base(subject) {
+
+                Subject = subject;
+            }
+
+            [CustomAssertion]
+            public AndConstraint<DataRowsAssertion> ContainRow(params object?[] values) {
+                base.Contain(e => e.SequenceEqual(values.Select(v => DBValue.Create(v))));
+                return new AndConstraint<DataRowsAssertion>(this);
+            }
+        }
+    }
+}

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -42,6 +42,7 @@ Archangel
 Archbishop
 Aria
 Armada
+Armory
 Aron Kodesh
 Arrondissement
 Arson
@@ -55,6 +56,7 @@ Atmospheric Layer
 Atoll
 Attribute (C#)
 Auction Lot
+Aurora
 Auto-da-Fé
 Avatar
 Avocado
@@ -242,6 +244,7 @@ Constitution
 Constitutional Amendment
 Cookbook
 Coral Reef
+Corn Maze
 Country
 County
 Coup d'État
@@ -256,10 +259,12 @@ Cryptid
 Cryptocurrency
 Cryptogram
 Cult
+Curling Match
 Currency
 CVE
 Cybersite
 Cyclops
+Cytonic
 D&D Character
 D&D Monster
 D&D Spell
@@ -321,6 +326,7 @@ Encryption
 Encyclopedia
 Engagement Ring
 Enumeration
+Enzyme
 Episode
 Escalator
 Escape Room
@@ -330,6 +336,7 @@ Etiology
 Eunuch
 Eurovision Song Contest
 Excel Range
+Existentialist
 Exorcism
 Experiment
 Expiration
@@ -403,6 +410,7 @@ Ground Meat
 Guillotine
 Guitar
 Gulag
+Guy's Grocery Game
 Gymnast
 Haiku
 Hairstyle
@@ -438,6 +446,7 @@ Hominin
 Honest Trailer
 Horcrux
 Hormone
+Horoscope
 Hospital
 Hostage Situation
 Hot Air Balloon
@@ -457,7 +466,9 @@ IKEA Furniture
 Imaginary Friend
 Immaculate Grid
 Immortal (Highlander)
+Impeachment
 Impractical Joke
+Improv Troupe
 Inator
 Indictment
 Infinity Stone
@@ -474,6 +485,7 @@ Intern
 Internet Craze
 Interview
 Intifada
+Iowa Caucus
 IP Address
 iPhone
 IPO
@@ -500,6 +512,7 @@ King of England
 Kite
 Knife
 Knock-Knock Joke
+Knot
 Kosher Agency
 Labor of Heracles
 Lagerstätte
@@ -515,12 +528,15 @@ Lawn Gnome
 Lawn Mower
 Lazarus Pit
 Lease
+Lego Set
 Legume
 Lens
 Leprechaun
+Library (books)
 License Plate
 Lifeguard
 Ligament
+Lighthouse
 Limbo Competition
 Limerick
 Linker
@@ -550,12 +566,14 @@ Magazine
 Magic System
 Magical Preserve (Fablehaven)
 Mall Santa
+Maori God
 Marathon
 Marble League
 Margarita
 Mariachi Band
 Marian Apparition
 Marijuana Strain
+Mario Kart Racetrack
 Mark-Up Symbol
 Mars Rover
 Masked Singer
@@ -587,6 +605,7 @@ Mongol Khan
 Monopoly Property
 Month
 Moon of Jupiter
+Morgue
 Mosque
 Motorcycle
 Mountain
@@ -610,6 +629,7 @@ Nazca Line
 Nebula
 Necktie
 Necromancer
+Ned's Declassified School Survival Guide Tip
 Neurotoxin
 Neurotransmitter
 News Anchor
@@ -620,6 +640,7 @@ Nobel Prize
 Norse God
 Norse World
 Nuclear Power Plant
+Nucleobase
 NuGet Package
 Nursery Rhyme
 Nymph
@@ -630,11 +651,13 @@ Ocean Current
 Oceanic Trench
 Oceanid
 Octopus
+Ode
 Oil (cooking)
 Oil Field
 Oil Spill
 Ointment
 Olympiad
+Olympian Boon (Hades)
 Onomatopoeia
 Opera
 Opioid
@@ -643,6 +666,7 @@ Organ Procurement Organization
 Orgasm
 Origami
 Orisha
+Orogene
 Orphanage
 Overnight Camp
 PACER Test
@@ -652,6 +676,7 @@ Painting
 Pajamas
 Panegyric
 Papal Bull
+Papal Conclave
 Parabola
 Parashah
 Parking Garage
@@ -688,6 +713,7 @@ Pigment (biology)
 Pillow
 Ping
 Pirate
+Pirate Ship
 Pizza
 Plane of Existence (D&D)
 Planeswalker
@@ -717,6 +743,7 @@ Pregnancy Test
 Prescription
 Presidential Election
 Press Secretary
+Pretzel
 Pride Parade
 Printer
 Prison
@@ -736,6 +763,7 @@ Pull Request
 Pulley
 Pulsar
 Puppet Show
+Python Interpreter
 QR Code
 Quadratic Equation
 Quarterback
@@ -828,6 +856,8 @@ Smoothie
 Smurf
 Snake
 SNL Episode
+Snowball Fight
+Soap Opera
 Soccer Team
 Solar Eclipse
 Solicitor General
@@ -840,6 +870,7 @@ Space Shuttle
 Speakeasy
 Speed Limit
 Speedometer
+Spelling Bee
 Spider
 Spider-Man
 Sporcle Quiz
@@ -855,6 +886,7 @@ Stanley Cup
 Star
 Star-Crossed Lovers
 State of the Union
+State Quarter
 Steak
 Step Pyramid
 Stock
@@ -892,8 +924,10 @@ TED Talk
 Telescope
 Tendon
 Tennis Match
+Teppanyaki
 Tepui
 Terminator
+Territory (Pendragon)
 Terrorist Organization
 Therapist
 Thesis
@@ -905,6 +939,7 @@ Time Traveler
 Time Zone
 Timestamp
 "Title of Your Sex Tape" Joke
+Tlatoani
 Tongue Twister
 Tooth
 Toothbrush
@@ -936,6 +971,7 @@ Umbrella
 Umpire
 UN Resolution
 UN Secretary General
+Underworld
 Union
 University
 Upanishad
@@ -970,6 +1006,7 @@ Weekend Update
 Werewolf
 Where's Waldo?
 White Walker
+Who Wants to Be a Millionaire? Question
 Wikipedia Page
 Wildfire
 Windmill


### PR DESCRIPTION
This commit implements the Translation layer for Extraction, which is the process by which data is pulled out of CLR objects and into 'rows' for the database. Annotations do not apply to the Extraction layer, and there are no errors possible. All classes of property are supported: scalars, enumerations, aggregates, references, and relations (including arbitrary nesting).