### PR TITLE
Update Dependenies (2025 Q1)

### DIFF
--- a/src/Atropos/Atropos.csproj
+++ b/src/Atropos/Atropos.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="4.6.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/Cybele/Cybele.csproj
+++ b/src/Cybele/Cybele.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="4.6.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/Kvasir/Kvasir.csproj
+++ b/src/Kvasir/Kvasir.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="4.6.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
     <PackageReference Include="Combinatorics" Version="2.0.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
   * Ardalis.GuardClauses: 4.6.0 --> 5.0.0
   * coverlet.msbuild: 6.0.2 --> 6.0.4
   * FluentAssertions: 6.12.0 --> 6.12.2 [avoiding major release with breaking changes]
   * Microsoft.NET.Test.Sdk: 17.11.0 --> 17.12.0
   * MSTest.TestAdapter: 3.5.2 --> 3.7.2
   * MSTest.TestFramework: 3.5.2 --> 3.7.2
   * NSubstitute: 5.1.0 --> 5.3.0