### PR TITLE
Add Error Check for Writeable Relation Properties

### DIFF
--- a/src/Cybele/Extensions/MemberInfo.cs
+++ b/src/Cybele/Extensions/MemberInfo.cs
@@ -6,7 +6,7 @@ namespace Cybele.Extensions {
     ///   A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
     ///   of the <see cref="MemberInfo"/> class.
     /// </summary>
-    public static partial class TypeExtensions {
+    public static class MemberInfoExtensions {
         /// <summary>
         ///   Determines if a member (e.g. a <see cref="Type"/> or a <see cref="PropertyInfo"/>) is annotated with a
         ///   particular <see cref="Attribute"/>.

--- a/src/Cybele/Extensions/PropertyInfo.cs
+++ b/src/Cybele/Extensions/PropertyInfo.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Cybele.Extensions {
+    /// <summary>
+    ///   A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
+    ///   of the <see cref="PropertyInfo"/> class.
+    /// </summary>
+    public static class PropertyInfoExtensions {
+        /// <summary>
+        ///   Determines if a property is init-only.
+        /// </summary>
+        /// <param name="propertyInfo">
+        ///   The <see cref="PropertyInfo"/> instance on which the extension method is invoked.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="propertyInfo"/> is init-only; otherwise (i.e. if it is
+        ///   read-only or freely writeable), <see langword="false"/>.
+        /// </returns>
+        public static bool IsInitOnly(this PropertyInfo propertyInfo) {
+            if (!propertyInfo.CanWrite) {
+                return false;
+            }
+
+            var setter = propertyInfo.SetMethod!;
+            var returnModifiers = setter.ReturnParameter.GetRequiredCustomModifiers();
+            return returnModifiers.Contains(typeof(IsExternalInit));
+        }
+    }
+}

--- a/src/Cybele/Extensions/Type.cs
+++ b/src/Cybele/Extensions/Type.cs
@@ -5,9 +5,9 @@ using System.Linq;
 namespace Cybele.Extensions {
     /// <summary>
     ///   A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
-    ///   of the <see cref="System.Reflection.MemberInfo"/> class.
+    ///   of the <see cref="Type"/> class.
     /// </summary>
-    public static partial class TypeExtensions {
+    public static class TypeExtensions {
         /// <summary>
         ///   Determines if an instance of one <see cref="Type"/> is also an instance of another <see cref="Type"/>
         ///   using a limited set of possible conversions.

--- a/src/Cybele/Intellisense.xml
+++ b/src/Cybele/Intellisense.xml
@@ -1225,17 +1225,13 @@
               <c>(index, element)</c> pairs of <paramref name="self"/>; otherwise, <see langword="false"/>.
             </returns>
         </member>
-        <member name="T:Cybele.Extensions.TypeExtensions">
-            <summary>
-              A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
-              of the <see cref="T:System.Reflection.MemberInfo"/> class.
-            </summary>
+        <member name="T:Cybele.Extensions.MemberInfoExtensions">
             <summary>
               A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
               of the <see cref="T:System.Reflection.MemberInfo"/> class.
             </summary>
         </member>
-        <member name="M:Cybele.Extensions.TypeExtensions.HasAttribute``1(System.Reflection.MemberInfo)">
+        <member name="M:Cybele.Extensions.MemberInfoExtensions.HasAttribute``1(System.Reflection.MemberInfo)">
             <summary>
               Determines if a member (e.g. a <see cref="T:System.Type"/> or a <see cref="T:System.Reflection.PropertyInfo"/>) is annotated with a
               particular <see cref="T:System.Attribute"/>.
@@ -1250,43 +1246,6 @@
               <see langword="true"/> if <paramref name="self"/> is member that is annotated with at least one instance
               of <typeparamref name="TAttribute"/>, possibly inherited; otherwise, <see langword="false"/>.
             </returns>
-        </member>
-        <member name="M:Cybele.Extensions.TypeExtensions.IsInstanceOf(System.Type,System.Type)">
-             <summary>
-               Determines if an instance of one <see cref="T:System.Type"/> is also an instance of another <see cref="T:System.Type"/>
-               using a limited set of possible conversions.
-             </summary>
-             <remarks>
-               A type <c>DERIVED</c> is said to be an instance of another type <c>ANCESTOR</c> if, and only if, at least
-               one of the following is true:
-            
-                   * <c>DERIVED</c> and <c>ANCESTOR</c> are the same, including open (or partially open) generics
-                   * <c>ANCESTOR</c> is a direct or indirect base of <c>DERIVED</c>; this covers the former being
-                         <see cref="T:System.Object"/> for all types, <see cref="T:System.ValueType"/> for structs and primitives,
-                         <see cref="T:System.Enum"/> for enumerations, and <see cref="T:System.Delegate"/> for delegates
-                   * <c>ANCESTOR</c> is an interface that is implemented by <c>DERIVED</c>
-                   * <c>ANCESTOR</c> is an instantiation of <see cref="T:System.Nullable`1"/> and <c>DERIVED</c> is the
-                         corresponding generic argument
-            
-               Note specifically that a handful of situations that one may otherwise expect to be recognized as
-               fulfilling the "is-instance-of" relation specifically do not:
-            
-                   * <c>DERIVED</c> is a narrower numeric type compared to <c>ANCESTOR</c>
-                   * There exists an implicit conversion between otherwise unrelated <c>DERIVED</c> and <c>ANCESTOR</c>
-                   * <c>DERIVED</c> is an instantiation of the open (or partially open) generic <c>ANCESTOR</c>
-                   * <c>DERIVED</c> is a co- or contravariant instantiation of <c>ANCESTOR</c>
-                   * <c>DERIVED</c> and <c>ANCESTOR</c> are interchangeable delegates
-             </remarks>
-             <param name="derivedType">
-               The hypothetical descendant <see cref="T:System.Type"/>.
-             </param>
-             <param name="ancestorType">
-               The hypothetical ancestor <see cref="T:System.Type"/>.
-             </param>
-             <returns>
-               <see langword="true"/> if any of the above-listed relationships holds between
-               <paramref name="derivedType"/> and <paramref name="ancestorType"/>; otherwise, <see langword="false"/>.
-             </returns>
         </member>
         <member name="T:Cybele.Extensions.MethodExtensions">
             <summary>
@@ -1377,6 +1336,67 @@
             <exception cref="T:System.InvalidOperationException">
               if <paramref name="self"/> is a <c>NONE</c> instance (i.e. an empty option).
             </exception>
+        </member>
+        <member name="T:Cybele.Extensions.PropertyInfoExtensions">
+            <summary>
+              A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
+              of the <see cref="T:System.Reflection.PropertyInfo"/> class.
+            </summary>
+        </member>
+        <member name="M:Cybele.Extensions.PropertyInfoExtensions.IsInitOnly(System.Reflection.PropertyInfo)">
+            <summary>
+              Determines if a property is init-only.
+            </summary>
+            <param name="propertyInfo">
+              The <see cref="T:System.Reflection.PropertyInfo"/> instance on which the extension method is invoked.
+            </param>
+            <returns>
+              <see langword="true"/> if <paramref name="propertyInfo"/> is init-only; otherwise (i.e. if it is
+              read-only or freely writeable), <see langword="false"/>.
+            </returns>
+        </member>
+        <member name="T:Cybele.Extensions.TypeExtensions">
+            <summary>
+              A collection of <see href="https://tinyurl.com/y8q6ojue">extension methods</see> that extend the public API
+              of the <see cref="T:System.Type"/> class.
+            </summary>
+        </member>
+        <member name="M:Cybele.Extensions.TypeExtensions.IsInstanceOf(System.Type,System.Type)">
+             <summary>
+               Determines if an instance of one <see cref="T:System.Type"/> is also an instance of another <see cref="T:System.Type"/>
+               using a limited set of possible conversions.
+             </summary>
+             <remarks>
+               A type <c>DERIVED</c> is said to be an instance of another type <c>ANCESTOR</c> if, and only if, at least
+               one of the following is true:
+            
+                   * <c>DERIVED</c> and <c>ANCESTOR</c> are the same, including open (or partially open) generics
+                   * <c>ANCESTOR</c> is a direct or indirect base of <c>DERIVED</c>; this covers the former being
+                         <see cref="T:System.Object"/> for all types, <see cref="T:System.ValueType"/> for structs and primitives,
+                         <see cref="T:System.Enum"/> for enumerations, and <see cref="T:System.Delegate"/> for delegates
+                   * <c>ANCESTOR</c> is an interface that is implemented by <c>DERIVED</c>
+                   * <c>ANCESTOR</c> is an instantiation of <see cref="T:System.Nullable`1"/> and <c>DERIVED</c> is the
+                         corresponding generic argument
+            
+               Note specifically that a handful of situations that one may otherwise expect to be recognized as
+               fulfilling the "is-instance-of" relation specifically do not:
+            
+                   * <c>DERIVED</c> is a narrower numeric type compared to <c>ANCESTOR</c>
+                   * There exists an implicit conversion between otherwise unrelated <c>DERIVED</c> and <c>ANCESTOR</c>
+                   * <c>DERIVED</c> is an instantiation of the open (or partially open) generic <c>ANCESTOR</c>
+                   * <c>DERIVED</c> is a co- or contravariant instantiation of <c>ANCESTOR</c>
+                   * <c>DERIVED</c> and <c>ANCESTOR</c> are interchangeable delegates
+             </remarks>
+             <param name="derivedType">
+               The hypothetical descendant <see cref="T:System.Type"/>.
+             </param>
+             <param name="ancestorType">
+               The hypothetical ancestor <see cref="T:System.Type"/>.
+             </param>
+             <returns>
+               <see langword="true"/> if any of the above-listed relationships holds between
+               <paramref name="derivedType"/> and <paramref name="ancestorType"/>; otherwise, <see langword="false"/>.
+             </returns>
         </member>
     </members>
 </doc>

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -8880,6 +8880,19 @@
               The reason that <paramref name="annotation"/> is unsatisfiable.
             </param>
         </member>
+        <member name="T:Kvasir.Translation.WriteableRelationException">
+            <summary>
+              An exception that is raised when a freely writeable Relation-type property is included in the data model.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.WriteableRelationException.#ctor(Kvasir.Translation.Context)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.WriteableRelationException"/>.
+            </summary>
+            <param name="context">
+              The <see cref="T:Kvasir.Translation.Context"/> in which the freely writeable Relation-type property was encountered.
+            </param>
+        </member>
         <member name="T:Kvasir.Translation.BooleanFieldDescriptor">
             <summary>
               The concrete base class for a <see cref="T:Kvasir.Translation.FieldDescriptor"/> whose data type is <see cref="T:System.Boolean"/>.

--- a/src/Kvasir/Translation/Exceptions/WriteableRelationException.cs
+++ b/src/Kvasir/Translation/Exceptions/WriteableRelationException.cs
@@ -1,0 +1,19 @@
+﻿namespace Kvasir.Translation {
+    /// <summary>
+    ///   An exception that is raised when a freely writeable Relation-type property is included in the data model.
+    /// </summary>
+    internal sealed class WriteableRelationException : TranslationException {
+        /// <summary>
+        ///   Constructs a new <see cref="WriteableRelationException"/>.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="Context"/> in which the freely writeable Relation-type property was encountered.
+        /// </param>
+        public WriteableRelationException(Context context)
+            : base(
+                new Location(context.ToString()),
+                new Problem("if a Relation-type property has a setter, is must be init-only")
+              )
+        {}
+    }
+}

--- a/src/Kvasir/Translation/TranslateType.cs
+++ b/src/Kvasir/Translation/TranslateType.cs
@@ -93,6 +93,9 @@ namespace Kvasir.Translation {
                         if (!allowRelations) {
                             throw new NestedRelationException(context);
                         }
+                        else if (property.CanWrite && !property.IsInitOnly()) {
+                            throw new WriteableRelationException(context);
+                        }
                         relationTrackers.Add(new RelationTracker(property));
                     }
                     else if (typeCategory.Equals(TypeCategory.Class)) {

--- a/test/UnitTests/Cybele/Extensions/PropertyInfo.cs
+++ b/test/UnitTests/Cybele/Extensions/PropertyInfo.cs
@@ -1,0 +1,52 @@
+﻿using Cybele.Extensions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UT.Cybele.Extensions {
+    [TestClass, TestCategory("PropertyInfo: IsInitOnly")]
+    public sealed class PropertyInfo_IsInitOnly : ExtensionTests {
+        [TestMethod] public void ReadOnlyPropertyIsNotInitOnly() {
+            // Arrange
+            var property = typeof(TestStruct).GetProperty(nameof(TestStruct.ReadOnly))!;
+
+            // Act
+            var isInitOnly = property.IsInitOnly();
+
+            // Assert
+            isInitOnly.Should().BeFalse();
+        }
+
+        [TestMethod] public void InitOnlyPropertyIsInitOnly() {
+            // Arrange
+            var property = typeof(TestStruct).GetProperty(nameof(TestStruct.InitOnly))!;
+
+            // Act
+            var isInitOnly = property.IsInitOnly();
+
+            // Assert
+            isInitOnly.Should().BeTrue();
+        }
+        
+        [TestMethod] public void WriteablePropertyIsNotInitOnly() {
+            // Arrange
+            var publicProperty = typeof(TestStruct).GetProperty(nameof(TestStruct.PublicWrite))!;
+            var nonPublicProperty = typeof(TestStruct).GetProperty(nameof(TestStruct.NonPublicWrite))!;
+
+            // Act
+            var publicIsInitOnly = publicProperty.IsInitOnly();
+            var nonPublicIsInitOnly = nonPublicProperty.IsInitOnly();
+
+            // Assert
+            publicIsInitOnly.Should().BeFalse();
+            nonPublicIsInitOnly.Should().BeFalse();
+        }
+    }
+    
+
+    struct TestStruct {
+        public bool ReadOnly { get; }
+        public bool InitOnly { get; init; }
+        public bool PublicWrite { get; set; }
+        public bool NonPublicWrite { get; private set; }
+    }
+}

--- a/test/UnitTests/Kvasir/Transaction/_Entities.cs
+++ b/test/UnitTests/Kvasir/Transaction/_Entities.cs
@@ -22,8 +22,8 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey] public Guid ProductID { get; set; }
             public string Brand { get; set; } = "";
             public Fruit Flavor { get; set; }
-            public RelationMap<string, double> NutritionInfo { get; } = new();
-            public RelationSet<Trait> Traits { get; } = new();
+            public RelationMap<string, double> NutritionInfo { get; init; } = new();
+            public RelationSet<Trait> Traits { get; init; } = new();
         }
 
         // Test Scenario: Multiple Unrelated Entities
@@ -122,8 +122,8 @@ namespace UT.Kvasir.Transaction {
 
             [PrimaryKey] public Guid RegisterID { get; set; }
             public string Location { get; set; } = "";
-            public RelationMap<Currency, ushort> CashOnHand { get; set; } = new RelationMap<Currency, ushort>();
-            public RelationSet<Item> Sellables { get; set; } = new RelationSet<Item>();
+            public RelationMap<Currency, ushort> CashOnHand { get; init; } = new RelationMap<Currency, ushort>();
+            public RelationSet<Item> Sellables { get; init; } = new RelationSet<Item>();
             public double Weight { get; set; }
             public bool IsDigital { get; set; }
             public string AdminCode { get; set; } = "";
@@ -136,8 +136,8 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey] public Guid MatrixID { get; set; }
             public ushort NumRows { get; set; }
             public ushort NumColumns { get; set; }
-            public IReadOnlyRelationList<double> Eigenvalues { get; set; } = new RelationList<double>();
-            public RelationSet<Matrix> Inverses { get; set; } = new RelationSet<Matrix>();
+            public IReadOnlyRelationList<double> Eigenvalues { get; init; } = new RelationList<double>();
+            public RelationSet<Matrix> Inverses { get; init; } = new RelationSet<Matrix>();
             public Traits MatrixTraits { get; set; }
         }
 
@@ -212,14 +212,14 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public string TableID { get; set; } = "";
             [PrimaryKey, Column(1)] public ushort Year { get; set; }
             [Column(2)] public bool EndorsedBySSA { get; set; }
-            public RelationMap<int, double> MaleDeathProbability { get; set; } = new RelationMap<int, double>();
-            public RelationMap<int, double> FemaleDeathProbability { get; set; } = new RelationMap<int, double>();
+            public RelationMap<int, double> MaleDeathProbability { get; init; } = new RelationMap<int, double>();
+            public RelationMap<int, double> FemaleDeathProbability { get; init; } = new RelationMap<int, double>();
         }
 
         // Test Scenario: Single Instance of Single Entity with Empty Scalar Relation
         public class Quasar {
             [PrimaryKey, Column(0)] public string Designation { get; set; } = "";
-            public IReadOnlyRelationSet<string> Discoverers { get; set; } = new RelationSet<string>();
+            public IReadOnlyRelationSet<string> Discoverers { get; init; } = new RelationSet<string>();
             [Column(1)] public string? Constellation { get; set; }
             [Column(2)] public double Redshift { get; set; }
             [Column(3)] public ulong Distance { get; set; }
@@ -228,7 +228,7 @@ namespace UT.Kvasir.Transaction {
         // Test Scenario: Multiple Instances of Single Entities with Scalar Relations
         public class Deodorant {
             [PrimaryKey, Column(0)] public Guid ProductID { get; set; }
-            public RelationOrderedList<string> Scents { get; set; } = new RelationOrderedList<string>();
+            public RelationOrderedList<string> Scents { get; init; } = new RelationOrderedList<string>();
             [Column(1)] public string Brand { get; set; } = "";
             [Column(2)] public decimal Price { get; set; }
             [Column(3)] public bool Antipersperant { get; set; }
@@ -333,7 +333,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public DateTime Date { get; set; }
             [PrimaryKey, Column(1)] public uint PlayNumber { get; set; }
             [Column(2)] public string Opponent { get; set; } = "";
-            public IReadOnlyRelationList<FootballPlayer> PlayersInvolved { get; set; } = new RelationList<FootballPlayer>();
+            public IReadOnlyRelationList<FootballPlayer> PlayersInvolved { get; init; } = new RelationList<FootballPlayer>();
             [Column(3)] public bool ResultedInTouchdown { get; set; }
         }
 
@@ -344,7 +344,7 @@ namespace UT.Kvasir.Transaction {
             [Column(2)] public DateTime ReignEnd { get; set; }
             [Column(3)] public string RoyalHouse { get; set; } = "";
             [Column(4)] public string Capital { get; set; } = "";
-            public IReadOnlyRelationSet<IranianShah> Predecessor { get; set; } = new RelationSet<IranianShah>();
+            public IReadOnlyRelationSet<IranianShah> Predecessor { get; init; } = new RelationSet<IranianShah>();
         }
     }
 
@@ -384,9 +384,9 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid ProductID { get; set; }
             [Column(1)] public string Location { get; set; } = "";
             [Column(2)] public Category TypeOfInstitute { get; set; }
-            public IReadOnlyRelationMap<string, bool> Sodas { get; set; } = new RelationMap<string, bool>();
+            public IReadOnlyRelationMap<string, bool> Sodas { get; init; } = new RelationMap<string, bool>();
             [Column(3)] public bool IsCokeFreestyle { get; set; }
-            public RelationOrderedList<DateTime> Inspections { get; set; } = new();
+            public RelationOrderedList<DateTime> Inspections { get; init; } = new();
         }
 
         // Test Scenario: Single Instance of Single Entity with Empty Scalar Relation
@@ -396,7 +396,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(2)] public ushort Year { get; set; }
             [Column(3)] public string Purpose { get; set; } = "";
             [Column(4)] public decimal? Compensation { get; set; }
-            public IReadOnlyRelationOrderedList<string> Words { get; set; } = new RelationOrderedList<string>();
+            public IReadOnlyRelationOrderedList<string> Words { get; init; } = new RelationOrderedList<string>();
         }
 
         // Test Scenario: Multiple Instances of Single Entities with Scalar Relations
@@ -404,7 +404,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid FundID { get; set; }
             [PrimaryKey, Column(1)] public Guid CompanyID { get; set; }
             [Column(2)] public decimal NAV { get; set; }
-            public RelationMap<string, decimal> Investors { get; set; } = new();
+            public RelationMap<string, decimal> Investors { get; init; } = new();
             [Column(3)] public string FundManager { get; set; } = "";
             [Column(4)] public double ManagementFee { get; set; }
         }
