### PR TITLE
Properly Memoize Translations

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -7719,6 +7719,33 @@
               The name of <paramref name="property"/>.
             </returns>
         </member>
+        <member name="T:Kvasir.Translation.EntityTranslation">
+            <summary>
+              A translation of a single CLR type.
+            </summary>
+            
+            <param name="CLRSource">The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.EntityTranslation"/></param>
+            <param name="Principal">The definition of the Principal Table</param>
+            <param name="Relations">The definitions of any Relation Tables</param>
+        </member>
+        <member name="M:Kvasir.Translation.EntityTranslation.#ctor(System.Type,Kvasir.Translation.PrincipalTableDef,System.Collections.Generic.IReadOnlyList{Kvasir.Translation.RelationTableDef})">
+            <summary>
+              A translation of a single CLR type.
+            </summary>
+            
+            <param name="CLRSource">The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.EntityTranslation"/></param>
+            <param name="Principal">The definition of the Principal Table</param>
+            <param name="Relations">The definitions of any Relation Tables</param>
+        </member>
+        <member name="P:Kvasir.Translation.EntityTranslation.CLRSource">
+            <summary>The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.EntityTranslation"/></summary>
+        </member>
+        <member name="P:Kvasir.Translation.EntityTranslation.Principal">
+            <summary>The definition of the Principal Table</summary>
+        </member>
+        <member name="P:Kvasir.Translation.EntityTranslation.Relations">
+            <summary>The definitions of any Relation Tables</summary>
+        </member>
         <member name="T:Kvasir.Translation.AmbiguousNullabilityException">
             <summary>
               An exception that is raised when the nullability of an Aggregate property causes an ambiguity.
@@ -10598,33 +10625,6 @@
         </member>
         <member name="P:Kvasir.Translation.RelationTableDef.Repopulator">
             <summary>The plan that can populate elements into a CLR Relation from a row of data stored in the Relation Table.</summary>
-        </member>
-        <member name="T:Kvasir.Translation.Translation">
-            <summary>
-              A translation of a single CLR type.
-            </summary>
-            
-            <param name="CLRSource">The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.Translation"/></param>
-            <param name="Principal">The definition of the Principal Table</param>
-            <param name="Relations">The definitions of any Relation Tables</param>
-        </member>
-        <member name="M:Kvasir.Translation.Translation.#ctor(System.Type,Kvasir.Translation.PrincipalTableDef,System.Collections.Generic.IReadOnlyList{Kvasir.Translation.RelationTableDef})">
-            <summary>
-              A translation of a single CLR type.
-            </summary>
-            
-            <param name="CLRSource">The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.Translation"/></param>
-            <param name="Principal">The definition of the Principal Table</param>
-            <param name="Relations">The definitions of any Relation Tables</param>
-        </member>
-        <member name="P:Kvasir.Translation.Translation.CLRSource">
-            <summary>The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.Translation"/></summary>
-        </member>
-        <member name="P:Kvasir.Translation.Translation.Principal">
-            <summary>The definition of the Principal Table</summary>
-        </member>
-        <member name="P:Kvasir.Translation.Translation.Relations">
-            <summary>The definitions of any Relation Tables</summary>
         </member>
         <member name="T:Kvasir.Translation.Bound">
             <summary>

--- a/src/Kvasir/Translation/EntityTranslation.cs
+++ b/src/Kvasir/Translation/EntityTranslation.cs
@@ -6,10 +6,10 @@ namespace Kvasir.Translation {
     ///   A translation of a single CLR type.
     /// </summary>
     /// 
-    /// <param name="CLRSource">The CLR <see cref="Type"/> that produced this <see cref="Translation"/></param>
+    /// <param name="CLRSource">The CLR <see cref="Type"/> that produced this <see cref="EntityTranslation"/></param>
     /// <param name="Principal">The definition of the Principal Table</param>
     /// <param name="Relations">The definitions of any Relation Tables</param>
-    internal sealed record class Translation(
+    internal sealed record class EntityTranslation(
         Type CLRSource,
         PrincipalTableDef Principal,
         IReadOnlyList<RelationTableDef> Relations

--- a/test/UnitTests/_FluentExtensions/ExceptionAssertions.cs
+++ b/test/UnitTests/_FluentExtensions/ExceptionAssertions.cs
@@ -12,14 +12,14 @@ using System.Linq;
 
 namespace FluentAssertions {
     internal static partial class AssertionExtensions {
-        public static TranslationAssertions Should(this Func<Translation> self) {
+        public static TranslationAssertions Should(this Func<EntityTranslation> self) {
             return new TranslationAssertions(self);
         }
 
 
-        public class TranslationAssertions : FunctionAssertions<Translation> {
-            public new Func<Translation> Subject { get; }
-            public TranslationAssertions(Func<Translation> subject)
+        public class TranslationAssertions : FunctionAssertions<EntityTranslation> {
+            public new Func<EntityTranslation> Subject { get; }
+            public TranslationAssertions(Func<EntityTranslation> subject)
                 : base(subject, new AggregateExceptionExtractor()) {
 
                 Subject = subject;


### PR DESCRIPTION
This commit adds memoization for overall Translations. We already have memoization for Principal Tables, which we have to keep because those can be translated without doing a full Translation. However, there is no memoization for Relation Tables, and therefore attempting to do a full translation of the same source type twice can lead to duplication errors.

I also renamed the Translation struct to EntityTranslation, since otherwise there's weird conflicts with the Kvasir.Translation namespace.