### PR TITLE
Fix Up ICommands and ICommandsFactory Interfaces

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -6681,28 +6681,25 @@
             <inheritdoc/>
         </member>
         <member name="T:Kvasir.Transaction.ICommands">
-            
-        </member>
-        <member name="P:Kvasir.Transaction.ICommands.Table">
             <summary>
-              The <see cref="T:Kvasir.Schema.ITable">Table</see> against which the commands execute.
+              The interface describing the selection and CRUD commands for a single <see cref="T:Kvasir.Schema.ITable">Table</see>.
             </summary>
         </member>
         <member name="P:Kvasir.Transaction.ICommands.CreateTableCommand">
             <summary>
-              The command that creates <see cref="P:Kvasir.Transaction.ICommands.Table"/> in the back-end database.
+              The command that creates the target <see cref="T:Kvasir.Schema.Table"/> in the back-end database.
             </summary>
         </member>
         <member name="P:Kvasir.Transaction.ICommands.SelectAllQuery">
             <summary>
-              The command that selects all data from <see cref="P:Kvasir.Transaction.ICommands.Table"/>. The rows should be returned in key-sorted
-              order, which for Relation Tables guarantees that the rows are grouped by "owning Entity."
+              The command that selects all data from the target <see cref="T:Kvasir.Schema.Table"/>. The rows should be returned in
+              key-sorted order, which for Relation Tables guarantees that the rows are grouped by "owning Entity."
             </summary>
         </member>
         <member name="M:Kvasir.Transaction.ICommands.InsertCommand(System.Collections.Generic.IEnumerable{System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue}})">
             <summary>
               Produce a command that, when executed against a back-end database and committed, inserts one or more rows
-              of data into <see cref="P:Kvasir.Transaction.ICommands.Table"/>.
+              of data into the target <see cref="T:Kvasir.Schema.Table"/>.
             </summary>
             <param name="rows">
               The rows of data to be inserted.
@@ -6711,7 +6708,7 @@
         <member name="M:Kvasir.Transaction.ICommands.UpdateCommand(System.Collections.Generic.IEnumerable{System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue}})">
             <summary>
               Produce a command that, when executed against a back-end database and committed, updates the values of one
-              or more rows that already exist in <see cref="P:Kvasir.Transaction.ICommands.Table"/>.
+              or more rows that already exist in the target <see cref="T:Kvasir.Schema.Table"/>.
             </summary>
             <remarks>
               Kvasir itself does not do any mutation tracking outside of Relations, and even then its tracking is
@@ -6727,7 +6724,7 @@
         <member name="M:Kvasir.Transaction.ICommands.DeleteCommand(System.Collections.Generic.IEnumerable{System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue}})">
             <summary>
               Produce a command that, when executed against a back-end database and committed, deleted one or more rows