@@ -495,7 +495,7 @@ namespace UT.Kvasir.Transaction {
             }
 
             [PrimaryKey, Column(0)] public Guid CovenID { get; set; }
-            public IReadOnlyRelationList<Witch> Witches { get; set; } = new RelationList<Witch>();
+            public IReadOnlyRelationList<Witch> Witches { get; init; } = new RelationList<Witch>();
             [Column(1)] public bool Wicca { get; set; }
             [Column(2)] public bool OwnsCauldron { get; set; }
         }
@@ -505,8 +505,8 @@ namespace UT.Kvasir.Transaction {
             [Flags] public enum Source { PopolVuh = 1, ChilamBilam = 2, MadridCodex = 4, Lacandon = 8, DiegoDeLanda = 16 }
 
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
-            public IReadOnlyRelationSet<MayanGod> Mothers { get; set; } = new RelationSet<MayanGod>();
-            public IReadOnlyRelationSet<MayanGod> Fathers { get; set; } = new RelationSet<MayanGod>();
+            public IReadOnlyRelationSet<MayanGod> Mothers { get; init; } = new RelationSet<MayanGod>();
+            public IReadOnlyRelationSet<MayanGod> Fathers { get; init; } = new RelationSet<MayanGod>();
             [Column(1)] public Source Attestations { get; set; }
             [Column(2)] public string Domain { get; set; } = "";
         }
@@ -575,7 +575,7 @@ namespace UT.Kvasir.Transaction {
             [Column(2)] public string CompanySponsor { get; set; } = "";
             [Column(3)] public double PercentMatch { get; set; }
             [Column(4)] public decimal Balance { get; set; }
-            public RelationMap<DateTime, decimal> Deposits { get; set; } = new RelationMap<DateTime, decimal>();
+            public RelationMap<DateTime, decimal> Deposits { get; init; } = new RelationMap<DateTime, decimal>();
         }
 
         // Test Scenario: Single Instance of Single Entity with Scalar Relation of Deleted Elements
@@ -585,7 +585,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid GameID { get; set; }
             [PrimaryKey, Column(1)] public uint Instance { get; set; }
             [Column(2)] public Which League { get; set; }
-            public RelationMap<string, string> Participants { get; set; } = new RelationMap<string, string>();
+            public RelationMap<string, string> Participants { get; init; } = new RelationMap<string, string>();
             [Column(3)] public string Referee { get; set; } = "";
         }
 
@@ -594,8 +594,8 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid BankID { get; set; }
             [PrimaryKey, Column(1)] public string Branch { get; set; } = "";
             [PrimaryKey, Column(2)] public short VaultNumber { get; set; }
-            public RelationMap<Guid, decimal> Storage { get; set; } = new();
-            public RelationOrderedList<sbyte> Combination { get; set; } = new();
+            public RelationMap<Guid, decimal> Storage { get; init; } = new();
+            public RelationOrderedList<sbyte> Combination { get; init; } = new();
         }
 
         // Test Scenario: Single Instance of Single Entity with Scalar Relation of Mixed-Status Elements
@@ -605,7 +605,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public string RollType { get; set; } = "";
             [PrimaryKey, Column(1)] public string Restaurant { get; set; } = "";
             [Column(2)] public decimal Price { get; set; }
-            public RelationSet<string> Ingredients { get; set; } = new();
+            public RelationSet<string> Ingredients { get; init; } = new();
             [Column(3)] public Color RiceType { get; set; }
         }
 
@@ -614,9 +614,9 @@ namespace UT.Kvasir.Transaction {
             public enum Wood { Birch, Cedar, Ash, Cherry, Cypress, Fir, Pine, Elm, Mahogany, Walnut, Maple, Bamboo }
 
             [PrimaryKey, Column(0)] public Guid WoodshopID { get; set; }
-            public RelationSet<string> Tools { get; set; } = new();
+            public RelationSet<string> Tools { get; init; } = new();
             [Column(1)] public string Owner { get; set; } = "";
-            public RelationOrderedList<Wood> TypesOfWood { get; set; } = new();
+            public RelationOrderedList<Wood> TypesOfWood { get; init; } = new();
             [Column(2)] public uint TotalIncidents { get; set; }
             [Column(3)] public decimal InsuranceCoverage { get; set; }
         }
@@ -627,8 +627,8 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(1)] public ulong StoreNumber { get; set; }
             [Column(2)] public string Address { get; set; } = "";
             [Column(3)] public bool IsBodega { get; set; }
-            public IReadOnlyRelationMap<string, decimal> Products { get; set; } = new RelationMap<string, decimal>();
-            public RelationOrderedList<string> Employees { get; set; } = new();
+            public IReadOnlyRelationMap<string, decimal> Products { get; init; } = new RelationMap<string, decimal>();
+            public RelationOrderedList<string> Employees { get; init; } = new();
         }
 
         // Test Scenario: Multiple Unrelated Entities
@@ -714,7 +714,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid ID { get; set; }
             [Column(1)] public string Affiant { get; set; } = "";
             [Column(2)] public DateTime NotarizationDate { get; set; }
-            public IReadOnlyRelationOrderedList<Lawyer> LawyersInvolved { get; set; } = new RelationOrderedList<Lawyer>();
+            public IReadOnlyRelationOrderedList<Lawyer> LawyersInvolved { get; init; } = new RelationOrderedList<Lawyer>();
             [Column(3)] public bool PartOfPleaDeal { get; set; }
         }
 
@@ -725,7 +725,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid LicenseNumber { get; set; }
             [PrimaryKey, Column(1)] public Kind Style { get; set; }
             [Column(2)] public string Name { get; set; } = "";
-            public IReadOnlyRelationSet<Masseuse> Teachers { get; set; } = new RelationSet<Masseuse>();
+            public IReadOnlyRelationSet<Masseuse> Teachers { get; init; } = new RelationSet<Masseuse>();
             [Column(3)] public bool IsFreelance { get; set; }
             [Column(4)] public sbyte NumTables { get; set; }
         }
@@ -778,7 +778,7 @@ namespace UT.Kvasir.Transaction {
 
             [PrimaryKey, Column(0)] public DateTime Airdate { get; set; }
             [Column(1)] public Kind Variety { get; set; }
-            public RelationMap<string, Team> Teams { get; set; } = new();
+            public RelationMap<string, Team> Teams { get; init; } = new();
             [Column(2)] public ulong YouTubeViews { get; set; }
             [Column(3)] public double TelevisionRating { get; set; }
         }
@@ -788,7 +788,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid GuacamoleID { get; set; }
             [Column(1)] public string Preparer { get; set; } = "";
             [Column(2)] public ushort NumServings { get; set; }
-            public RelationSet<string> Ingredients { get; set; } = new();
+            public RelationSet<string> Ingredients { get; init; } = new();
             [Column(3)] public bool MadeInMolcajete { get; set; }
         }
 
@@ -807,7 +807,7 @@ namespace UT.Kvasir.Transaction {
             [Column(2)] public string? Artist { get; set; }
             [Column(3)] public string HorsebackFigure { get; set; } = "";
             [Column(4)] public sbyte NumHorses { get; set; }
-            public RelationMap<Dimension, Measurement> Dimensions { get; set; } = new();
+            public RelationMap<Dimension, Measurement> Dimensions { get; init; } = new();
         }
 
         // Test Scenario: Single Instance of Single Entity with Scalar Relation of Modified Elements
@@ -824,7 +824,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid ID { get; set; }
             [Column(1)] public string For { get; set; } = "";
             [Column(2)] public Standard Style { get; set; }
-            public RelationOrderedList<Reference> References { get; set; } = new();
+            public RelationOrderedList<Reference> References { get; init; } = new();
             [Column(3)] public byte NumPages { get; set; }
         }
 
@@ -833,7 +833,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public string PrimaryMPID { get; set; } = "";
             [Column(1)] public string FirmName { get; set; } = "";
             [Column(2)] public decimal NetCapital { get; set; }
-            public RelationOrderedList<string> Symbols { get; set; } = new();
+            public RelationOrderedList<string> Symbols { get; init; } = new();
             [Column(3)] public bool IsDesignated { get; set; }
         }
 
@@ -846,7 +846,7 @@ namespace UT.Kvasir.Transaction {
             [Column(2)] public Language ScrollLanguage { get; set; }
             [Column(3)] public string BiblicalSource { get; set; } = "";
             [Column(4)] public ushort DiscoveryYear { get; set; }
-            public RelationSet<string> VerifiedAuthors { get; set; } = new();
+            public RelationSet<string> VerifiedAuthors { get; init; } = new();
         }
 
         // Test Scenario: Multiple Instances of Single Entities with Scalar Relations
@@ -860,7 +860,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(1)] public string Church { get; set; } = "";
             [Column(2)] public bool IsArchdiocese { get; set; }
             [Column(3)] public ushort Parishes { get; set; }
-            public RelationMap<string, DateRange> Bishops { get; set; } = new();
+            public RelationMap<string, DateRange> Bishops { get; init; } = new();
         }
 
         // Test Scenario: Multiple Unrelated Entities
@@ -955,7 +955,7 @@ namespace UT.Kvasir.Transaction {
 
             [PrimaryKey, Column(0)] public int Incarnation { get; set; }
             [Column(1)] public string Gamemaker { get; set; } = "";
-            public RelationMap<PanemCitizen, PanemCitizen?> Killers { get; set; } = new();
+            public RelationMap<PanemCitizen, PanemCitizen?> Killers { get; init; } = new();
             [Column(2)] public bool IsQuarterQuell { get; set; }
             [Column(3)] public string President { get; set; } = "";
         }
@@ -965,7 +965,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
             [Column(1)] public string Father { get; set; } = "";
             [Column(2)] public ulong MahabharataMentions { get; set; }
-            public RelationList<Pandava> Brothers { get; set; } = new();
+            public RelationList<Pandava> Brothers { get; init; } = new();
             [Column(3)] public string PrimaryWeapon { get; set; } = "";
         }
 

--- a/test/UnitTests/Kvasir/Translation/Extraction.cs
+++ b/test/UnitTests/Kvasir/Translation/Extraction.cs
@@ -958,19 +958,13 @@ namespace UT.Kvasir.Translation {
                 BirthName = null,
                 BirthComm = null,
                 Rings = 10,
-                Appearances = new RelationMap<Orogene.Book, bool>() {
-                    { Orogene.Book.FifthSeason, true },
-                    { Orogene.Book.ObeliskGate, true },
-                    { Orogene.Book.StoneSky, false }
-                },
+                Appearances = null,
                 AtNodeStation = false
             };
 
             // Act
             var translator = new Translator(NO_ENTITIES);
             var translation = translator[typeof(Orogene)];
-            var _ = translation.Relations[0].Extractor.ExtractFrom(orogene);
-            orogene.Appearances = null;
             var data = translation.Relations[0].Extractor.ExtractFrom(orogene);
 
             // Assert

--- a/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
+++ b/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
@@ -934,6 +934,21 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void PropertyTypeIsWriteableRelation_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(BugZapper);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<WriteableRelationException>()
+                .WithLocation("`BugZapper` → SusceptibleSpecies")
+                .WithProblem("if a Relation-type property has a setter, is must be init-only")
+                .EndMessage();
+        }
+
         [TestMethod] public void AggregateConsistingOnlyOfRelations() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -391,10 +391,10 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public string Project { get; set; } = "";
             [PrimaryKey] public string TargetName { get; set; } = "";
-            public RelationList<string> Files { get; set; } = new();
-            public RelationSet<Macro> Macros { get; set; } = new();
-            public RelationMap<Mode, int> OptimizationLevel { get; set; } = new();
-            public RelationOrderedList<string> LinkAgainst { get; set; } = new();
+            public RelationList<string> Files { get; init; } = new();
+            public RelationSet<Macro> Macros { get; init; } = new();
+            public RelationMap<Mode, int> OptimizationLevel { get; init; } = new();
+            public RelationOrderedList<string> LinkAgainst { get; init; } = new();
         }
 
         // Test Scenario: Nullable Relations of Non-Nullable Elements (✓recognized✓)
@@ -404,10 +404,10 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public string City { get; set; } = "";
             public ulong PersonsImpacted { get; set; }
-            public RelationList<SingleDay>? Dailies { get; set; }
-            public RelationSet<string>? Meteorologists { get; set; }
-            public RelationMap<string, bool>? DataSources { get; set; }
-            public RelationOrderedList<Extremity>? ExtremeWeather { get; set; }
+            public RelationList<SingleDay>? Dailies { get; init; }
+            public RelationSet<string>? Meteorologists { get; init; }
+            public RelationMap<string, bool>? DataSources { get; init; }
+            public RelationOrderedList<Extremity>? ExtremeWeather { get; init; }
         }
 
         // Test Scenario: Read-Only Relations (✓recognized✓)
