### PR TITLE
Transaction Commands Interfaces

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -6678,6 +6678,87 @@
         <member name="M:Kvasir.Schema.Table.Kvasir#Schema#ITable#GenerateDeclaration``5(Kvasir.Transcription.IBuilderFactory{``0,``1,``2,``3,``4})">
             <inheritdoc/>
         </member>
+        <member name="T:Kvasir.Transaction.ICommands">
+            
+        </member>
+        <member name="P:Kvasir.Transaction.ICommands.Table">
+            <summary>
+              The <see cref="T:Kvasir.Schema.ITable">Table</see> against which the commands execute.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Transaction.ICommands.CreateTableCommand">
+            <summary>
+              The command that creates <see cref="P:Kvasir.Transaction.ICommands.Table"/> in the back-end database.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Transaction.ICommands.SelectAllQuery">
+            <summary>
+              The command that selects all data from <see cref="P:Kvasir.Transaction.ICommands.Table"/>. The rows should be returned in key-sorted
+              order, which for Relation Tables guarantees that the rows are grouped by "owning Entity."
+            </summary>
+        </member>
+        <member name="M:Kvasir.Transaction.ICommands.InsertCommand(System.Collections.Generic.IEnumerable{System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue}})">
+            <summary>
+              Produce a command that, when executed against a back-end database and committed, inserts one or more rows
+              of data into <see cref="P:Kvasir.Transaction.ICommands.Table"/>.
+            </summary>
+            <param name="rows">
+              The rows of data to be inserted.
+            </param>
+        </member>
+        <member name="M:Kvasir.Transaction.ICommands.UpdateCommand(System.Collections.Generic.IEnumerable{System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue}})">
+            <summary>
+              Produce a command that, when executed against a back-end database and committed, updates the values of one
+              or more rows that already exist in <see cref="P:Kvasir.Transaction.ICommands.Table"/>.
+            </summary>
+            <remarks>
+              Kvasir itself does not do any mutation tracking outside of Relations, and even then its tracking is
+              somewhat rudimentary. <see cref="T:Kvasir.Transaction.ICommands"/> implementations are free to implement their own state
+              tracking, such that an update request does nothing if no state has actually changes. This is not required
+              however: implementations may unconditionally perform an update, even if the result is no net difference.
+              It is always safe to assume that the values that make up a particular Entity's primary key do not change.
+            </remarks>
+            <param name="rows">
+              The full rows of data that should exist in the back-end database after the update.
+            </param>
+        </member>
+        <member name="M:Kvasir.Transaction.ICommands.DeleteCommand(System.Collections.Generic.IEnumerable{System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue}})">
+            <summary>
+              Produce a command that, when executed against a back-end database and committed, deleted one or more rows
+              from <see cref="P:Kvasir.Transaction.ICommands.Table"/>.
+            </summary>
+            <remarks>
+              Deleting a row from a Principal Table may result in rows in various other tables (either other Entities'
+              Principal Tables or Relation Tables) being invalid due to existing Foreign Keys. <see cref="T:Kvasir.Transaction.ICommands"/>
+              implementations are encouraged to leverage <c>ON DELETE</c> behavior to account for these situations.
+              Implementations may, however, handle such events manually (such as if <c>ON DELETE</c> behavior is not
+              supported.)
+            </remarks>
+            <param name="rows">
+              The rows of data that should be deleted. (Note that this is <b>not</b> just the rows' Primary Keys.)
+            </param>
+        </member>
+        <member name="T:Kvasir.Transaction.ICommandsFactory">
+            <summary>
+              The interface describing how to create <see cref="T:Kvasir.Transaction.ICommands"/> instances.
+            </summary>
+            <remarks>
+              The purpose of this interface is to provide a mechanism for the framework to create instances of the
+              <see cref="T:Kvasir.Transaction.ICommands"/> interface for constituent tables without knowing anything about the particular
+              implementation details. An implementation of the <see cref="T:Kvasir.Transaction.ICommandsFactory"/> interface should generally
+              correspond to a particular back-end database provider (e.g. MySQL) and produce instances that can operate
+              against that RDBMS.
+            </remarks>
+        </member>
+        <member name="M:Kvasir.Transaction.ICommandsFactory.CreateCommand(Kvasir.Schema.ITable)">
+            <summary>
+              Get the <see cref="T:Kvasir.Transaction.ICommands"/> that defines database interactions against a particular
+              <see cref="T:Kvasir.Schema.ITable">Table</see>.
+            </summary>
+            <param name="table">
+              The <see cref="T:Kvasir.Schema.ITable">Table</see>.
+            </param>
+        </member>
         <member name="T:Kvasir.Transcription.IBuilderFactory`5">
             <summary>
               The interface for a factory that creates internally consistent declaration builders for generating

--- a/src/Kvasir/Transaction/ICommands.cs
+++ b/src/Kvasir/Transaction/ICommands.cs
@@ -1,0 +1,65 @@
+﻿using Kvasir.Schema;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Kvasir.Transaction {
+    ///
+    public interface ICommands {
+        /// <summary>
+        ///   The <see cref="ITable">Table</see> against which the commands execute.
+        /// </summary>
+        ITable Table { get; set; }
+
+        /// <summary>
+        ///   The command that creates <see cref="Table"/> in the back-end database.
+        /// </summary>
+        DbCommand CreateTableCommand { get; }
+
+        /// <summary>
+        ///   The command that selects all data from <see cref="Table"/>. The rows should be returned in key-sorted
+        ///   order, which for Relation Tables guarantees that the rows are grouped by "owning Entity."
+        /// </summary>
+        DbCommand SelectAllQuery { get; }
+
+        /// <summary>
+        ///   Produce a command that, when executed against a back-end database and committed, inserts one or more rows
+        ///   of data into <see cref="Table"/>.
+        /// </summary>
+        /// <param name="rows">
+        ///   The rows of data to be inserted.
+        /// </param>
+        DbCommand InsertCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
+
+        /// <summary>
+        ///   Produce a command that, when executed against a back-end database and committed, updates the values of one
+        ///   or more rows that already exist in <see cref="Table"/>.
+        /// </summary>
+        /// <remarks>
+        ///   Kvasir itself does not do any mutation tracking outside of Relations, and even then its tracking is
+        ///   somewhat rudimentary. <see cref="ICommands"/> implementations are free to implement their own state
+        ///   tracking, such that an update request does nothing if no state has actually changes. This is not required
+        ///   however: implementations may unconditionally perform an update, even if the result is no net difference.
+        ///   It is always safe to assume that the values that make up a particular Entity's primary key do not change.
+        /// </remarks>
+        /// <param name="rows">
+        ///   The full rows of data that should exist in the back-end database after the update.
+        /// </param>
+        DbCommand UpdateCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
+
+        /// <summary>
+        ///   Produce a command that, when executed against a back-end database and committed, deleted one or more rows
+        ///   from <see cref="Table"/>.
+        /// </summary>
+        /// <remarks>
+        ///   Deleting a row from a Principal Table may result in rows in various other tables (either other Entities'
+        ///   Principal Tables or Relation Tables) being invalid due to existing Foreign Keys. <see cref="ICommands"/>
+        ///   implementations are encouraged to leverage <c>ON DELETE</c> behavior to account for these situations.
+        ///   Implementations may, however, handle such events manually (such as if <c>ON DELETE</c> behavior is not
+        ///   supported.)
+        /// </remarks>
+        /// <param name="rows">
+        ///   The rows of data that should be deleted. (Note that this is <b>not</b> just the rows' Primary Keys.)
+        /// </param>
+        DbCommand DeleteCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
+    }
+}

--- a/src/Kvasir/Transaction/ICommandsFactory.cs
+++ b/src/Kvasir/Transaction/ICommandsFactory.cs
@@ -1,0 +1,24 @@
+﻿using Kvasir.Schema;
+
+namespace Kvasir.Transaction {
+    /// <summary>
+    ///   The interface describing how to create <see cref="ICommands"/> instances.
+    /// </summary>
+    /// <remarks>
+    ///   The purpose of this interface is to provide a mechanism for the framework to create instances of the
+    ///   <see cref="ICommands"/> interface for constituent tables without knowing anything about the particular
+    ///   implementation details. An implementation of the <see cref="ICommandsFactory"/> interface should generally
+    ///   correspond to a particular back-end database provider (e.g. MySQL) and produce instances that can operate
+    ///   against that RDBMS.
+    /// </remarks>
+    public interface ICommandsFactory {
+        /// <summary>
+        ///   Get the <see cref="ICommands"/> that defines database interactions against a particular
+        ///   <see cref="ITable">Table</see>.
+        /// </summary>
+        /// <param name="table">
+        ///   The <see cref="ITable">Table</see>.
+        /// </param>
+        ICommands CreateCommand(ITable table);
+    }
+}

--- a/src/Kvasir/Translation/TableDefs.cs
+++ b/src/Kvasir/Translation/TableDefs.cs
@@ -26,6 +26,6 @@ namespace Kvasir.Translation {
     internal sealed record class RelationTableDef(
         ITable Table,
         RelationExtractionPlan Extractor,
-        RelationRepopulationPlan? Repopulator
+        RelationRepopulationPlan Repopulator
     );
 }


### PR DESCRIPTION
This commit adds two interfaces: ICommands and ICommandsFactory. The former is responsible for producing DBCommands for CRUD operations against a particular Table, and the latter is responsible for creating the former. Conceptually, an implementation of the ICommandsFactory interface will correspond to a particular back-end database system and/or SQL flavor. These are the APIs that the Kvasir framework will interact with to load and store data, enabling support for arbitrary RDBMSes.