### PR TITLE
Fix Bug that Missed Detecting Nested Relations due to Memoization

### DIFF
--- a/src/Kvasir/Translation/TranslateType.cs
+++ b/src/Kvasir/Translation/TranslateType.cs
@@ -57,7 +57,15 @@ namespace Kvasir.Translation {
 
             // Memoization
             if (typeCache_.TryGetValue(source, out IReadOnlyList<FieldGroup>? memoization)) {
-                return memoization.Select(g => g.Clone());
+                // This may not be the most elegant solution, but it works. If we've seen an Aggregate type before in a
+                // context that allows Relations, and then we see it again in a context that doesn't (namely, when
+                // translating a Relation), we have to flag it as an error. We don't have enough information from the
+                // initial translation to fully report the error, so we simply let the regular translation happen again.
+                // Since we know there's a Relation, we know it's guaranteed to fail; and, since we know the type got
+                // translated once, we know there won't be any other errors.
+                if (allowRelations || relationTrackersCache_[source].Count == 0) {
+                    return memoization.Select(g => g.Clone());
+                }
             }
             var translation = new List<FieldGroup>();
             var relationTrackers = new List<RelationTracker>();

--- a/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
+++ b/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
@@ -889,7 +889,7 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
-        [TestMethod] public void RelationNestedWithAggregateNestedWithinRelation_IsError() {
+        [TestMethod] public void RelationNestedWithinAggregateNestedWithinRelation_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
             var source = typeof(Poll);
@@ -900,6 +900,21 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<NestedRelationException>()
                 .WithLocation("`Poll` → <synthetic> `Questions` → `Question` (from \"Item\") → Answers")
+                .WithProblem("nested Relations are not supported")
+                .EndMessage();
+        }
+
+        [TestMethod] public void RelationNestedWithinAggregateNestedWithinRelation_PostMemoization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Quinceanera);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NestedRelationException>()
+                .WithLocation("`Quinceanera` → <synthetic> `Presents` → `Gift` (from \"Value\") → Adjectives")
                 .WithProblem("nested Relations are not supported")
                 .EndMessage();
         }

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -476,6 +476,22 @@ namespace UT.Kvasir.Translation {
             public double ReponseRate { get; set; }
         }
 
+        // Test Scenario: Relation Nested Within Aggregate Nested Within Relation, post-Memoization (✗not permitted✗)
+        public class Quinceanera {
+            public record struct Gift {
+                public string Description { get; set; }
+                public decimal Price { get; set; }
+                public RelationSet<string> Adjectives { get; }
+            }
+
+            [PrimaryKey] public Guid PartyID { get; set; }
+            public DateTime Date { get; set; }
+            public string BirthdayGirl { get; set; } = "";
+            public Gift BestGift { get; set; }
+            public RelationMap<string, Gift> Presents { get; } = new();
+            public bool InMexico { get; set; }
+        }
+
         // Test Scenario: Relation List/Set of KeyValuePair<X, Y> (✗not permitted - implementation ambiguity✗)
         public class Caricature {
             public enum Location { Circus, Zoo, AmusementPark, SportingEvent, FarmersMarket, Other }

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -889,6 +889,7 @@ Quarterback
 Quasar
 Quatrain
 Quilt
+Quinceañera
 Rabbi
 Racehorse
 Racetrack (auto racing)


### PR DESCRIPTION
This commit fixes a bug in the Translation layer whereby a certain layout led to a Relation-nested Relation not being flagged as illegal. Specifically, the bug was triggered by the following set-up:

   1. A Relation is nested in an Aggregate 'A'
   2. A Field of type 'A' is translated successfully
   3. A Relation-type Field that has 'A' as an element is translated

Because the result of (2) is memoized, when 'A' is re-encountered during (3) we previously skipped all additional translation and simply returned back the all the non-Relation Fields of 'A'. This memoization causes the discrepancy: if (2) had never happened, then (3) would have correctly identified the illegal schema.

The solution is to detect when something like this is going to happen (thanks to RelationTrackers) and simply pretend that the type's translation is not memoized. In letting the normal course of translation continue, the regular detection path will be executed and the correct (contextually rich) exception will be raised. We know that no other errors can be raised, since the type was translated successfully once already.

A new unit test, which failed to trigger an exception before the change, has been added.