@@ -434,17 +434,17 @@ namespace UT.Kvasir.Translation {
             public ushort ProductionCost { get; set; }
             public string? PrereqTechnology { get; set; }
             public string? PrereqCivic { get; set; }
-            public IReadOnlyRelationList<Terrain> AllowedTerrain { get; set; } = new RelationList<Terrain>();
-            public IReadOnlyRelationSet<CivVIBuilding> Buildings { get; set; } = new RelationSet<CivVIBuilding>();
-            public IReadOnlyRelationMap<int, Yield> Yields { get; set; } = new RelationMap<int, Yield>();
-            public IReadOnlyRelationOrderedList<string> Icons { get; set; } = new RelationOrderedList<string>();
+            public IReadOnlyRelationList<Terrain> AllowedTerrain { get; init; } = new RelationList<Terrain>();
+            public IReadOnlyRelationSet<CivVIBuilding> Buildings { get; init; } = new RelationSet<CivVIBuilding>();
+            public IReadOnlyRelationMap<int, Yield> Yields { get; init; } = new RelationMap<int, Yield>();
+            public IReadOnlyRelationOrderedList<string> Icons { get; init; } = new RelationOrderedList<string>();
         }
 
         // Test Scenario: Relations Nested Within Aggregates (✓recognized✓)
         public class Gelateria {
             public struct Owning {
                 public DateTime Since { get; set; }
-                public IReadOnlyRelationSet<string> People { get; set; }
+                public IReadOnlyRelationSet<string> People { get; init; }
                 public decimal LifetimeRevenue { get; set; }
             }
 
@@ -460,8 +460,8 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Identifier { get; set; } = "";
             public string? Constellation { get; set; }
             public string? Galaxy { get; set; }
-            public RelationSet<string> AKAs { get; set; } = new();
-            public RelationMap<string, RelationMap<string, double>> Measurements { get; set; } = new();
+            public RelationSet<string> AKAs { get; init; } = new();
+            public RelationMap<string, RelationMap<string, double>> Measurements { get; init; } = new();
         }
 
         // Test Scenario: Relation Nested Within Aggregate Nested Within Relation (✗not permitted✗)
@@ -471,7 +471,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid PollID { get; set; }
             public string PollTitle { get; set; } = "";
             public string? Pollster { get; set; }
-            public RelationList<Question> Questions { get; set; } = new();
+            public RelationList<Question> Questions { get; init; } = new();
             public ulong Responses { get; set; }
             public double ReponseRate { get; set; }
         }
@@ -483,7 +483,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid ID { get; set; }
             public string Subject { get; set; } = "";
             public string Artist { get; set; } = "";
-            public RelationSet<KeyValuePair<DateTime, decimal>> SaleHistory { get; set; } = new();
+            public RelationSet<KeyValuePair<DateTime, decimal>> SaleHistory { get; init; } = new();
             public double HeadSize { get; set; }
             public bool Certified { get; set; }
             public Location Source { get; set; }
@@ -496,12 +496,24 @@ namespace UT.Kvasir.Translation {
             public decimal RetailValue { get; set; }
             public DateTime Launched { get; set; }
             public bool ForWomen { get; set; }
-            public IRelation PatentNumbers { get; set; } = new RelationSet<ulong>();
+            public IRelation PatentNumbers { get; init; } = new RelationSet<ulong>();
+        }
+
+        // Test Scenario: Writeable Relation (✗not permitted✗)
+        public class BugZapper {
+            [PrimaryKey] public Guid ProductID { get; set; }
+            public decimal RetailPrice { get; set; }
+            public RelationSet<string> SusceptibleSpecies { get; set; } = new();
+            public bool IsScented { get; set; }
+            public float MaxVoltage { get; set; }
         }
 
         // Test Scenario: Aggregate Consisting of Only Relations (✓recognized✓)
         public class Loch {
-            public record struct Geography(RelationMap<char, float> Coordinates, IReadOnlyRelationSet<string> Shires);
+            public record struct Geography {
+                public RelationMap<char, float> Coordinates { get; }
+                public IReadOnlyRelationSet<string> Shires { get; }
+            }
 
             [PrimaryKey] public string Name { get; set; } = "";
             public double Area { get; set; }
@@ -687,7 +699,7 @@ namespace UT.Kvasir.Translation {
             public string Earth { get; set; } = "";
             public string Location { get; set; } = "";
             public DateTime FirstAppearance { get; set; }
-            [CodeOnly] public IReadOnlyRelationSet<string> Resurrections { get; set; } = new RelationSet<string>();
+            [CodeOnly] public IReadOnlyRelationSet<string> Resurrections { get; } = new RelationSet<string>();
             public bool DiscoveredByRasAlGhul { get; set; }
         }
 
@@ -1099,11 +1111,11 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid ID { get; set; }
             public string Address { get; set; } = "";
             public ulong MailVolume { get; set; }
-            public RelationMap<short, string?> POBoxes { get; set; } = new();
-            public RelationSet<string?> Employees { get; set; } = new();
-            public RelationList<LicensePlate?> MailTrucks { get; set; } = new();
-            public RelationMap<DateTime?, Stamp?> Stamps { get; set; } = new();
-            public RelationOrderedList<decimal?> Budgets { get; set; } = new();
+            public RelationMap<short, string?> POBoxes { get; } = new();
+            public RelationSet<string?> Employees { get; } = new();
+            public RelationList<LicensePlate?> MailTrucks { get; } = new();
+            public RelationMap<DateTime?, Stamp?> Stamps { get; } = new();
+            public RelationOrderedList<decimal?> Budgets { get; } = new();
         }
 
         // Test Scenario: Relation with Nullable Aggregate Element Type with Only Nullable Fields (✗ambiguous✗)
@@ -1115,7 +1127,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Point Vertex { get; set; }
             [PrimaryKey] public float Eccentricity { get; set; }
             public Direction Concavity { get; set; }
-            public RelationSet<MaybePoint?> Points { get; set; } = new();
+            public RelationSet<MaybePoint?> Points { get; } = new();
         }
 
         // Test Scenario: Relation Property Marked as [NonNullable] (✓redundant✓)
@@ -1125,7 +1137,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string FirstName { get; set; } = "";
             [PrimaryKey] public string LastName { get; set; } = "";
             public bool IsFemale { get; set; }
-            [NonNullable] public RelationList<Episode> Appearances { get; set; } = new();
+            [NonNullable] public RelationList<Episode> Appearances { get; } = new();
             public bool HasTemperancesApproval { get; set; }
         }
 
@@ -1135,7 +1147,7 @@ namespace UT.Kvasir.Translation {
             public string Formulation { get; set; } = "";
             public string? PostulatedBy { get; set; }
             public bool IsLogical { get; set; }
-            [Nullable] public RelationSet<string> DerivedTheories { get; set; } = new();
+            [Nullable] public RelationSet<string> DerivedTheories { get; } = new();
         }
     }
 
@@ -1164,8 +1176,8 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid SwapID { get; set; }
             public string PartyA { get; set; } = "";
             public string PartyB { get; set; } = "";
-            public RelationSet<ushort> AtoB { get; set; } = new();
-            public RelationSet<ushort> BtoA { get; set; } = new();
+            public RelationSet<ushort> AtoB { get; } = new();
+            public RelationSet<ushort> BtoA { get; } = new();
             public DateTime Executed { get; set; }
             public bool Covert { get; set; }
         }
@@ -1273,7 +1285,7 @@ namespace UT.Kvasir.Translation {
         // Test Scenario: New Relation Table Name (✓renamed✓)
         public class MagicalPreserve {
             [PrimaryKey] public string Name { get; set; } = "";
-            [RelationTable("CreaturesTable")] public RelationMap<string, int> Population { get; set; } = new();
+            [RelationTable("CreaturesTable")] public RelationMap<string, int> Population { get; } = new();
             public string SecretArtifact { get; set; } = "";
             public DateTime? Founding { get; set; }
             public string PrimaryCaretaker { get; set; } = "";
@@ -1290,7 +1302,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public string School { get; set; } = "";
             [PrimaryKey] public ushort Year { get; set; }
-            [RelationTable("UT.Kvasir.Translation.TableNaming+PacerTest.LapsCompletedTable")] public RelationMap<Student, byte> LapsCompleted { get; set; } = new();
+            [RelationTable("UT.Kvasir.Translation.TableNaming+PacerTest.LapsCompletedTable")] public RelationMap<Student, byte> LapsCompleted { get; } = new();
             public DateTime AdministeredOn { get; set; }
         }
 
@@ -1299,7 +1311,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid DwarfID { get; set; }
             public bool IsFictional { get; set; }
             public string Name { get; set; } = "";
-            [RelationTable(null!)] public RelationMap<DateTime, string> LifeEvents { get; set; } = new();
+            [RelationTable(null!)] public RelationMap<DateTime, string> LifeEvents { get; } = new();
             public byte Height { get; set; }
             public bool WieldsSword { get; set; }
             public double ShoeSize { get; set; }
@@ -1311,7 +1323,7 @@ namespace UT.Kvasir.Translation {
             public enum IUCN { Extinct, CaptivityOnly, CriticallyEndangered, Endangered, Vulnerable, NearThreatened, LeastConcern }
 
             [PrimaryKey] public string CommonName { get; set; } = "";
-            [RelationTable("")] public RelationMap<Taxon, string> Taxonomy { get; set; } = new();
+            [RelationTable("")] public RelationMap<Taxon, string> Taxonomy { get; } = new();
             public double AverageAdultMaleWeight { get; set; }
             public double AverageAdultFemaleWeight { get; set; }
             public float TailLength { get; set; }
@@ -1331,8 +1343,8 @@ namespace UT.Kvasir.Translation {
             public bool Closed { get; set; }
             public bool Long { get; set; }
             public Feature Features { get; set; }
-            [RelationTable("AuxiliaryVowelTable")] public RelationSet<string> Languages { get; set; } = new();
-            [RelationTable("AuxiliaryVowelTable")] public RelationMap<char, char> Diacritics { get; set; } = new();
+            [RelationTable("AuxiliaryVowelTable")] public RelationSet<string> Languages { get; } = new();
+            [RelationTable("AuxiliaryVowelTable")] public RelationMap<char, char> Diacritics { get; } = new();
         }
 
         // Test Scenario: Table Name Duplicated between Principal Table and Relation Table (✗duplication✗)
@@ -1343,7 +1355,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string IP { get; set; } = "";
             public Kind Type { get; set; }
             public bool PasswordProtected { get; set; }
-            [RelationTable("OfficialInfoVPN")] public RelationList<Guid> AuthorizedUsers { get; set; } = new();
+            [RelationTable("OfficialInfoVPN")] public RelationList<Guid> AuthorizedUsers { get; } = new();
         }
 
         // Test Scenario: [RelationTable] Applied to Numeric Field (✗impermissible✗)
@@ -1352,7 +1364,7 @@ namespace UT.Kvasir.Translation {
             public string Maker { get; set; } = "";
             public double Weight { get; set; }
             public ushort NumTurns { get; set; }
-            [RelationTable("---")] public float Tekiah { get; set; }
+            [RelationTable("---")] public float Tekiah { get; set;}
             public float Teruah { get; set; }
             public float Shevarim { get; set; }
             public float TekiahGedolah { get; set; }
@@ -1588,20 +1600,20 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid KidneyStoneID { get; set; }
             public float Size { get; set; }
             public string Patient { get; set; } = "";
-            [Name("MaterialsTable")] public RelationSet<string> Composition { get; set; } = new();
+            [Name("MaterialsTable")] public RelationSet<string> Composition { get; } = new();
             public bool HasPassed { get; set; }
         }
 
         // Test Scenario: Change Relation-Nested Field Name to New Value (✓renamed✓)
         public class SwissCanton {
             [PrimaryKey] public Guid ID { get; set; }
-            [Name("Canton", Path = "SwissCanton")] public RelationMap<string, string> Names { get; set; } = new();
+            [Name("Canton", Path = "SwissCanton")] public RelationMap<string, string> Names { get; } = new();
             public ulong Area { get; set; }
             public ulong Population { get; set; }
             public string CantonCapital { get; set; } = "";
             public ushort YearJoinedSwissConfederation { get; set; }
-            [Name("CantonID", Path = "SwissCanton.ID"), Name("Councilor", Path = "Item")] public RelationSet<string> Councilors { get; set; } = new();
-            [Name("Religion", Path = "Key"), Name("%PCNT", Path = "Value")] public RelationMap<string, double> Religions { get; set; } = new();
+            [Name("CantonID", Path = "SwissCanton.ID"), Name("Councilor", Path = "Item")] public RelationSet<string> Councilors { get; } = new();
+            [Name("Religion", Path = "Key"), Name("%PCNT", Path = "Value")] public RelationMap<string, double> Religions { get; } = new();
         }
 
         // Test Scenario: Change Nested Relation Name (✓affects name of Table✓)
@@ -1610,7 +1622,7 @@ namespace UT.Kvasir.Translation {
             public record struct Naming(string English, string Russian);
             public struct Personnel {
                 public string Commandant { get; set; }
-                public RelationList<string> Overseers { get; set; }
+                public RelationList<string> Overseers { get; }
                 public Org Administeredby { get; set; }
             }
 
@@ -1669,8 +1681,8 @@ namespace UT.Kvasir.Translation {
                 public string DishName { get; set; } = "";
                 public ushort PrepTime { get; set; }
                 public ushort CookTime { get; set; }
-                public RelationMap<string, Measure> Ingredients { get; set; } = new();
-                public RelationOrderedList<string> Steps { get; set; } = new();
+                public RelationMap<string, Measure> Ingredients { get; } = new();
+                public RelationOrderedList<string> Steps { get; } = new();
             }
 
             [PrimaryKey] public string ISBN { get; set; } = "";
@@ -1678,7 +1690,7 @@ namespace UT.Kvasir.Translation {
             public string Author { get; set; } = "";
             public DateTime PublicationDate { get; set; }
             public string AmazonURL { get; set; } = "";
-            [Name("Cookbook.ISBN", Path = "Item.RecipeID")] public RelationList<Recipe> Recipes { get; set; } = new();
+            [Name("Cookbook.ISBN", Path = "Item.RecipeID")] public RelationList<Recipe> Recipes { get; } = new();
         }
 
         // Test Scenario: Change Two Field Names to Same Value in Relation Table (✗duplication✗)
@@ -1693,7 +1705,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid IncidentID { get; set; }
             public string Location { get; set; } = "";
             public Person HostageTaker { get; set; } = new();
-            [Name("Value", Path = "HostageSituation.IncidentID"), Name("Value", Path = "Item.SSN")] public RelationList<Person> Hostages { get; set; } = new();
+            [Name("Value", Path = "HostageSituation.IncidentID"), Name("Value", Path = "Item.SSN")] public RelationList<Person> Hostages { get; } = new();
             public ushort Casualties { get; set; }
         }
 
@@ -1827,14 +1839,14 @@ namespace UT.Kvasir.Translation {
             public class Spell {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public string Incantation { get; set; } = "";
-                public RelationSet<string> Components { get; set; } = new();
+                public RelationSet<string> Components { get; } = new();
                 public bool TimeSensitive { get; set; }
             }
 
             [PrimaryKey] public Guid MagicUserID { get; set; }
             public string? Name { get; set; }
             public AlignedAs Alignment { get; set; }
-            [Name("Spellbook"), Name("Spellbook")] public RelationSet<Spell> Spells { get; set; } = new();
+            [Name("Spellbook"), Name("Spellbook")] public RelationSet<Spell> Spells { get; } = new();
             public ulong Resurrections { get; set; }
             public byte Level { get; set; }
         }
@@ -1847,7 +1859,7 @@ namespace UT.Kvasir.Translation {
             public string Identifier { get; set; } = "";
             public string EthnicGroup { get; set; } = "";
             public ulong DeathCount { get; set; }
-            [Name("TimelineOfEvents"), Name("Calendar")] public RelationMap<DateTime, Event> Timeline { get; set; } = new();
+            [Name("TimelineOfEvents"), Name("Calendar")] public RelationMap<DateTime, Event> Timeline { get; } = new();
             public ushort ICCIndictments { get; set; }
         }
 
@@ -1857,7 +1869,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public Guid ID { get; set; }
             public DateTime Date { get; set; }
-            [Name("Participants"), Name("Paraders")] public IReadOnlyRelationSet<string> Participants { get; set; } = new RelationSet<string>();
+            [Name("Participants"), Name("Paraders")] public IReadOnlyRelationSet<string> Participants { get; } = new RelationSet<string>();
             public bool Protested { get; set; }
             public uint RainbowFlags { get; set; }
             public Group Representation { get; set; }
@@ -1893,7 +1905,7 @@ namespace UT.Kvasir.Translation {
             public string Name { get; set; } = "";
             public string Country { get; set; } = "";
             public ulong Age { get; set; }
-            [Name("TotalArea", Path = "Item.TotalSpace")] public RelationSet<PointOfInterest> Ruins { get; set; } = new();
+            [Name("TotalArea", Path = "Item.TotalSpace")] public RelationSet<PointOfInterest> Ruins { get; } = new();
         }
 
         // Test Scenario: [Name] Change on Nested Aggregate that Already Has [Name] Change (✓renamed✓)
@@ -1936,8 +1948,8 @@ namespace UT.Kvasir.Translation {
         // Test Scenario: [Name] Change on Nested Relation that Already Has [Name] Change (✓affects name of Table✓)
         public class PolarVortex {
             public struct Temps {
-                [Name("HighTemps")] public RelationMap<DateTime, double> Highs { get; set; }
-                [Name("LowTemps")] public RelationMap<DateTime, double> Lows { get; set; }
+                [Name("HighTemps")] public RelationMap<DateTime, double> Highs { get; }
+                [Name("LowTemps")] public RelationMap<DateTime, double> Lows { get; }
             }
 
             [PrimaryKey] public Guid VortexID { get; set; }
@@ -2077,7 +2089,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Identifier { get; set; } = "";
             public Operation AllowedOperations { get; set; }
             public short Size { get; set; }
-            [Name("eax?", Path = "---")] public RelationSet<string> Architectures { get; set; } = new();
+            [Name("eax?", Path = "---")] public RelationSet<string> Architectures { get; } = new();
             public bool StackPointer { get; set; }
         }
 
@@ -2091,7 +2103,7 @@ namespace UT.Kvasir.Translation {
             public Denom Denomination { get; set; }
             public string ChiefRabbi { get; set; } = "";
             public DateTime Founded { get; set; }
-            [Name("HomeCity", Path = "Yeshiva.City")] public RelationList<Student> Students { get; set; } = new();
+            [Name("HomeCity", Path = "Yeshiva.City")] public RelationList<Student> Students { get; } = new();
         }
     }
 
@@ -2277,15 +2289,15 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Image { get; set; } = "";
             [PrimaryKey, Default(0)] public int PID { get; set; }
             public string EntryPoint { get; set; } = "";
-            public RelationMap<Directory, string> Mounts { get; set; } = new();
+            public RelationMap<Directory, string> Mounts { get; } = new();
         }
 
         // Test Scenario: Default on Relation-Nested Field (✓valid✓)
         public class Kami {
             [PrimaryKey] public string Name { get; set; } = "";
             public string CultCenter { get; set; } = "";
-            [Default("n/a", Path = "Item")] public RelationSet<string> AKAs { get; set; } = new();
-            [Default("Susano'o", Path = "Kami.Name"), Default((short)19, Path = "Value")] public RelationMap<string, short> Appearances { get; set; } = new();
+            [Default("n/a", Path = "Item")] public RelationSet<string> AKAs { get; } = new();
+            [Default("Susano'o", Path = "Kami.Name"), Default((short)19, Path = "Value")] public RelationMap<string, short> Appearances { get; } = new();
             public string? PrimaryTorii { get; set; }
             public bool Female { get; set; }
         }
