### PR TITLE
Update Dependencies (2024 Q2)

### DIFF
--- a/src/Atropos/Atropos.csproj
+++ b/src/Atropos/Atropos.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="4.3.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="4.5.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>

--- a/src/Cybele/Cybele.csproj
+++ b/src/Cybele/Cybele.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="4.3.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="4.5.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/Kvasir/Kvasir.csproj
+++ b/src/Kvasir/Kvasir.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="4.3.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="4.5.0" />
     <PackageReference Include="Combinatorics" Version="2.0.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
  * Ardalis.GuardClauses: 4.3.0 --> 4.5.0
  * coverlet.msbuild: 6.0.0 --> 6.0.2
  * Microsoft.NET.Test.Sdk: 17.8.0 --> 17.10.0
  * MSTest.TestAdapter: 3.1.1 --> 3.4.3
  * MSTest.TestFramework: 3.1.1 --> 3.4.3