-              from <see cref="P:Kvasir.Transaction.ICommands.Table"/>.
+              from the target <see cref="T:Kvasir.Schema.Table"/>.
             </summary>
             <remarks>
               Deleting a row from a Principal Table may result in rows in various other tables (either other Entities'
@@ -6746,13 +6743,13 @@
             </summary>
             <remarks>
               The purpose of this interface is to provide a mechanism for the framework to create instances of the
-              <see cref="T:Kvasir.Transaction.ICommands"/> interface for constituent tables without knowing anything about the particular
+              <see cref="T:Kvasir.Transaction.ICommands"/> interface for constituent without knowing anything about the particular
               implementation details. An implementation of the <see cref="T:Kvasir.Transaction.ICommandsFactory"/> interface should generally
               correspond to a particular back-end database provider (e.g. MySQL) and produce instances that can operate
               against that RDBMS.
             </remarks>
         </member>
-        <member name="M:Kvasir.Transaction.ICommandsFactory.CreateCommand(Kvasir.Schema.ITable)">
+        <member name="M:Kvasir.Transaction.ICommandsFactory.CreateCommands(Kvasir.Schema.ITable)">
             <summary>
               Get the <see cref="T:Kvasir.Transaction.ICommands"/> that defines database interactions against a particular
               <see cref="T:Kvasir.Schema.ITable">Table</see>.

--- a/src/Kvasir/Transaction/ICommands.cs
+++ b/src/Kvasir/Transaction/ICommands.cs
@@ -1,38 +1,35 @@
 ﻿using Kvasir.Schema;
 using System.Collections.Generic;
-using System.Data.Common;
+using System.Data;
 
 namespace Kvasir.Transaction {
-    ///
+    /// <summary>
+    ///   The interface describing the selection and CRUD commands for a single <see cref="ITable">Table</see>.
+    /// </summary>
     public interface ICommands {
         /// <summary>
-        ///   The <see cref="ITable">Table</see> against which the commands execute.
+        ///   The command that creates the target <see cref="Table"/> in the back-end database.
         /// </summary>
-        ITable Table { get; set; }
+        IDbCommand CreateTableCommand { get; }
 
         /// <summary>
-        ///   The command that creates <see cref="Table"/> in the back-end database.
+        ///   The command that selects all data from the target <see cref="Table"/>. The rows should be returned in
+        ///   key-sorted order, which for Relation Tables guarantees that the rows are grouped by "owning Entity."
         /// </summary>
-        DbCommand CreateTableCommand { get; }
-
-        /// <summary>
-        ///   The command that selects all data from <see cref="Table"/>. The rows should be returned in key-sorted
-        ///   order, which for Relation Tables guarantees that the rows are grouped by "owning Entity."
-        /// </summary>
-        DbCommand SelectAllQuery { get; }
+        IDbCommand SelectAllQuery { get; }
 
         /// <summary>
         ///   Produce a command that, when executed against a back-end database and committed, inserts one or more rows
-        ///   of data into <see cref="Table"/>.
+        ///   of data into the target <see cref="Table"/>.
         /// </summary>
         /// <param name="rows">
         ///   The rows of data to be inserted.
         /// </param>
-        DbCommand InsertCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
+        IDbCommand InsertCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
 
         /// <summary>
         ///   Produce a command that, when executed against a back-end database and committed, updates the values of one
-        ///   or more rows that already exist in <see cref="Table"/>.
+        ///   or more rows that already exist in the target <see cref="Table"/>.
         /// </summary>
         /// <remarks>
         ///   Kvasir itself does not do any mutation tracking outside of Relations, and even then its tracking is
@@ -44,11 +41,11 @@ namespace Kvasir.Transaction {
         /// <param name="rows">
         ///   The full rows of data that should exist in the back-end database after the update.
         /// </param>
-        DbCommand UpdateCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
+        IDbCommand UpdateCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
 
         /// <summary>
         ///   Produce a command that, when executed against a back-end database and committed, deleted one or more rows
-        ///   from <see cref="Table"/>.
+        ///   from the target <see cref="Table"/>.
         /// </summary>
         /// <remarks>
         ///   Deleting a row from a Principal Table may result in rows in various other tables (either other Entities'
@@ -60,6 +57,6 @@ namespace Kvasir.Transaction {
         /// <param name="rows">
         ///   The rows of data that should be deleted. (Note that this is <b>not</b> just the rows' Primary Keys.)
         /// </param>
-        DbCommand DeleteCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
+        IDbCommand DeleteCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
     }
 }

--- a/src/Kvasir/Transaction/ICommandsFactory.cs
+++ b/src/Kvasir/Transaction/ICommandsFactory.cs
@@ -6,7 +6,7 @@ namespace Kvasir.Transaction {
     /// </summary>
     /// <remarks>
     ///   The purpose of this interface is to provide a mechanism for the framework to create instances of the
-    ///   <see cref="ICommands"/> interface for constituent tables without knowing anything about the particular
+    ///   <see cref="ICommands"/> interface for constituent without knowing anything about the particular
     ///   implementation details. An implementation of the <see cref="ICommandsFactory"/> interface should generally
     ///   correspond to a particular back-end database provider (e.g. MySQL) and produce instances that can operate
     ///   against that RDBMS.
@@ -19,6 +19,6 @@ namespace Kvasir.Transaction {
         /// <param name="table">
         ///   The <see cref="ITable">Table</see>.
         /// </param>
-        ICommands CreateCommand(ITable table);
+        ICommands CreateCommands(ITable table);
     }
 }


### PR DESCRIPTION
The main change here is that the ICommands interface now produces IDbCommands instead of DbCommands, providing some additional flexibility of not committing to a particular derived class. Also added some documentation that was missing from the original commit.