@@ -2304,7 +2316,7 @@ namespace UT.Kvasir.Translation {
             public ushort HatchTime { get; set; }
             public byte Age { get; set; }
             public uint Weight { get; set; }
-            [Default(3.75, Path = "Item.Cost")] public RelationList<Accessory> Accessories { get; set; } = new();
+            [Default(3.75, Path = "Item.Cost")] public RelationList<Accessory> Accessories { get; } = new();
         }
 
         // Test Scenario: `null` Default for Non-Nullable Field (✗invalid✗)
@@ -2396,13 +2408,16 @@ namespace UT.Kvasir.Translation {
 
         // Test Scenario: Applied to Nested Relation (✗invalid✗)
         public class TimeTraveler {
-            public record struct Machine(Guid SerialNumber, RelationList<string> Owners);
+            public struct Machine {
+                public Guid SerialNumber { get; set; }
+                public RelationList<string> Owners { get; }
+            }
 
             [PrimaryKey] public string FirstName { get; set; } = "";
             [PrimaryKey] public string LastName { get; set; } = "";
             public DateTime BirthDate { get; set; }
             [Default("Marty McFly", Path = "Owners")] public Machine TimeMachine { get; set; }
-            public RelationSet<DateTime> Visitations { get; set; } = new();
+            public RelationSet<DateTime> Visitations { get; } = new();
             public uint ParadoxesCaused { get; set; }
         }
 
@@ -2625,7 +2640,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid SerialNumber { get; set; }
             public string Title { get; set; } = "";
             public string Name { get; set; } = "";
-            [Default(0.00, Path = "---")] public RelationMap<string, double> HighScores { get; set; } = new();
+            [Default(0.00, Path = "---")] public RelationMap<string, double> HighScores { get; } = new();
             public ushort NumLevels { get; set; }
             public bool IsSports { get; set; }
         }
@@ -2635,7 +2650,7 @@ namespace UT.Kvasir.Translation {
             public enum Operation { Map, Join, Unit, Bind, Constructor }
 
             [PrimaryKey] public string Name { get; set; } = "";
-            [Default((sbyte)77, Path = "Monad.ModelsOption")] public RelationMap<Operation, string> Traits { get; set; } = new();
+            [Default((sbyte)77, Path = "Monad.ModelsOption")] public RelationMap<Operation, string> Traits { get; } = new();
             public bool ModelsOption { get; set; }
         }
 
@@ -2644,7 +2659,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid DetergentID { get; set; }
             public string Brand { get; set; } = "";
             public double VolumePerLoad { get; set; }
-            [Default(null)] public RelationSet<string> Ingredients { get; set; } = new();
+            [Default(null)] public RelationSet<string> Ingredients { get; } = new();
             public bool ToxiToConsume { get; set; }
         }
     }
@@ -2713,9 +2728,9 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Issuer { get; set; } = "";
             public short SecurityCode { get; set; }
             public decimal DebitLimit { get; set; }
-            public RelationMap<string, Permission> Account { get; set; } = new();
+            public RelationMap<string, Permission> Account { get; } = new();
             public DateTime Expiration { get; set; }
-            public RelationList<Transaction> Transactions { get; set; } = new();
+            public RelationList<Transaction> Transactions { get; } = new();
         }
 
         // Test Scenario: Relation Fields are Manually Ordered (✗impermissible✗)
@@ -2723,7 +2738,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid TapestryID { get; set; }
             public double Length { get; set; }
             public double Width { get; set; }
-            [Column(6)] public RelationList<string> Depictions { get; set; } = new();
+            [Column(6)] public RelationList<string> Depictions { get; } = new();
             public string? Artist { get; set; }
             public ulong ThreadCount { get; set; }
         }
@@ -2750,7 +2765,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(3)] public Guid DeviceID { get; set; }
             [PrimaryKey, Column(0)] public DateTime Timestamp { get; set; }
             public Result Outcome { get; set; }
-            public RelationList<string> Notifications { get; set; } = new();
+            public RelationList<string> Notifications { get; } = new();
             public short PassCode { get; set; }
             public bool Mobile { get; set; }
         }
@@ -2951,7 +2966,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public short Year { get; set; }
             [PrimaryKey] public string Country { get; set; } = "";
-            [PrimaryKey(Path = "GrandPrix.Year"), PrimaryKey(Path = "GrandPrix.Country"), PrimaryKey(Path = "Key.CarNumber")] public RelationMap<Driver, short> Results { get; set; } = new();
+            [PrimaryKey(Path = "GrandPrix.Year"), PrimaryKey(Path = "GrandPrix.Country"), PrimaryKey(Path = "Key.CarNumber")] public RelationMap<Driver, short> Results { get; } = new();
             public byte NumLaps { get; set; }
             public ulong TrackLength { get; set; }
             public uint NumCrashes { get; set; }
@@ -2960,7 +2975,10 @@ namespace UT.Kvasir.Translation {
 
         // Test Scenario: Nested Relation Property Marked as [PrimaryKey] (✗illegal✗)
         public class Psalm {
-            public record struct TextInfo(string Title, RelationMap<ushort, string> Verses);
+            public record struct TextInfo {
+                public string Title { get; set; }
+                public RelationMap<ushort, string> Verses { get; }
+            }
 
             [PrimaryKey] public int Number { get; set; }
             [PrimaryKey(Path = "Verses")] public TextInfo Text { get; set; } = new();
@@ -3116,10 +3134,10 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Address { get; set; } = "";
             public string Country { get; set; } = "";
             public string? Proprietor { get; set; }
-            public RelationList<string> Employees { get; set; } = new();
+            public RelationList<string> Employees { get; } = new();
             public decimal YearlyRevenue { get; set; }
             public bool IsLegal { get; set; }
-            public RelationSet<Service> Services { get; set; } = new();
+            public RelationSet<Service> Services { get; } = new();
         }
 
         // Test Scenario: Default Deduction for Map Relation (✓identified✓)
@@ -3130,7 +3148,7 @@ namespace UT.Kvasir.Translation {
             public string Leader { get; set; } = "";
             public DateTime Founded { get; set; }
             public DateTime? Shuttered { get; set; }
-            public RelationMap<string, Info> Members { get; set; } = new();
+            public RelationMap<string, Info> Members { get; } = new();
             public bool FederallyMonitored { get; set; }
             public ulong AttributableDeaths { get; set; }
         }
@@ -3149,7 +3167,7 @@ namespace UT.Kvasir.Translation {
             public double Duration { get; set; }
             public TimeSignature Signature { get; set; }
             public sbyte Movements { get; set; }
-            public RelationOrderedList<Note> Score { get; set; } = new();
+            public RelationOrderedList<Note> Score { get; } = new();
         }
 
         // Test Scenario: Single Candidate Key on Relation Including Anchor (✓identified✓)
@@ -3159,7 +3177,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid ExtensionID { get; set; }
             public string ExtensionName { get; set; } = "";
             public ulong Downloads { get; set; }
-            [Unique("Key", Path = "ChromeExtension.ExtensionID"), Unique("Key", Path = "Item.Reviewer")] public RelationList<Rating> Reviews { get; set; } = new();
+            [Unique("Key", Path = "ChromeExtension.ExtensionID"), Unique("Key", Path = "Item.Reviewer")] public RelationList<Rating> Reviews { get; } = new();
             public string CurrentVersion { get; set; } = "";
             public ulong Size { get; set; }
             public bool ByGoogle { get; set; }
@@ -3173,7 +3191,7 @@ namespace UT.Kvasir.Translation {
             public ulong MaxHeight { get; set; }
             public ulong MinHeight { get; set; }
             public float TopSpeed { get; set; }
-            [Unique(Path = "Item")] public RelationSet<string> Precautions { get; set; } = new();
+            [Unique(Path = "Item")] public RelationSet<string> Precautions { get; } = new();
             public bool Aquatic { get; set; }
             public bool Forested { get; set; }
         }
@@ -3307,7 +3325,7 @@ namespace UT.Kvasir.Translation {
             public float Longitude { get; set; }
             public DateTime CarbonDating { get; set; }
             public string GeologicEra { get; set; } = "";
-            public RelationSet<Fossil> Fossils { get; set; } = new();
+            public RelationSet<Fossil> Fossils { get; } = new();
         }
 
         // Test Scenario: Primary Key on Relation Table with Candidate Keys Cannot Be Deduced (✗illegal✗)
@@ -3316,7 +3334,7 @@ namespace UT.Kvasir.Translation {
             public string Manager { get; set; } = "";
             public DateTime Opened { get; set; }
             public DateTime? Closed { get; set; }
-            [Unique("V", Path = "Blockbuster.ID"), Unique("V", Path = "Value")] public RelationMap<string, string> Rentals { get; set; } = new();
+            [Unique("V", Path = "Blockbuster.ID"), Unique("V", Path = "Value")] public RelationMap<string, string> Rentals { get; } = new();
             public ushort TotalVideos { get; set; }
             public decimal LifetimeRevenue { get; set; }
             public bool IsFranchise { get; set; }
@@ -3422,7 +3440,7 @@ namespace UT.Kvasir.Translation {
             public Terrain LaunchedFrom { get; set; }
             public Terrain Targeting { get; set; }
             public ulong MaxRange { get; set; }
-            [PrimaryKey(Path = "---")] public RelationSet<string> Manufacturers { get; set; } = new();
+            [PrimaryKey(Path = "---")] public RelationSet<string> Manufacturers { get; } = new();
         }
 
         // Test Scenario: <Path> on Relation Refers to Non-Primary-Key Field of Anchor Entity (✗non-existent path✗)
@@ -3433,7 +3451,7 @@ namespace UT.Kvasir.Translation {
             public string? Author { get; set; }
             public decimal TreasureValue { get; set; }
             public Coordinate X { get; set; }
-            [PrimaryKey(Path = "TreasureMap.X")] public RelationList<Coordinate> SuggestedPath { get; set; } = new();
+            [PrimaryKey(Path = "TreasureMap.X")] public RelationList<Coordinate> SuggestedPath { get; } = new();
             public bool Damaged { get; set; }
         }
 
@@ -3442,7 +3460,7 @@ namespace UT.Kvasir.Translation {
             public Guid ID { get; set; }
             public double Height { get; set; }
             public double AspectRatio { get; set; }
-            [PrimaryKey] public RelationMap<short, string> Copyrights { get; set; } = new();
+            [PrimaryKey] public RelationMap<short, string> Copyrights { get; } = new();
             public bool ThreeDimensional { get; set; }
         }
     }
@@ -3752,14 +3770,17 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public ushort Episode { get; set; }
             public string ChiefOfStaff { get; set; } = "";
-            [PrimaryKey(Path = "Key.Time"), Unique("X", Path = "BigBlockOfCheeseDay"), Unique("X", Path = "Key.Organization")] public RelationMap<Slot, string> Schedule { get; set; } = new();
+            [PrimaryKey(Path = "Key.Time"), Unique("X", Path = "BigBlockOfCheeseDay"), Unique("X", Path = "Key.Organization")] public RelationMap<Slot, string> Schedule { get; } = new();
             public double PercentCrackpots { get; set; }
         }
 
         // Test Scenario: Nested Relation Field in Candidate Key (✗illegal✗)
         public class RentalCar {
             public record struct Duration(DateTime Start, DateTime End);
-            public record struct History(RelationMap<string, Duration> Renters, DateTime Acquired);
+            public record struct History {
+                public RelationMap<string, Duration> Renters { get; }
+                public DateTime Acquired { get; set; }
+            }
 
             [PrimaryKey] public string LicensePlate { get; set; } = "";
             public decimal CostPerDay { get; set; }
@@ -3782,7 +3803,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Name { get; set; } = "";
             public DateTime WarStart { get; set; }
             public DateTime WarEnd { get; set; }
-            [PrimaryKey(Path = "Intifada.Name"), PrimaryKey(Path = "Item.CountryName")] public RelationSet<Country> Belligerents { get; set; } = new();
+            [PrimaryKey(Path = "Intifada.Name"), PrimaryKey(Path = "Item.CountryName")] public RelationSet<Country> Belligerents { get; } = new();
             public ulong Casualties { get; set; }
         }
 
@@ -3794,7 +3815,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid VoodooID { get; set; }
             public string Target { get; set; } = "";
             public string? PatronLoa { get; set; }
-            [PrimaryKey(Path = "VoodooDoll.VoodooID"), PrimaryKey(Path = "Value"), Unique("Unique", Path = "VoodooDoll.VoodooID"), Unique("Unique", Path = "Key")] public RelationMap<Color, string> Pins { get; set; } = new();
+            [PrimaryKey(Path = "VoodooDoll.VoodooID"), PrimaryKey(Path = "Value"), Unique("Unique", Path = "VoodooDoll.VoodooID"), Unique("Unique", Path = "Key")] public RelationMap<Color, string> Pins { get; } = new();
             public bool Effective { get; set; }
             public Thing Material { get; set; }
         }
@@ -3809,7 +3830,7 @@ namespace UT.Kvasir.Translation {
             public ulong LungsProcessed { get; set; }
             public ulong LiversProcessed { get; set; }
             public ulong KidneysProcessed { get; set; }
-            [PrimaryKey(Path = "OPO.ID"), PrimaryKey(Path = "Item"), Unique("Unique", Path = "OPO.ID"), Unique("Unique", Path = "Index")] public RelationOrderedList<string> Administrators { get; set; } = new();
+            [PrimaryKey(Path = "OPO.ID"), PrimaryKey(Path = "Item"), Unique("Unique", Path = "OPO.ID"), Unique("Unique", Path = "Index")] public RelationOrderedList<string> Administrators { get; } = new();
         }
 
         // Test Scenario: Scalar Fields in Same Candidate Key as Nested Fields (✓recognized✓)
@@ -3973,7 +3994,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Name { get; set; } = "";
             public string Formula { get; set; } = "";
             public double Bioavalability { get; set; }
-            [Unique(Path = "---")] public RelationMap<string, string> MedicalIdentifiers { get; set; } = new();
+            [Unique(Path = "---")] public RelationMap<string, string> MedicalIdentifiers { get; } = new();
             public Symptom SymptomsRelieved { get; set; }
         }
 
@@ -3982,7 +4003,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public float Latitude { get; set; }
             [PrimaryKey] public float Longitude { get; set; }
             public ulong Water { get; set; }
-            [Unique(Path = "Oasis.Water")] public RelationSet<string> TreeSpecies { get; set; } = new();
+            [Unique(Path = "Oasis.Water")] public RelationSet<string> TreeSpecies { get; } = new();
             public double AverageTemperature { get; set; }
         }
 
@@ -3991,7 +4012,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid ID { get; set; }
             public string Song { get; set; } = "";
             public ushort BarLength { get; set; }
-            [Unique] public IReadOnlyRelationMap<string, float> Heights { get; set; } = new RelationMap<string, float>();
+            [Unique] public IReadOnlyRelationMap<string, float> Heights { get; } = new RelationMap<string, float>();
             public decimal PrizeMoney { get; set; }
             public bool SoberRequired { get; set; }
         }
@@ -4138,7 +4159,7 @@ namespace UT.Kvasir.Translation {
         public class Bank {
             [PrimaryKey] public uint FDICNumber { get; set; }
             public string Name { get; set; } = "";
-            [DataConverter<ToInt<RelationMap<ulong, decimal>>>] public RelationMap<ulong, decimal> Accounts { get; set; } = new();
+            [DataConverter<ToInt<RelationMap<ulong, decimal>>>] public RelationMap<ulong, decimal> Accounts { get; } = new();
             public string VaultModel { get; set; } = "";
             public sbyte NumTellers { get; set; }
             public decimal CashOnHand { get; set; }
@@ -4316,7 +4337,7 @@ namespace UT.Kvasir.Translation {
             public ulong Length { get; set; }
             public ulong Elevation { get; set; }
             public Coordinate? Mouth { get; set; }
-            [Numeric] public RelationSet<string> MineralDeposits { get; set; } = new();
+            [Numeric] public RelationSet<string> MineralDeposits { get; } = new();
             public sbyte NumOases { get; set; }
         }
 
@@ -4402,7 +4423,7 @@ namespace UT.Kvasir.Translation {
             public DateTime Published { get; set; }
             public string Author { get; set; } = "";
             public string EncryptedText { get; set; } = "";
-            [AsString] public RelationMap<char, char> Solution { get; set; } = new();
+            [AsString] public RelationMap<char, char> Solution { get; } = new();
         }
 
         // Test Scenario: Property Marked with [DataConverter] and [Numeric] (✗conflicting✗)
@@ -4642,14 +4663,14 @@ namespace UT.Kvasir.Translation {
                 public enum Type { General, Generative, Recommendatory, Classification, Search, Other }
                 public struct Support {
                     public double LatestVersions { get; set; }
-                    public RelationSet<double> SupportedVersions { get; set; }
+                    public RelationSet<double> SupportedVersions { get; }
                 }
 
                 [PrimaryKey] public string Name { get; set; } = "";
                 public Type Category { get; set; }
                 public DateTime Debut { get; set; }
                 [Check.IsPositive(Path = "SupportedVersions.Item")] public Support Versions { get; set; }
-                public RelationSet<string> Creators { get; set; } = new();
+                public RelationSet<string> Creators { get; } = new();
                 public bool CanPassTuringTest { get; set; }
             }
 
@@ -4667,7 +4688,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid MargaritaID { get; set; }
                 public string Tequila { get; set; } = "";
                 public Rimming Rim { get; set; }
-                [Check.IsPositive(Path = "Item.ID")] public RelationSet<Ingredient> Ingredients { get; set; } = new();
+                [Check.IsPositive(Path = "Item.ID")] public RelationSet<Ingredient> Ingredients { get; } = new();
                 public double AlcoholVolume { get; set; }
                 public decimal Price { get; set; }
             }
@@ -4675,7 +4696,10 @@ namespace UT.Kvasir.Translation {
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class PulitzerPrize {
                 public enum Categorization { Fiction, Music, Drama, Biography, Poetry, History, Reporting, Photography, Illustration }
-                public record struct Committee(RelationList<string> Members, string Chairperson);
+                public record struct Committee {
+                    public RelationList<string> Members { get; }
+                    public string Chairperson { get; set; }
+                }
 
                 [PrimaryKey] public ushort Year { get; set; }
                 [PrimaryKey] public Categorization Category { get; set; }
@@ -4811,7 +4835,7 @@ namespace UT.Kvasir.Translation {
                 public float Height { get; set; }
                 public float Width { get; set; }
                 public float Length { get; set; }
-                [Check.IsPositive(Path = "---")] public RelationMap<string, short> Builders { get; set; } = new();
+                [Check.IsPositive(Path = "---")] public RelationMap<string, short> Builders { get; } = new();
                 public bool IsPermanent { get; set; }
                 public int AmountSkakh { get; set; }
                 public DateTime Constructed { get; set; }
@@ -4831,7 +4855,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string FirstName { get; set; } = "";
                 [PrimaryKey] public string LastName { get; set; } = "";
                 public DateTime Birthdate { get; set; }
-                [Check.IsPositive(Path = "Item.WordCount")] public RelationList<Script> Scripts { get; set; } = new();
+                [Check.IsPositive(Path = "Item.WordCount")] public RelationList<Script> Scripts { get; } = new();
                 public decimal Salary { get; set; }
                 public bool WGAMember { get; set; }
             }
@@ -4839,7 +4863,7 @@ namespace UT.Kvasir.Translation {
             // Test Scenario: <Path> on Relation Not Specified (✗missing path✗)
             public class Typewriter {
                 [PrimaryKey] public Guid TypewriterID { get; set; }
-                [Check.IsPositive] public RelationSet<char> MissingKeys { get; set; } = new();
+                [Check.IsPositive] public RelationSet<char> MissingKeys { get;  } = new();
                 public bool OwnedByTomHanks { get; set; }
                 public DateTime Created { get; set; }
                 public uint ClickSoundNumber { get; set; }
@@ -5080,7 +5104,7 @@ namespace UT.Kvasir.Translation {
                 public string Title { get; set; } = "";
                 public string Author { get; set; } = "";
                 public DateTime Copyright { get; set; }
-                [Check.IsNegative(Path = "Item.PageEnd")] public RelationList<Section> Sections { get; set; } = new();
+                [Check.IsNegative(Path = "Item.PageEnd")] public RelationList<Section> Sections { get; } = new();
                 public ushort NumImages { get; set; }
             }
 
@@ -5092,14 +5116,18 @@ namespace UT.Kvasir.Translation {
                 public float Latitude { get; set; }
                 public float Longitude { get; set; }
                 public bool Detonated { get; set; }
-                [Check.IsNegative(Path = "Item")] public IReadOnlyRelationSet<string> Casualties { get; set; } = new RelationSet<string>();
+                [Check.IsNegative(Path = "Item")] public IReadOnlyRelationSet<string> Casualties { get; } = new RelationSet<string>();
                 public Kind Type { get; set; }
             }
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class YahtzeeGame {
                 public enum Category { Ones, Twos, Threes, Fours, Five, Sixes, ThreeOAK, FourOAK, FullHouse, SmallSTR, LargeSTR, Yahtzee, Chance };
-                public record struct Player(Guid PlayerID, string Name, RelationMap<Category, byte> Score);
+                public record struct Player {
+                    public Guid PlayerID { get; set; }
+                    public string Name { get; set; }
+                    public RelationMap<Category, byte> Score { get; }
+                }
 
                 [PrimaryKey] public Guid ID { get; set; }
                 public string DiceColor { get; set; } = "";
@@ -5244,7 +5272,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public string? DeityHonored { get; set; }
                 public bool Drunken { get; set; }
-                [Check.IsNegative(Path = "---")] public RelationSet<DateTime> PossibleDates { get; set; } = new();
+                [Check.IsNegative(Path = "---")] public RelationSet<DateTime> PossibleDates { get; } = new();
                 public string? GreekEquivalent { get; set; }
             }
 
@@ -5255,7 +5283,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid AlertID { get; set; }
                 public string ChildsName { get; set; } = "";
                 public DateTime Issued { get; set; }
-                [Check.IsNegative(Path = "AmberAlert.EmergencyContactNumber")] public RelationMap<Category, string> VehicleDescription { get; set; } = new();
+                [Check.IsNegative(Path = "AmberAlert.EmergencyContactNumber")] public RelationMap<Category, string> VehicleDescription { get; } = new();
                 public ushort EmergencyContactNumber { get; set; }
             }
 
@@ -5274,7 +5302,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime? Disbanded { get; set; }
                 public DateTime? Renunited { get; set; }
                 public ulong RecordsSold { get; set; }
-                [Check.IsNegative] public RelationList<Singer> Members { get; set; } = new();
+                [Check.IsNegative] public RelationList<Singer> Members { get; } = new();
                 public ushort NumAlbums { get; set; }
                 public ulong InstagramFollowers { get; set; }
             }
@@ -5499,7 +5527,7 @@ namespace UT.Kvasir.Translation {
                 public string Tradition { get; set; } = "";
                 public double Duration { get; set; }
                 public ushort? MaxParticipants { get; set; }
-                [Check.IsNonZero(Path = "Key")] public RelationMap<uint, string> Steps { get; set; } = new();
+                [Check.IsNonZero(Path = "Key")] public RelationMap<uint, string> Steps { get; } = new();
             }
 
             // Test Scenario: Applied to Relation-Nested Non-Numeric Scalar (✗impermissible✗)
@@ -5517,13 +5545,16 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public DateTime Established { get; set; }
                 public char CertificationSymbol { get; set; }
-                [Check.IsNonZero(Path = "Item.ID")] public RelationSet<Company> CertifiedCompanies { get; set; } = new();
+                [Check.IsNonZero(Path = "Item.ID")] public RelationSet<Company> CertifiedCompanies { get; } = new();
                 public Judaism Branch { get; set; }
             }
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class CarpoolKaraoke {
-                public record struct Cantante(string Singer, RelationList<string> Songs);
+                public record struct Cantante {
+                    public string Singer { get; set; }
+                    public RelationList<string> Songs { get; }
+                }
 
                 [PrimaryKey] public uint EpisodeNumber { get; set; }
                 [Check.IsNonZero(Path = "Songs")] public Cantante Guest { get; set; }
@@ -5681,7 +5712,7 @@ namespace UT.Kvasir.Translation {
                 public string IssuedBy { get; set; } = "";
                 public string School { get; set; } = "";
                 public DateTime LastIssued { get; set; }
-                [Check.IsNonZero(Path = "---")] public RelationList<string> PermittedLocations { get; set; } = new();
+                [Check.IsNonZero(Path = "---")] public RelationList<string> PermittedLocations { get; } = new();
                 public bool IsExpired { get; set; }
             }
 
@@ -5693,14 +5724,14 @@ namespace UT.Kvasir.Translation {
                 public string Name { get; set; } = "";
                 public Kind Cuisine { get; set; }
                 public float IdealPanDepth { get; set; }
-                [Check.IsNonZero(Path = "Casserole.IdealPanDepth")] public RelationMap<string, bool> Ingredients { get; set; } = new();
+                [Check.IsNonZero(Path = "Casserole.IdealPanDepth")] public RelationMap<string, bool> Ingredients { get; } = new();
                 public bool IsGratin { get; set; }
             }
 
             // Test Scenario: <Path> on Relation Not Specified (✗missing path✗)
             public class GarbageTruck {
                 [PrimaryKey] public string LicensePlate { get; set; } = "";
-                [Check.IsNonZero] public RelationSet<string> RouteStops { get; set; } = new();
+                [Check.IsNonZero] public RelationSet<string> RouteStops { get; } = new();
                 public ulong TonnesProcessed { get; set; }
                 public string ManagementCompany { get; set; } = "";
                 public string Driver { get; set; } = "";
@@ -5920,7 +5951,7 @@ namespace UT.Kvasir.Translation {
                 public string LegalName { get; set; } = "";
                 public string Sector { get; set; } = "";
                 public string VoiceActor { get; set; } = "";
-                [Check.IsGreaterThan('@', Path = "Key"), Check.IsGreaterThan(0L, Path = "KidNextDoor.Number")] public RelationMap<char, string> DebutMission { get; set; } = new();
+                [Check.IsGreaterThan('@', Path = "Key"), Check.IsGreaterThan(0L, Path = "KidNextDoor.Number")] public RelationMap<char, string> DebutMission { get; } = new();
                 public string? ArchNemesis { get; set; } = "";
             }
 
@@ -5938,7 +5969,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public LNDN London { get; set; }
                 public Element StrongestElement { get; set; }
-                [Check.IsGreaterThan("9dc286f1-3ce5-4bd6-9afa-5bb6049e0ffe", Path = "Item.SpellID")] public RelationList<Spell> KnownSpells { get; set; } = new();
+                [Check.IsGreaterThan("9dc286f1-3ce5-4bd6-9afa-5bb6049e0ffe", Path = "Item.SpellID")] public RelationList<Spell> KnownSpells { get; } = new();
                 public DateTime Birthdate { get; set; }
                 public bool Deceased { get; set; }
                 public byte? BestEssenTaschPlacement { get; set; }
@@ -5947,7 +5978,11 @@ namespace UT.Kvasir.Translation {
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class Clown {
                 public enum Kind { Party, Jester, Demon, Circus, Rodeo, Other }
-                public record struct Outfit(decimal Nose, RelationList<string> Accoutrement, double Shoes);
+                public record struct Outfit {
+                    public decimal Nose { get; set; }
+                    public RelationList<string> Accoutrement { get; }
+                    public double Shoes { get; set; }
+                }
 
                 [PrimaryKey] public Guid ClownID { get; set; }
                 public string Name { get; set; } = "";
@@ -6224,7 +6259,7 @@ namespace UT.Kvasir.Translation {
                 public string Owner { get; set; } = "";
                 public string? URL { get; set; }
                 public ushort MaxSeating { get; set; }
-                [Check.IsGreaterThan(18752.53f, Path = "---")] public RelationList<MenuItem> MenuItems { get; set; } = new();
+                [Check.IsGreaterThan(18752.53f, Path = "---")] public RelationList<MenuItem> MenuItems { get; } = new();
                 public bool OffersCatering { get; set; }
                 public bool JewishStyle { get; set; }
             }
@@ -6236,8 +6271,8 @@ namespace UT.Kvasir.Translation {
                 public record struct Card(FaceValue Value, CardSuit Suit);
 
                 [PrimaryKey] public Guid HandID { get; set; }
-                public RelationSet<Card> PlayerCards { get; set; } = new();
-                [Check.IsGreaterThan(17512UL, Path = "BlackjackHand.TotalPot")] public RelationSet<Card> DealerCards { get; set; } = new();
+                public RelationSet<Card> PlayerCards { get; } = new();
+                [Check.IsGreaterThan(17512UL, Path = "BlackjackHand.TotalPot")] public RelationSet<Card> DealerCards { get; } = new();
                 public ulong TotalPot { get; set; }
                 public bool DoubleDown { get; set; }
             }
@@ -6248,7 +6283,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public DateTime End { get; set; }
                 public string OfficialTitle { get; set; } = "";
                 public string GrandInquisitor { get; set; } = "";
-                [Check.IsGreaterThan("Religious Persecution")] public RelationSet<string> Victims { get; set; } = new();
+                [Check.IsGreaterThan("Religious Persecution")] public RelationSet<string> Victims { get; } = new();
                 public bool IncludedWitchTrials { get; set; }
             }
 
@@ -6476,7 +6511,7 @@ namespace UT.Kvasir.Translation {
                 public ulong WishesGranted { get; set; }
                 public Color HairColor { get; set; }
                 public Color EyeColor { get; set; }
-                [Check.IsLessThan("Warmonger", Path = "FairyGodparent.Name"), Check.IsLessThan((ushort)1851, Path = "Key"), Check.IsLessThan((ushort)42144, Path = "Value")] public RelationMap<ushort, ushort> LinesByEpisode { get; set; } = new();
+                [Check.IsLessThan("Warmonger", Path = "FairyGodparent.Name"), Check.IsLessThan((ushort)1851, Path = "Key"), Check.IsLessThan((ushort)42144, Path = "Value")] public RelationMap<ushort, ushort> LinesByEpisode { get; } = new();
                 public uint TimesDaRulesBroken { get; set; }
             }
 
@@ -6488,7 +6523,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ID { get; set; }
                 public DateTime Instituted { get; set; }
                 public DateTime? Lifted { get; set; }
-                [Check.IsLessThan(AquaKind.Swamp, Path = "Item.Kind")] public RelationSet<Waterway> WaterwaysAffected { get; set; } = new();
+                [Check.IsLessThan(AquaKind.Swamp, Path = "Item.Kind")] public RelationSet<Waterway> WaterwaysAffected { get; } = new();
                 public decimal EconomicImpact { get; set; }
                 public bool ActOfWar { get; set; }
                 public ushort NumShips { get; set; }
@@ -6496,13 +6531,16 @@ namespace UT.Kvasir.Translation {
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class Blacksmith {
-                public record struct Inventory(RelationSet<string> Metals, RelationSet<string> Hammers);
+                public struct Inventory {
+                    public RelationSet<string> Metals { get; }
+                    public RelationSet<string> Hammers { get; }
+                }
 
                 [PrimaryKey] public Guid InternationalBlacksmithNumber { get; set; }
                 public string Address { get; set; } = "";
                 public DateTime Birthdate { get; set; }
                 [Check.IsLessThan(1000, Path = "Hammers")] public Inventory Materials { get; set; }
-                public RelationMap<string, decimal> Prices { get; set; } = new();
+                public RelationMap<string, decimal> Prices { get; } = new();
                 public double SlagPerDay { get; set; }
                 public ushort BenchPress { get; set; }
             }
@@ -6746,7 +6784,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid MimeID { get; set; }
                 public string FullName { get; set; } = "";
                 public DateTime Birthdate { get; set; }
-                [Check.IsLessThan(0L, Path = "---")] public RelationList<Performance> Performances { get; set; } = new();
+                [Check.IsLessThan(0L, Path = "---")] public RelationList<Performance> Performances { get; } = new();
                 public ulong LifetimeWordsSpoken { get; set; }
                 public string GoToMiming { get; set; } = "";
             }
@@ -6758,14 +6796,14 @@ namespace UT.Kvasir.Translation {
                 public DateTime Birthdate { get; set; }
                 public DateTime? DeathDate { get; set; }
                 public DateTime Elevation { get; set; }
-                [Check.IsLessThan("2657-03-19", Path = "CatholicCardinal.DeathDate")] public RelationSet<DateTime> Conclaves { get; set; } = new();
+                [Check.IsLessThan("2657-03-19", Path = "CatholicCardinal.DeathDate")] public RelationSet<DateTime> Conclaves { get; } = new();
                 public bool PreviouslyArchbishop { get; set; }
             }
 
             // Test Scenario: <Path> on Relation Not Specified (✗missing path✗)
             public class Hemalurgy {
                 [PrimaryKey] public string Metal { get; set; } = "";
-                [Check.IsLessThan("Allomantic Powers")] public RelationSet<string> Steals { get; set; } = new();
+                [Check.IsLessThan("Allomantic Powers")] public RelationSet<string> Steals { get; } = new();
                 public bool IsDepictedInBooks { get; set; }
             }
 
@@ -6991,7 +7029,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ID { get; set; }
                 public string ShowTitle { get; set; } = "";
                 public double ShowLength { get; set; }
-                [Check.IsGreaterOrEqualTo("Elmo", Path = "Item.Name"), Check.IsGreaterOrEqualTo(22.5, Path = "Item.Value")] public RelationSet<Puppet> Puppets { get; set; } = new();
+                [Check.IsGreaterOrEqualTo("Elmo", Path = "Item.Name"), Check.IsGreaterOrEqualTo(22.5, Path = "Item.Value")] public RelationSet<Puppet> Puppets { get; } = new();
                 public decimal TicketPrice { get; set; }
                 public ushort Attendees { get; set; }
             }
@@ -7004,7 +7042,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Victim { get; set; } = "";
                 public bool AvadaKedavra { get; set; }
                 public string Object { get; set; } = "";
-                [Check.IsGreaterOrEqualTo(false, Path = "Value.Discovered")] public RelationMap<string, Pair> HidingPlaces { get; set; } = new();
+                [Check.IsGreaterOrEqualTo(false, Path = "Value.Discovered")] public RelationMap<string, Pair> HidingPlaces { get; } = new();
             }
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
@@ -7012,7 +7050,7 @@ namespace UT.Kvasir.Translation {
                 public record struct Coordinate(float X, float Y);
                 public struct Quadrant {
                     public byte Number { get; set; }
-                    public RelationList<Coordinate> Decoys { get; set; }
+                    public RelationList<Coordinate> Decoys { get; }
                 }
 
                 [PrimaryKey] public Guid PuzzleID { get; set; }
@@ -7272,7 +7310,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public DateTime FirstDeath { get; set; }
                 public double Quickening { get; set; }
-                [Check.IsGreaterOrEqualTo("MacLeod", Path = "---")] public RelationSet<Guid> Swords { get; set; } = new();
+                [Check.IsGreaterOrEqualTo("MacLeod", Path = "---")] public RelationSet<Guid> Swords { get; } = new();
                 public double Height { get; set; }
             }
 
@@ -7283,7 +7321,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ID { get; set; }
                 public Judaism Denomination { get; set; }
                 public ulong SquareFootage { get; set; }
-                [Check.IsGreaterOrEqualTo("%999u$", Path = "Synagogue.Denomination")] public RelationSet<string> Congregants { get; set; } = new();
+                [Check.IsGreaterOrEqualTo("%999u$", Path = "Synagogue.Denomination")] public RelationSet<string> Congregants { get; } = new();
                 public DateTime NeirTamidInstalled { get; set; }
                 public uint BneiMitzvot { get; set; }
                 public string SeniorRabbi { get; set; } = "";
@@ -7295,7 +7333,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public DateTime Delivered { get; set; }
                 public string Topic { get; set; } = "";
                 public bool Religious { get; set; }
-                [Check.IsGreaterOrEqualTo(68174)] public RelationMap<int, string> Lines { get; set; } = new();
+                [Check.IsGreaterOrEqualTo(68174)] public RelationMap<int, string> Lines { get; } = new();
                 public bool Recorded { get; set; }
             }
 
@@ -7503,7 +7541,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Language { get; set; } = "";
                 public DateTime? Created { get; set; }
                 public ulong WorldwideUsers { get; set; }
-                [Check.IsLessOrEqualTo('|', Path = "Value")] public RelationMap<char, char> IPA { get; set; } = new();
+                [Check.IsLessOrEqualTo('|', Path = "Value")] public RelationMap<char, char> IPA { get; } = new();
                 public bool IsAlphasyllabary { get; set; }
             }
 
@@ -7515,8 +7553,8 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public byte EpisodeNumber { get; set; }
                 public DateTime AirDate { get; set; }
                 public bool IsParody { get; set; }
-                public RelationMap<string, Role> Cast { get; set; } = new();
-                [Check.IsLessOrEqualTo("Robert", Path = "Value")] public RelationMap<string, Role> Crew { get; set; } = new();
+                public RelationMap<string, Role> Cast { get; } = new();
+                [Check.IsLessOrEqualTo("Robert", Path = "Value")] public RelationMap<string, Role> Crew { get; } = new();
                 public string Segment1Title { get; set; } = "";
                 public string Segment2Title { get; set; } = "";
                 public string Segment3Title { get; set; } = "";
@@ -7525,7 +7563,11 @@ namespace UT.Kvasir.Translation {
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class CocoaFarm {
-                public record struct PersonnelGroup(string Owner, RelationSet<string> Workers, RelationList<string> Regulators);
+                public struct PersonnelGroup {
+                    public string Owner { get; set; }
+                    public RelationSet<string> Workers { get; }
+                    public RelationList<string> Regulators { get; }
+                }
 
                 [PrimaryKey] public Guid ID { get; set; }
                 public uint Area { get; set; }
@@ -7772,7 +7814,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ThumbWarID { get; set; }
                 public uint Player1 { get; set; }
                 public uint Player2 { get; set; }
-                [Check.IsLessOrEqualTo(105, Path = "---")] public RelationList<Play> PlayByPlay { get; set; } = new();
+                [Check.IsLessOrEqualTo(105, Path = "---")] public RelationList<Play> PlayByPlay { get; } = new();
                 public Result Outcome { get; set; }
             }
 
@@ -7783,7 +7825,7 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public Guid ID { get; set; }
                 public Stone Centerpiece { get; set; }
-                [Check.IsLessOrEqualTo(285712905UL, Path = "EngagementRing.Centerpiece")] public RelationMap<string, Measurement> Measurements { get; set; } = new();
+                [Check.IsLessOrEqualTo(285712905UL, Path = "EngagementRing.Centerpiece")] public RelationMap<string, Measurement> Measurements { get; } = new();
                 public decimal Price { get; set; }
                 public bool FamilyHeirloom { get; set; }
                 public string Wearer { get; set; } = "";
@@ -7795,7 +7837,7 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public Guid JokeID { get; set; }
                 public Joker ImpracticalJoker { get; set; }
-                [Check.IsLessOrEqualTo((short)7512)] public RelationSet<string> JokeTargets { get; set; } = new();
+                [Check.IsLessOrEqualTo((short)7512)] public RelationSet<string> JokeTargets { get; } = new();
                 public double ComedyRating { get; set; }
                 public double JokeLength { get; set; }
                 public bool IsPhysicalComedy { get; set; }
@@ -7994,7 +8036,7 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public string FirstName { get; set; } = "";
                 [PrimaryKey] public string LastName { get; set; } = "";
-                [Check.IsNot(Kind.Other, Path = "Item.Kind"), Check.IsNot(false, Path = "Item.NSFW")] public RelationList<Joke> Jokes { get; set; } = new();
+                [Check.IsNot(Kind.Other, Path = "Item.Kind"), Check.IsNot(false, Path = "Item.NSFW")] public RelationList<Joke> Jokes { get; } = new();
                 public DateTime FirstShow { get; set; }
                 public bool LateNightHost { get; set; }
                 public ulong TwitterFollowers { get; set; }
@@ -8002,7 +8044,9 @@ namespace UT.Kvasir.Translation {
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class Interview {
-                public record struct Course(RelationMap<string, double> Questions);
+                public struct Course {
+                    public RelationMap<string, double> Questions { get; }
+                }
 
                 [PrimaryKey] public Guid ID { get; set; }
                 public string Company { get; set; } = "";
@@ -8281,9 +8325,9 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public DateTime Date { get; set; }
                 public string Sponsor { get; set; } = "";
                 public string Religion { get; set; } = "";
-                public RelationSet<string> BooksBurned { get; set; } = new();
-                public RelationSet<string> PeopleBurned { get; set; } = new();
-                [Check.IsNot("Mona Lisa", Path = "---")] public RelationSet<string> ArtworkBurned { get; set; } = new();
+                public RelationSet<string> BooksBurned { get; } = new();
+                public RelationSet<string> PeopleBurned { get; } = new();
+                [Check.IsNot("Mona Lisa", Path = "---")] public RelationSet<string> ArtworkBurned { get; } = new();
             }
 
             // Test Scenario: <Path> on Relation Refers to Non-Primary-Key Field of Anchor Entity (✗non-existent path✗)
@@ -8294,7 +8338,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public DateTime DateOfDream { get; set; }
                 [PrimaryKey] public uint SequenceNumber { get; set; }
                 public sbyte Length { get; set; }
-                [Check.IsNot("Hercules", Path = "Dream.REM")] public RelationList<string> Cameos { get; set; } = new();
+                [Check.IsNot("Hercules", Path = "Dream.REM")] public RelationList<string> Cameos { get; } = new();
                 public bool REM { get; set; }
             }
 
@@ -8306,7 +8350,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Bachelor { get; set; } = "";
                 [PrimaryKey] public DateTime Date { get; set; }
                 public sbyte Attendees { get; set; }
-                [Check.IsNot((byte)121)] public RelationList<Destination> Destinations { get; set; } = new();
+                [Check.IsNot((byte)121)] public RelationList<Destination> Destinations { get; } = new();
                 public bool FianceeSanctioned { get; set; }
                 public DateTime WeddingDay { get; set; }
             }
@@ -8542,7 +8586,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime Started { get; set; }
                 public DateTime? Ended { get; set; }
                 public ulong Participants { get; set; }
-                [Check.IsNonEmpty(Path = "Item")] public RelationSet<string> Sponsors { get; set; } = new();
+                [Check.IsNonEmpty(Path = "Item")] public RelationSet<string> Sponsors { get; } = new();
                 public bool BDS { get; set; }
                 public decimal Damage { get; set; }
             }
@@ -8562,7 +8606,7 @@ namespace UT.Kvasir.Translation {
                 public string FirstName { get; set; } = "";
                 public char MiddleInitial { get; set; }
                 public string LastName { get; set; } = "";
-                [Check.IsNonEmpty(Path = "Value.MallID")] public RelationMap<ushort, Mall> Jobs { get; set; } = new();
+                [Check.IsNonEmpty(Path = "Value.MallID")] public RelationMap<ushort, Mall> Jobs { get; } = new();
                 public ulong TotalKids { get; set; }
                 public bool NaturalBeard { get; set; }
             }
@@ -8573,7 +8617,7 @@ namespace UT.Kvasir.Translation {
                 public struct Category {
                     public uint Color { get; set; }
                     public string Connection { get; set; }
-                    public RelationList<string> Squares { get; set; }
+                    public RelationList<string> Squares { get; }
                 }
 
                 [PrimaryKey] public sbyte Season { get; set; }
@@ -8710,7 +8754,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string EnglishName { get; set; } = "";
                 public string GreekName { get; set; } = "";
                 public Variety Category { get; set; }
-                [Check.IsNonEmpty(Path = "---")] public RelationSet<sbyte> MetamorphosesAppearances { get; set; } = new();
+                [Check.IsNonEmpty(Path = "---")] public RelationSet<sbyte> MetamorphosesAppearances { get; } = new();
                 public bool Virgin { get; set; }
                 public string? TurnedInto { get; set; }
             }
@@ -8723,7 +8767,7 @@ namespace UT.Kvasir.Translation {
                 public string CEO { get; set; } = "";
                 public DateTime Launched { get; set; }
                 public ulong Users { get; set; }
-                [Check.IsNonEmpty(Path = "DatingApp.CEO")] public RelationList<Pair> CouplesFormed { get; set; } = new();
+                [Check.IsNonEmpty(Path = "DatingApp.CEO")] public RelationList<Pair> CouplesFormed { get; } = new();
                 public bool SwipeBased { get; set; }
                 public decimal? MonthlyFee { get; set; }
             }
@@ -8735,7 +8779,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public ulong Downloads { get; set; }
                 public bool Free { get; set; }
-                [Check.IsNonEmpty] public RelationSet<AdType> EffectiveAgainst { get; set; } = new();
+                [Check.IsNonEmpty] public RelationSet<AdType> EffectiveAgainst { get; } = new();
                 public bool Mobile { get; set; }
             }
 
@@ -8957,22 +9001,26 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public DateTime TermBegin { get; set; }
                 public DateTime? TermEnd { get; set; }
-                [Check.LengthIsAtLeast(6, Path = "Item.Title")] public RelationList<Resolution> ResolutionsPassed { get; set; } = new();
-                [Check.LengthIsAtLeast(17, Path = "UNSecretaryGeneral.Name")] public RelationSet<string> CountriesAdmitted { get; set; } = new();
+                [Check.LengthIsAtLeast(6, Path = "Item.Title")] public RelationList<Resolution> ResolutionsPassed { get; } = new();
+                [Check.LengthIsAtLeast(17, Path = "UNSecretaryGeneral.Name")] public RelationSet<string> CountriesAdmitted { get; } = new();
             }
 
             // Test Scenario: Applied to Relation-Nested Non-String Scalar (✗impermissible✗)
             public class MemoryBuffer {
                 [PrimaryKey] public ulong StartAddress { get; set; }
                 [PrimaryKey] public ulong EndAddress { get; set; }
-                [Check.LengthIsAtLeast(489, Path = "MemoryBuffer.EndAddress")] public RelationList<bool> Bits { get; set; } = new();
+                [Check.LengthIsAtLeast(489, Path = "MemoryBuffer.EndAddress")] public RelationList<bool> Bits { get; } = new();
                 public string IntendedType { get; set; } = "";
                 public bool HeapAllocated { get; set; }
             }
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class HotTub {
-                public record struct Settings(RelationMap<string, int> PresetSpeeds, double DefaultTemperature, bool Bubbles);
+                public struct Settings {
+                    public RelationMap<string, int> PresetSpeeds { get; }
+                    public double DefaultTemperature { get; set; }
+                    public bool Bubbles { get; set; }
+                }
 
                 [PrimaryKey] public Guid ProductID { get; set; }
                 public bool IsJacuzzi { get; set; }
@@ -9133,7 +9181,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid CigarID { get; set; }
                 public float Length { get; set; }
                 public bool IsCuban { get; set; }
-                [Check.LengthIsAtLeast(52, Path = "---")] public RelationMap<Tobacco, double> Contents { get; set; } = new();
+                [Check.LengthIsAtLeast(52, Path = "---")] public RelationMap<Tobacco, double> Contents { get; } = new();
             }
 
             // Test Scenario: <Path> on Relation Refers to Non-Primary-Key Field of Anchor Entity (✗non-existent path✗)
@@ -9148,7 +9196,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid StrainID { get; set; }
                 public string StrainName { get; set; } = "";
                 public DateTime Created { get; set; }
-                [Check.LengthIsAtLeast(4, Path = "MarijuanaStrain.StrainName")] public RelationSet<Dispensary> SoldAt { get; set; } = new();
+                [Check.LengthIsAtLeast(4, Path = "MarijuanaStrain.StrainName")] public RelationSet<Dispensary> SoldAt { get; } = new();
                 public double Addictiveness { get; set; }
             }
 
@@ -9159,7 +9207,7 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public string Name { get; set; } = "";
                 public Guid? FBINumber { get; set; }
-                [Check.LengthIsAtLeast(87)] public RelationList<Robbery> Robberies { get; set; } = new();
+                [Check.LengthIsAtLeast(87)] public RelationList<Robbery> Robberies { get; } = new();
                 public ushort MurdersCommitted { get; set; }
                 public bool Incarcerated { get; set; }
             }
@@ -9382,7 +9430,7 @@ namespace UT.Kvasir.Translation {
             public class Golem {
                 [PrimaryKey] public Guid ID { get; set; }
                 public DateTime Created { get; set; }
-                [Check.LengthIsAtMost(26, Path = "Item")] public RelationSet<string> Materials { get; set; } = new();
+                [Check.LengthIsAtMost(26, Path = "Item")] public RelationSet<string> Materials { get; } = new();
                 public float ShemSize { get; set; }
                 public string OwningRabbi { get; set; } = "";
                 public ulong Weight { get; set; }
@@ -9398,14 +9446,16 @@ namespace UT.Kvasir.Translation {
                 public string Flavor { get; set; } = "";
                 public double Volume { get; set; }
                 public DateTime ExpirationDate { get; set; }
-                [Check.LengthIsAtMost(255, Path = "Item.Grams")] public RelationSet<Ingredient> Ingredients { get; set; } = new();
+                [Check.LengthIsAtMost(255, Path = "Item.Grams")] public RelationSet<Ingredient> Ingredients { get; } = new();
                 public Color BalsamicColor { get; set; }
                 public bool DOP { get; set; }
             }
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class TerroristOrganization {
-                public record struct Record(RelationMap<string, DateTime> Entities);
+                public struct Record {
+                    public RelationMap<string, DateTime> Entities { get; }
+                }
 
                 [PrimaryKey] public string Name { get; set; } = "";
                 public DateTime ActiveSince { get; set; }
@@ -9564,7 +9614,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime TermBegin { get; set; }
                 public DateTime TermEnd { get; set; }
                 public string RuledFrom { get; set; } = "";
-                [Check.LengthIsAtMost(30, Path = "---")] public RelationList<string> CardinalsCreated { get; set; } = new();
+                [Check.LengthIsAtMost(30, Path = "---")] public RelationList<string> CardinalsCreated { get; } = new();
                 public bool Excommunicated { get; set; }
             }
 
@@ -9576,7 +9626,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid CabaretID { get; set; }
                 public DateTime Date { get; set; }
                 public Loc Venue { get; set; }
-                [Check.LengthIsAtMost(102, Path = "Cabaret.Venue.Name")] public RelationMap<string, string> Performers { get; set; } = new();
+                [Check.LengthIsAtMost(102, Path = "Cabaret.Venue.Name")] public RelationMap<string, string> Performers { get; } = new();
                 public bool Drag { get; set; }
                 public bool Burlesque { get; set; }
             }
@@ -9589,7 +9639,7 @@ namespace UT.Kvasir.Translation {
                 public string Creator { get; set; } = "";
                 public ushort Length { get; set; }
                 public bool Viral { get; set; }
-                [Check.LengthIsAtMost(100000)] public RelationMap<string, ulong> Views { get; set; } = new();
+                [Check.LengthIsAtMost(100000)] public RelationMap<string, ulong> Views { get; } = new();
                 public Kind Category { get; set; }
             }
 
@@ -9824,7 +9874,7 @@ namespace UT.Kvasir.Translation {
                 public string Series { get; set; } = "";
                 public Pub Publisher { get; set; }
                 public DateTime Published { get; set; }
-                [Check.LengthIsBetween(4, 37, Path = "Item"), Check.LengthIsBetween(8, 19, Path = "ComicBook.Title")] public RelationSet<string> Characters { get; set; } = new();
+                [Check.LengthIsBetween(4, 37, Path = "Item"), Check.LengthIsBetween(8, 19, Path = "ComicBook.Title")] public RelationSet<string> Characters { get; } = new();
                 public decimal Price { get; set; }
                 public bool Vintage { get; set; }
             }
@@ -9836,7 +9886,7 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public Guid ID { get; set; }
                 public Kind Variety { get; set; }
-                [Check.LengthIsBetween(14, 99, Path = "Item.Z")] public RelationSet<Location> ConnectedLocations { get; set; } = new();
+                [Check.LengthIsBetween(14, 99, Path = "Item.Z")] public RelationSet<Location> ConnectedLocations { get; } = new();
                 public double Radius { get; set; }
                 public ulong Density { get; set; }
             }
@@ -9845,7 +9895,10 @@ namespace UT.Kvasir.Translation {
             public class LunarEclipse {
                 public enum Kind { Penumbral, Partial, Total, Central, Selenion }
                 public record struct Coordinate(float Latitude, float Longitude);
-                public record struct Viewing(RelationMap<Coordinate, double> Locations, bool NakedEye);
+                public struct Viewing {
+                    public RelationMap<Coordinate, double> Locations { get; }
+                    public bool NakedEye { get; set; }
+                }
 
                 [PrimaryKey] public DateTime Date { get; set; }
                 public Kind Type { get; set; }
@@ -10014,7 +10067,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime Launched { get; set; }
                 public decimal Budget { get; set; }
                 public string SpaceAgency { get; set; } = "";
-                [Check.LengthIsBetween(177, 179, Path = "---")] public RelationList<Specimen> SpecimensCollected { get; set; } = new();
+                [Check.LengthIsBetween(177, 179, Path = "---")] public RelationList<Specimen> SpecimensCollected { get; } = new();
                 public double Height { get; set; }
                 public double Length { get; set; }
                 public double Width { get; set; }
@@ -10029,7 +10082,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public string Country { get; set; } = "";
                 public Branch MilitaryBranch { get; set; }
-                [Check.LengthIsBetween(6, 29, Path = "BlackOp.Country")] public RelationSet<string> Participants { get; set; } = new();
+                [Check.LengthIsBetween(6, 29, Path = "BlackOp.Country")] public RelationSet<string> Participants { get; } = new();
                 public DateTime Executed { get; set; }
                 public DateTime Declassified { get; set; }
                 public ushort Casualites { get; set; }
@@ -10041,7 +10094,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Victim { get; set; } = "";
                 [PrimaryKey] public DateTime Occurrence { get; set; }
                 public bool Fatal { get; set; }
-                [Check.LengthIsBetween(4, 67)] public RelationSet<string> Symptoms { get; set; } = new();
+                [Check.LengthIsBetween(4, 67)] public RelationSet<string> Symptoms { get; } = new();
             }
 
             // Test Scenario: Default Value Does Not Satisfy Constraint (✗contradiction✗)
@@ -10249,7 +10302,7 @@ namespace UT.Kvasir.Translation {
                 public Period MesozoicPeriod { get; set; }
                 public Hips Clade { get; set; }
                 public Diet FoodPreference { get; set; }
-                [Check.IsOneOf("Americas", "Eurasia", "Middle East", "Africa", "Australia", "Pacific Islands", "Arctic", "Antarctica", "Oceans", Path = "Item")] public RelationSet<string> FossilLocations { get; set; } = new();
+                [Check.IsOneOf("Americas", "Eurasia", "Middle East", "Africa", "Australia", "Pacific Islands", "Arctic", "Antarctica", "Oceans", Path = "Item")] public RelationSet<string> FossilLocations { get; } = new();
                 public int FacialHorns { get; set; }
                 public int NumTeeth { get; set; }
             }
@@ -10257,7 +10310,12 @@ namespace UT.Kvasir.Translation {
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class Cheerleader {
                 [Flags] public enum Item { PomPoms = 1, Batons = 2, Dancing = 4, Sparklers = 8, Instruments = 16 }
-                public record struct Cheer(string Title, string CallSign, RelationMap<int, string> Moves, string Music);
+                public struct Cheer {
+                    public string Title { get; set; }
+                    public string CallSign { get; set; }
+                    public RelationMap<int, string> Moves { get; }
+                    public string Music { get; set; }
+                }
 
                 [PrimaryKey] public string Name { get; set; } = "";
                 public string Squad { get; set; } = "";
@@ -10553,11 +10611,11 @@ namespace UT.Kvasir.Translation {
                 public record struct Object(string Name, Status Status, decimal Appraisal, DateTime Acquired);
 
                 [PrimaryKey] public string ShopName { get; set; } = "";
-                public RelationList<string> Employees { get; set; } = new();
+                public RelationList<string> Employees { get; } = new();
                 public sbyte Floors { get; set; }
                 public DateTime Opened { get; set; }
                 public Guid License { get; set; }
-                [Check.IsOneOf('A', '7', '_', '/', '=', '~', Path = "---")] public RelationList<Object> Inventory { get; set; } = new();
+                [Check.IsOneOf('A', '7', '_', '/', '=', '~', Path = "---")] public RelationList<Object> Inventory { get; } = new();
                 public decimal Revenue { get; set; }
             }
 
@@ -10569,7 +10627,7 @@ namespace UT.Kvasir.Translation {
                 public bool EcoFriendly { get; set; }
                 public double WaterPressure { get; set; }
                 public ulong VolumeDispensed { get; set; }
-                [Check.IsOneOf(37.6, 1158.44, 0.919, 63.6666, Path = "DrinkingFountain.WaterPressure")] public RelationSet<DateTime> Inspections { get; set; } = new();
+                [Check.IsOneOf(37.6, 1158.44, 0.919, 63.6666, Path = "DrinkingFountain.WaterPressure")] public RelationSet<DateTime> Inspections { get; } = new();
                 public bool MotionSensored { get; set; }
             }
 
@@ -10580,7 +10638,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ID { get; set; }
                 public string Name { get; set; } = "";
                 public string Description { get; set; } = "";
-                [Check.IsOneOf(true, false)] public RelationMap<Guid, bool> Certifications { get; set; } = new();
+                [Check.IsOneOf(true, false)] public RelationMap<Guid, bool> Certifications { get; } = new();
                 public DateTime? FirstDocumented { get; set; }
                 public string? Culture { get; set; } = "";
                 public Gender AppropriateFor { get; set; }
@@ -10766,7 +10824,7 @@ namespace UT.Kvasir.Translation {
             public class Infomercial {
                 [PrimaryKey] public Guid ID { get; set; }
                 public string Product { get; set; } = "";
-                [Check.IsNotOneOf("2022-03-17", "1965-11-14", "1333-01-02", Path = "Value")] public RelationMap<uint, DateTime> Broadcasts { get; set; } = new();
+                [Check.IsNotOneOf("2022-03-17", "1965-11-14", "1333-01-02", Path = "Value")] public RelationMap<uint, DateTime> Broadcasts { get; } = new();
                 public string Hawker { get; set; } = "";
                 public double Discount { get; set; }
                 public double CommercialLength { get; set; }
@@ -10776,7 +10834,10 @@ namespace UT.Kvasir.Translation {
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class PersonOfTheYear {
                 public enum Category { Politics, FilmTV, Sports, Music, News, Science, Philanthropy, Religion, Art, Other }
-                public record struct Magazine(DateTime Publication, RelationList<uint> Editions);
+                public struct Magazine {
+                    public DateTime Publication { get; set; }
+                    public RelationList<uint> Editions { get; }
+                }
 
                 [PrimaryKey] public ushort Year { get; set; }
                 public string Person { get; set; } = "";
@@ -11081,7 +11142,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime Published { get; set; }
                 public string Region { get; set; } = "";
                 public ulong PageCount { get; set; }
-                [Check.IsNotOneOf(8471294811, 2056178955, 8005882340, Path = "---")] public RelationMap<string, ulong> PhoneNumbers { get; set; } = new();
+                [Check.IsNotOneOf(8471294811, 2056178955, 8005882340, Path = "---")] public RelationMap<string, ulong> PhoneNumbers { get; } = new();
                 public double Weight { get; set; }
             }
 
@@ -11092,7 +11153,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ID { get; set; }
                 public string BakuganName { get; set; } = "";
                 public Attribute BakuganAttribute { get; set; }
-                [Check.IsNotOneOf("Counterspell", "Basic Island", "Lightning Bolt", Path = "Bakugan.BakuganName")] public RelationSet<string> AbilityCards { get; set; } = new();
+                [Check.IsNotOneOf("Counterspell", "Basic Island", "Lightning Bolt", Path = "Bakugan.BakuganName")] public RelationSet<string> AbilityCards { get; } = new();
                 public bool InAnime { get; set; }
             }
 
@@ -11100,8 +11161,8 @@ namespace UT.Kvasir.Translation {
             public class QRCode {
                 [PrimaryKey] public Guid ID { get; set; }
                 public string URL { get; set; } = "";
-                public RelationList<bool> Horizontal { get; set; } = new();
-                [Check.IsNotOneOf(false)] public RelationList<bool> Vertical { get; set; } = new();
+                public RelationList<bool> Horizontal { get; } = new();
+                [Check.IsNotOneOf(false)] public RelationList<bool> Vertical { get; } = new();
                 public double Version { get; set; }
                 public char ErrorCorrection { get; set; }
             }
@@ -11229,14 +11290,23 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Bear { get; set; } = "";
             public string Color { get; set; } = "";
             public char TummySymbol { get; set; }
-            [Check<CustomCheck>(Path = "Item")] public RelationSet<string> MediaAppearances { get; set; } = new();
+            [Check<CustomCheck>(Path = "Item")] public RelationSet<string> MediaAppearances { get; } = new();
             public string LeadDesigner { get; set; } = "";
         }
 
         // Test Scenario: Applied to Nested Relation (✗impermissible✗)
         public class RiverWalk {
             public record struct TimeRange(ushort Open, ushort Close);
-            public record struct Schedule(TimeRange M, TimeRange TU, TimeRange W, TimeRange TH, TimeRange F, TimeRange SA, TimeRange SU, RelationSet<string> HolidaysClosed);
+            public struct Schedule {
+                public TimeRange M { get; set; }
+                public TimeRange TU { get; set; }
+                public TimeRange W { get; set; }
+                public TimeRange TH { get; set; }
+                public TimeRange F { get; set; }
+                public TimeRange SA { get; set; }
+                public TimeRange SU { get; set; }
+                public RelationSet<string> HolidaysClosed { get; }
+            }
 
             [PrimaryKey] public Guid ID { get; set; }
             public string City { get; set; } = "";
@@ -11448,7 +11518,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public string Name { get; set; } = "";
             public Kind Classification { get; set; }
-            [Check<CustomCheck>(Path = "---")] public RelationList<City> Cities { get; set; } = new();
+            [Check<CustomCheck>(Path = "---")] public RelationList<City> Cities { get; } = new();
             public string PostalCode { get; set; } = "";
             public Language OfficialLanguages { get; set; }
             public Reps Representation { get; set; }
@@ -11462,14 +11532,14 @@ namespace UT.Kvasir.Translation {
             public string Name { get; set; } = "";
             public double Height { get; set; }
             public double Weight { get; set; }
-            [Check<CustomCheck>(Path = "Skydiver.Height")] public RelationMap<DateTime, long> Dives { get; set; } = new();
+            [Check<CustomCheck>(Path = "Skydiver.Height")] public RelationMap<DateTime, long> Dives { get; } = new();
             public Vehicle HasJumpedFrom { get; set; }
         }
 
         // Test Scenario: <Path> on Relation Not Specified (✗missing path✗)
         public class Spring {
             [PrimaryKey] public Guid ID { get; set; }
-            [Check<CustomCheck>] public RelationSet<string> ConstituentMetals { get; set; } = new();
+            [Check<CustomCheck>] public RelationSet<string> ConstituentMetals { get; } = new();
             public double SpringConstant { get; set; }
             public ushort NumCoils { get; set; }
         }
@@ -12163,9 +12233,9 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Hash { get; set; } = "";
             public string Name { get; set; } = "";
             public string Version { get; set; } = "";
-            public RelationMap<string, bool> Flags { get; set; } = new();
-            public RelationSet<SoftwarePackage> BuildDependencies { get; set; } = new();
-            public RelationSet<SoftwarePackage> RunDependencies { get; set; } = new();
+            public RelationMap<string, bool> Flags { get; } = new();
+            public RelationSet<SoftwarePackage> BuildDependencies { get; } = new();
+            public RelationSet<SoftwarePackage> RunDependencies { get; } = new();
             public bool Secure { get; set; }
         }
 
@@ -12178,7 +12248,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public ulong IndictmentNumber { get; set; }
             [PrimaryKey] public string Defendant { get; set; } = "";
             public DateTime Issued { get; set; }
-            public RelationList<Charge> Charges { get; set; } = new();
+            public RelationList<Charge> Charges { get; } = new();
             public Level Government { get; set; }
             public bool? Conviction { get; set; }
         }
@@ -12194,7 +12264,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public Guid ID { get; set; }
             public sbyte FrameNumber { get; set; }
-            public RelationList<Breakpoint> Breakpoints { get; set; } = new();
+            public RelationList<Breakpoint> Breakpoints { get; } = new();
             public string Debugger { get; set; } = "";
             public double Memory { get; set; }
         }
@@ -12204,7 +12274,7 @@ namespace UT.Kvasir.Translation {
             public class Politician {
                 [PrimaryKey] public string FullName { get; set; } = "";
                 public DateTime FirstElected { get; set; }
-                public RelationSet<Filibuster> FilibustersBroken { get; set; } = new();
+                public RelationSet<Filibuster> FilibustersBroken { get; } = new();
             }
 
             [PrimaryKey] public Guid FilibusterID { get; set; }
@@ -12573,7 +12643,7 @@ namespace UT.Kvasir.Translation {
         public class Pretzel {
             [PrimaryKey, Column(0)] public Guid PretzelID { get; set; }
             [Column(1)] public string Name { get; set; } = "";
-            public RelationSet<string> Toppings { get; set; } = new();
+            public RelationSet<string> Toppings { get; init;  } = new();
             [Column(2)] public decimal RetailPrice { get; set; }
             [Column(3)] public string DoughSource { get; set; } = "";
         }
@@ -12582,8 +12652,8 @@ namespace UT.Kvasir.Translation {
         public class Teppanyaki {
             [PrimaryKey, Column(0)] public Guid GrillID { get; set; }
             [Column(1)] public double GrillSurfaceArea { get; set; }
-            public RelationSet<string> AuthorizedChefs { get; set; } = new();
-            public RelationList<string> SupportedFoods { get; set; } = new();
+            public RelationSet<string> AuthorizedChefs { get; init; } = new();
+            public RelationList<string> SupportedFoods { get; init; } = new();
             [Column(2)] public float MaxTemperature { get; set; }
             [Column(3)] public string? Restaurant { get; set; }
             [Column(4)] public bool IsHibachi { get; set; }
@@ -12594,7 +12664,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public ushort Year { get; set; }
             [Column(1)] public byte NumRounds { get; set; }
             [Column(2)] public string Champion { get; set; } = "";
-            public RelationMap<uint, string> EliminationWords { get; set; } = new();
+            public RelationMap<uint, string> EliminationWords { get; init; } = new();
         }
 
         // Scenario: Non-Null Ordered List Relation Property with Only New Elements (✓values extracted per element✓)
@@ -12602,7 +12672,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
             [Column(1)] public DateTime Created { get; set; }
             [Column(2)] public uint NumShows { get; set; }
-            public RelationOrderedList<string> Lineup { get; set; } = new();
+            public RelationOrderedList<string> Lineup { get; init; } = new();
             [Column(3)] public string Location { get; set; } = "";
             [Column(4)] public string URL { get; set; } = "";
         }
@@ -12612,13 +12682,13 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid ID { get; set; }
             public string Category { get; set; } = "";
             public string Tip { get; set; } = "";
-            public RelationSet<string> For { get; set; } = new();
+            public RelationSet<string> For { get; init; } = new();
         }
 
         // Scenario: Non-Null Relation Property with At Least One Modified Element (✓values extracted per element✓)
         public class PendragonTerritory {
             [PrimaryKey] public string Name { get; set; } = "";
-            public RelationOrderedList<string> Travellers { get; set; } = new();
+            public RelationOrderedList<string> Travellers { get; init; } = new();
             public string FirstAppearance { get; set; } = "";
             public string Capital { get; set; } = "";
         }
@@ -12630,7 +12700,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public ushort Year { get; set; }
             [PrimaryKey] public PoliticalParty Party { get; set; }
             public DateTime Date { get; set; }
-            public RelationMap<string, double> DelegatesEarned { get; set; } = new();
+            public RelationMap<string, double> DelegatesEarned { get; init; } = new();
             public bool Bellwether { get; set; }
         }
 
@@ -12643,7 +12713,7 @@ namespace UT.Kvasir.Translation {
             }
 
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
-            public RelationOrderedList<Thesis>? DoctoralTheses { get; set; }
+            public RelationOrderedList<Thesis>? DoctoralTheses { get; init; }
             [Column(1)] public DateTime DateOfBirth { get; set; }
             [Column(2)] public DateTime? DateOfDeath { get; set; }
             [Column(3)] public string ExistentialSchool { get; set; } = "";
@@ -12657,7 +12727,7 @@ namespace UT.Kvasir.Translation {
             [Column(1)] public string? BirthName { get; set; }
             [Column(2)] public string? BirthComm { get; set; }
             [Column(3)] public byte Rings { get; set; }
-            public RelationMap<Book, bool>? Appearances { get; set; }
+            public RelationMap<Book, bool>? Appearances { get; init; }
             [Column(4)] public bool AtNodeStation { get; set; }
         }
 
@@ -12674,7 +12744,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public string BoonName { get; set; } = "";
             [Column(1)] public Deity Benefactor { get; set; }
             [Column(2)] public Ability AbilityAffected { get; set; }
-            public RelationOrderedList<Benefit> Progressions { get; set; } = new();
+            public RelationOrderedList<Benefit> Progressions { get; init; } = new();
             [Column(3)] public double Likelihood { get; set; }
         }
 
@@ -12695,7 +12765,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public string Official { get; set; } = "";
             [Column(1)] public string Position { get; set; } = "";
             [PrimaryKey, Column(2)] public DateTime Commenced { get; set; }
-            public RelationList<Count> Counts { get; set; } = new();
+            public RelationList<Count> Counts { get; init; } = new();
             [Calculated, Column(3)] public bool Convicted => Counts.Any(c => c.Guilty);
         }
 
@@ -12705,7 +12775,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
             [Column(1)] public string Domain { get; set; } = "";
-            public RelationMap<MaoriGod, Relation> Family { get; set; } = new();
+            public RelationMap<MaoriGod, Relation> Family { get; init; } = new();
             [Column(2)] public bool IsAtua { get; set; }
             [Column(3)] public bool EncounteredMaui { get; set; }
         }
@@ -12715,12 +12785,12 @@ namespace UT.Kvasir.Translation {
             public struct Computers {
                 [Column(0)] public ushort NumCabinets { get; set; }
                 [Column(1)] public ushort RacksPerCabinet { get; set; }
-                public RelationSet<string> Brands { get; set; }
+                public RelationSet<string> Brands { get; init; }
             }
             public struct Stats {
                 [Column(0)] public double CO2 { get; set; }
                 [Column(1)] public ushort Electricity { get; set; }
-                public RelationMap<string, double> Dimensions { get; set; }
+                public RelationMap<string, double> Dimensions { get; init; }
                 [Column(2)] public Computers Machines { get; set; }
             }
 
@@ -12742,7 +12812,7 @@ namespace UT.Kvasir.Translation {
             [Column(1)] public ulong TimesChangedColor { get; set; }
             [Column(2)] public string Genus { get; set; } = "";
             [Column(3)] public string Species { get; set; } = "";
-            [Calculated] public RelationOrderedList<Eye> Eyes { get; set; }
+            [Calculated] public RelationOrderedList<Eye> Eyes { get; init; }
 
             public Chameleon() {
                 Eyes = new RelationOrderedList<Eye>();
@@ -12764,7 +12834,7 @@ namespace UT.Kvasir.Translation {
             }
 
             [PrimaryKey, Column(0)] public Zodiac Sign { get; set; }
-            public RelationMap<DateTime, Listing> Readings { get; set; } = new();
+            public RelationMap<DateTime, Listing> Readings { get; init; } = new();
             [Column(1)] public DateTime RangeLower { get; set; }
             [Column(2)] public DateTime RangeUpper { get; set; }
         }
@@ -13226,18 +13296,18 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public Guid ID { get; set; }
             [Column(1)] public string BoardMaterial { get; set; } = "";
             [Column(2)] public double BoardArea { get; set; }
-            public RelationList<string> Cheeses { get; set; } = new();
-            public RelationSet<string> Meats { get; set; } = new();
-            public RelationOrderedList<string> Sauces { get; set; } = new();
-            public RelationMap<DateTime, uint> Usages { get; set; } = new();
+            public RelationList<string> Cheeses { get; } = new();
+            public RelationSet<string> Meats { get; } = new();
+            public RelationOrderedList<string> Sauces { get; } = new();
+            public RelationMap<DateTime, uint> Usages { get; } = new();
         }
 
         // Scenario: List/Set Relation Elements (✓values reconstituted per element✓)
         public class Mutant {
             [PrimaryKey, Column(0)] public string CodeName { get; set; } = "";
             [Column(1)] public string BirthName { get; set; } = "";
-            public RelationList<string> Powers { get; set; } = new();
-            public RelationSet<DateTime> Appearances { get; set; } = new();
+            public RelationList<string> Powers { get; } = new();
+            public RelationSet<DateTime> Appearances { get; } = new();
             [Column(2)] public bool InXMenMovies { get; set; }
         }
 
@@ -13247,17 +13317,17 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey, Column(0)] public Guid WaterParkID { get; set; }
             [Column(1)] public string Name { get; set; } = "";
-            public RelationMap<string, double> WaterSlides { get; set; } = new();
+            public RelationMap<string, double> WaterSlides { get; } = new();
             [Column(2)] public bool LazyRiver { get; set; }
             [Column(3)] public ulong GallonsWater { get; set; }
-            public RelationMap<Customer, decimal> AdmissionPrices { get; set; } = new();
+            public RelationMap<Customer, decimal> AdmissionPrices { get; } = new();
         }
 
         // Scenario: Ordered List Relation Elements (✓values reconstituted per element✓)
         public class Seance {
             [PrimaryKey, Column(0)] public DateTime Timestamp { get; set; }
             [PrimaryKey, Column(1)] public string Medium { get; set; } = "";
-            public RelationOrderedList<string> SpiritsContacted { get; set; } = new();
+            public RelationOrderedList<string> SpiritsContacted { get; } = new();
             [Column(2)] public decimal PriceTag { get; set; }
             [Column(3)] public ushort NumCandles { get; set; }
         }
@@ -13271,10 +13341,10 @@ namespace UT.Kvasir.Translation {
             [Column(1)] public DateTime DateOfBirth { get; set; }
             [Column(2)] public string OfficeAddress { get; set; } = "";
             [Column(3)] public bool OwnsPractice { get; set; }
-            public IReadOnlyRelationMap<Degree, string> AlmaMaters { get; set; } = new RelationMap<Degree, string>();
-            public IReadOnlyRelationSet<string> Patients { get; set; } = new RelationSet<string>();
-            public IReadOnlyRelationOrderedList<decimal> SalaryHistory { get; set; } = new RelationOrderedList<decimal>();
-            public IReadOnlyRelationList<Day> Workdays { get; set; } = new RelationList<Day>();
+            public IReadOnlyRelationMap<Degree, string> AlmaMaters { get; } = new RelationMap<Degree, string>();
+            public IReadOnlyRelationSet<string> Patients { get; } = new RelationSet<string>();
+            public IReadOnlyRelationOrderedList<decimal> SalaryHistory { get; } = new RelationOrderedList<decimal>();
+            public IReadOnlyRelationList<Day> Workdays { get; } = new RelationList<Day>();
         }
 
         // Scenario: Null Relation (✓no reconstitution [should be impossible unless empty]✓)
@@ -13287,8 +13357,8 @@ namespace UT.Kvasir.Translation {
             [Column(3)] public decimal Price { get; set; }
             [Column(4)] public string Breading { get; set; } = "";
             [Column(5)] public bool ButtermilkMarinated { get; set; }
-            public RelationSet<string> Spices { get; set; } = null!;
-            public RelationList<string> RecommendedSauces { get; set; } = null!;
+            public RelationSet<string> Spices { get; } = null!;
+            public RelationList<string> RecommendedSauces { get; } = null!;
         }
 
         // Scenario: Relation Nested in Non-Null Aggregate (✓values reconstituted per element✓)
@@ -13297,7 +13367,7 @@ namespace UT.Kvasir.Translation {
 
             public struct Personnel {
                 [Column(0)] public string Owner { get; set; } = "";
-                public RelationSet<string> LicensedDrivers { get; set; }
+                public RelationSet<string> LicensedDrivers { get; init;  }
                 [Column(1)] public string Mechanic { get; set; } = "";
                 [Column(2)] public string? DecalMaker { get; set; }
 
@@ -13317,7 +13387,7 @@ namespace UT.Kvasir.Translation {
         public class Xenomorph {
             public struct Victims {
                 [Column(0)] public uint ConfirmedKills { get; set; }
-                public RelationMap<string, bool> Impregnations { get; set; }
+                public RelationMap<string, bool> Impregnations { get; }
                 [Column(1)] public bool Suicide { get; set; }
             }
 
@@ -13339,7 +13409,7 @@ namespace UT.Kvasir.Translation {
             [Column(1)] public string Author { get; set; } = "";
             [Column(2)] public DateTime Published { get; set; }
             [Column(3)] public uint StanzaCount { get; set; }
-            public RelationOrderedList<Section> Sections { get; set; } = new();
+            public RelationOrderedList<Section> Sections { get; } = new();
             [Column(4)] public string Language { get; set; } = "";
         }
 
@@ -13354,7 +13424,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey, Column(0)] public DateTime Timestamp { get; set; }
             [Column(1)] public string Driver { get; set; } = "";
-            public RelationList<PoliceOfficer> Officers { get; set; } = new();
+            public RelationList<PoliceOfficer> Officers { get; } = new();
             [Column(2)] public bool TicketIssued { get; set; }
             [Column(3)] public bool ArrestMade { get; set; }
         }
@@ -13367,7 +13437,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
             [Column(1)] public Continent ActiveLocations { get; set; }
             [Column(2)] public AnimalType Targets { get; set; }
-            public RelationSet<Poacher> PoachingGroup { get; set; } = new();
+            public RelationSet<Poacher> PoachingGroup { get; } = new();
             [Column(3)] public decimal Income { get; set; }
         }
 
@@ -13380,7 +13450,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey, Column(0)] public ushort Year { get; set; }
             [Column(1)] public uint PageCount { get; set; }
-            public RelationMap<string, Rating> Restaurants { get; set; } = new();
+            public RelationMap<string, Rating> Restaurants { get; } = new();
             [Column(2)] public bool IsGreenGuide { get; set; }
         }
 

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -160,6 +160,7 @@ Briefcase
 Brothel
 Buffet
 Bug Spray
+Bug Zapper
 Burrito
 Bust
 Butterfly


### PR DESCRIPTION
This commit adds a new Translation error that is raised when a Relation-type property that is included in the data model is freely writeable. Notably, this excludes init-only properties. The intent here is to prevent properties that allow users to freely change the actual relation object rather than just manipulating the collection's contents: the former causes issues with state tracking, while the latter is obviously fine.