### PR TITLE
Fix Bug causing Missing Information in Error Messages for Nested Relations

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -10282,10 +10282,9 @@
               A utility for tracking annotations applied to Aggregate-nested Relation-type properties.
             </summary>
         </member>
-        <member name="P:Kvasir.Translation.RelationTracker.Name">
+        <member name="P:Kvasir.Translation.RelationTracker.AnnotatedName">
             <summary>
-              The name of the backing Relation-type property, accounting for any <see cref="T:Kvasir.Annotations.NameAttribute">[Name]</see>
-              annotation that has been applied.
+              The value of the <c>[Name]</c> annotation applied to the backing Relation-type property, if any.
             </summary>
         </member>
         <member name="P:Kvasir.Translation.RelationTracker.Path">
@@ -10307,16 +10306,16 @@
               The source <see cref="P:Kvasir.Translation.RelationTracker.Property"/>.
             </param>
         </member>
-        <member name="M:Kvasir.Translation.RelationTracker.#ctor(Kvasir.Translation.RelationTracker,System.String)">
+        <member name="M:Kvasir.Translation.RelationTracker.#ctor(Kvasir.Translation.RelationTracker,System.Reflection.PropertyInfo)">
             <summary>
-              Constructs a new <see cref="T:Kvasir.Translation.RelationTracker"/> that is identical to another but with a different
-              <see cref="P:Kvasir.Translation.RelationTracker.Path"/>.
+              Constructs a new <see cref="T:Kvasir.Translation.RelationTracker"/> that is identical to another but with an additional
+              property prepended to its <see cref="P:Kvasir.Translation.RelationTracker.Path"/>.
             </summary>
             <param name="source">
               The source <see cref="T:Kvasir.Translation.RelationTracker"/>.
             </param>
-            <param name="path">
-              The new <see cref="P:Kvasir.Translation.RelationTracker.Path">access path</see>.
+            <param name="upstreamProperty">
+              The additional property.
             </param>
         </member>
         <member name="M:Kvasir.Translation.RelationTracker.AttachAnnotation``1(Kvasir.Translation.Context,Kvasir.Translation.Nested{``0})">
@@ -10334,16 +10333,17 @@
               <see cref="T:Kvasir.Annotations.NameAttribute">[Name]</see> annotation.
             </exception>
         </member>
-        <member name="M:Kvasir.Translation.RelationTracker.ExtendPath(System.String)">
+        <member name="M:Kvasir.Translation.RelationTracker.Extend(System.Reflection.PropertyInfo)">
             <summary>
-              Prepend a segment to the <see cref="P:Kvasir.Translation.RelationTracker.Path"/>.
+              Prepends a property to the <see cref="P:Kvasir.Translation.RelationTracker.Path"/>.
             </summary>
-            <param name="path">
-              The new path segment.
+            <param name="property">
+              The <see cref="T:System.Reflection.PropertyInfo">property</see> to prepend to the <see cref="P:Kvasir.Translation.RelationTracker.Path"/>. This also affects the
+              <see cref="M:Kvasir.Translation.RelationTracker.GetSyntheticTypenameOn(System.Type)">implied synthetic typename</see>.
             </param>
             <returns>
-              A new <see cref="T:Kvasir.Translation.RelationTracker"/> that is equivalent to this one but with <paramref name="path"/> (and a
-              following <c>.</c>) prepended to the <see cref="P:Kvasir.Translation.RelationTracker.Path"/>.
+              A new <see cref="T:Kvasir.Translation.RelationTracker"/> identical to the current one, but with <paramref name="property"/>
+              prepended to the <see cref="P:Kvasir.Translation.RelationTracker.Path"/>.
             </returns>
         </member>
         <member name="M:Kvasir.Translation.RelationTracker.AnnotationsFor(System.String)">
@@ -10357,6 +10357,33 @@
             <returns>
               A collection of attached annotations, no particular order, where the path of the annotation at the time of
               application is exactly <paramref name="fieldPath"/> or is nested thereunder.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.RelationTracker.AsPropertyChainOn(System.Type)">
+            <summary>
+              Produces a <see cref="T:Cybele.Core.PropertyChain"/> that can be used to access the Relation-type property being tracked
+              from a particular CLR type.
+            </summary>
+            <param name="source">
+              The starting-point CLR type.
+            </param>
+            <returns>
+              A <see cref="T:Cybele.Core.PropertyChain"/> that, when given an instance of <paramref name="source"/>, will produce the
+              value of the Relation-type property being tracked.
+            </returns>
+        </member>
+        <member name="M:Kvasir.Translation.RelationTracker.GetSyntheticTypenameOn(System.Type)">
+            <summary>
+              Produces the full, decorated typename of the <see cref="T:Kvasir.Translation.SyntheticType"/> implied by the current
+              <see cref="T:Kvasir.Translation.RelationTracker"/>.
+            </summary>
+            <param name="entity">
+              The "owning Entity" of the tracked Relation. The name of this Entity type will appear first in the implied
+              synthetic typename.
+            </param>
+            <returns>
+              The display-caliber name of the <see cref="T:Kvasir.Translation.SyntheticType"/> implied by the current
+              <see cref="T:Kvasir.Translation.RelationTracker"/> when considered "owned" by <paramref name="entity"/>.
             </returns>
         </member>
         <member name="T:Kvasir.Translation.SyntheticConstructorInfo">

--- a/src/Kvasir/Translation/RelationTracker.cs
+++ b/src/Kvasir/Translation/RelationTracker.cs
@@ -1,10 +1,12 @@
-﻿using Cybele.Extensions;
+﻿using Cybele.Core;
+using Cybele.Extensions;
 using Kvasir.Annotations;
 using Kvasir.Relations;
 using Optional;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 
 namespace Kvasir.Translation {
@@ -13,20 +15,15 @@ namespace Kvasir.Translation {
     /// </summary>
     internal sealed class RelationTracker {
         /// <summary>
-        ///   The name of the backing Relation-type property, accounting for any <see cref="NameAttribute">[Name]</see>
-        ///   annotation that has been applied.
+        ///   The value of the <c>[Name]</c> annotation applied to the backing Relation-type property, if any.
         /// </summary>
-        public string Name {
-            get {
-                return annotatedName_.ValueOr(Path);
-            }
-        }
+        public Option<string> AnnotatedName { get; private set; }
 
         /// <summary>
         ///   The access path, relative to some arbitrary "current" location in the translation process, at which
         ///   <see cref="Property"/> resides.
         /// </summary>
-        public string Path { get; }
+        public string Path => string.Join('.', decontextualizedAccessPath_);
 
         /// <summary>
         ///   The <see cref="PropertyInfo">property</see> defining the Relation.
@@ -43,30 +40,40 @@ namespace Kvasir.Translation {
             Debug.Assert(source is not null);
             Debug.Assert(source.PropertyType.IsInstanceOf(typeof(IRelation)) && source.PropertyType != typeof(IRelation));
 
+            AnnotatedName = Option.None<string>();
             Property = source;
-            Path = source.Name;
+            contextualizedAccessPath_ = new List<string>() { source.Name.Split('.')[^1] };
+            decontextualizedAccessPath_ = new List<string>() { source.Name.Split('.')[^1] };
             annotations_ = new Dictionary<string, List<Attribute>>();
-            annotatedName_ = Option.None<string>();
         }
 
         /// <summary>
-        ///   Constructs a new <see cref="RelationTracker"/> that is identical to another but with a different
-        ///   <see cref="Path"/>.
+        ///   Constructs a new <see cref="RelationTracker"/> that is identical to another but with an additional
+        ///   property prepended to its <see cref="Path"/>.
         /// </summary>
         /// <param name="source">
         ///   The source <see cref="RelationTracker"/>.
         /// </param>
-        /// <param name="path">
-        ///   The new <see cref="Path">access path</see>.
+        /// <param name="upstreamProperty">
+        ///   The additional property.
         /// </param>
-        private RelationTracker(RelationTracker source, string path) {
+        private RelationTracker(RelationTracker source, PropertyInfo upstreamProperty) {
             Debug.Assert(source is not null);
-            Debug.Assert(path is not null && path != "");
+            Debug.Assert(upstreamProperty is not null);
 
+            AnnotatedName = source.AnnotatedName;
             Property = source.Property;
-            Path = path;
             annotations_ = new Dictionary<string, List<Attribute>>(source.annotations_);
-            annotatedName_ = source.annotatedName_;
+
+            var contextualized = new List<string>(source.contextualizedAccessPath_);
+            var type = Nullable.GetUnderlyingType(upstreamProperty.PropertyType) ?? upstreamProperty.PropertyType;
+            var newContextualizedSegment = $"{type.DisplayName()} (from \"{upstreamProperty.Name.Split('.')[^1]}\")";
+            contextualized.Insert(0, newContextualizedSegment);
+            contextualizedAccessPath_ = contextualized;
+
+            var decontextualized = new List<string>(source.decontextualizedAccessPath_);
+            decontextualized.Insert(0, upstreamProperty.Name.Split('.')[^1]);
+            decontextualizedAccessPath_ = decontextualized;
         }
 
         /// <summary>
@@ -89,7 +96,7 @@ namespace Kvasir.Translation {
             if (annotation.AppliesHere) {
                 if (typeof(T) == typeof(NameAttribute)) {
                     Debug.Assert(annotation.AppliesHere);
-                    annotatedName_ = Option.Some((annotation.Annotation as NameAttribute)!.Name);
+                    AnnotatedName = Option.Some((annotation.Annotation as NameAttribute)!.Name);
                 }
                 else {
                     throw new InapplicableAnnotationException(context, annotation.Annotation, Property.PropertyType, MultiKind.Relation);
@@ -105,18 +112,19 @@ namespace Kvasir.Translation {
         }
 
         /// <summary>
-        ///   Prepend a segment to the <see cref="Path"/>.
+        ///   Prepends a property to the <see cref="Path"/>.
         /// </summary>
-        /// <param name="path">
-        ///   The new path segment.
+        /// <param name="property">
+        ///   The <see cref="PropertyInfo">property</see> to prepend to the <see cref="Path"/>. This also affects the
+        ///   <see cref="GetSyntheticTypenameOn(Type)">implied synthetic typename</see>.
         /// </param>
         /// <returns>
-        ///   A new <see cref="RelationTracker"/> that is equivalent to this one but with <paramref name="path"/> (and a
-        ///   following <c>.</c>) prepended to the <see cref="Path"/>.
+        ///   A new <see cref="RelationTracker"/> identical to the current one, but with <paramref name="property"/>
+        ///   prepended to the <see cref="Path"/>.
         /// </returns>
-        public RelationTracker ExtendPath(string path) {
-            Debug.Assert(path is not null && path != "");
-            return new RelationTracker(this, path + '.' + Path);
+        public RelationTracker Extend(PropertyInfo property) {
+            Debug.Assert(property is not null);
+            return new RelationTracker(this, property);
         }
 
         /// <summary>
@@ -142,8 +150,55 @@ namespace Kvasir.Translation {
             }
         }
 
+        /// <summary>
+        ///   Produces a <see cref="PropertyChain"/> that can be used to access the Relation-type property being tracked
+        ///   from a particular CLR type.
+        /// </summary>
+        /// <param name="source">
+        ///   The starting-point CLR type.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="PropertyChain"/> that, when given an instance of <paramref name="source"/>, will produce the
+        ///   value of the Relation-type property being tracked.
+        /// </returns>
+        public PropertyChain AsPropertyChainOn(Type source) {
+            Debug.Assert(source is not null);
 
+            var accessChain = new PropertyChain(source, decontextualizedAccessPath_[0]);
+            for (int idx = 1; idx < decontextualizedAccessPath_.Count; ++idx) {
+                if (Nullable.GetUnderlyingType(accessChain.PropertyType) is not null) {
+                    accessChain = accessChain.Append("Value");
+                }
+                accessChain = accessChain.Append(decontextualizedAccessPath_[idx]);
+            }
+
+            return accessChain;
+        }
+
+        /// <summary>
+        ///   Produces the full, decorated typename of the <see cref="SyntheticType"/> implied by the current
+        ///   <see cref="RelationTracker"/>.
+        /// </summary>
+        /// <param name="entity">
+        ///   The "owning Entity" of the tracked Relation. The name of this Entity type will appear first in the implied
+        ///   synthetic typename.
+        /// </param>
+        /// <returns>
+        ///   The display-caliber name of the <see cref="SyntheticType"/> implied by the current
+        ///   <see cref="RelationTracker"/> when considered "owned" by <paramref name="entity"/>.
+        /// </returns>
+        public string GetSyntheticTypenameOn(Type entity) {
+            Debug.Assert(entity is not null && entity.IsClass);
+
+            var first = entity.DisplayName();
+            var middle = contextualizedAccessPath_.SkipLast(1);
+            var last = $"<synthetic> `{decontextualizedAccessPath_[^1]}`";
+            return string.Join(" → ", Enumerable.Repeat(first, 1).Concat(middle).Append(last));
+        }
+
+
+        private readonly IReadOnlyList<string> contextualizedAccessPath_;
+        private readonly IReadOnlyList<string> decontextualizedAccessPath_;
         private readonly Dictionary<string, List<Attribute>> annotations_;
-        private Option<string> annotatedName_;
     }
 }

--- a/src/Kvasir/Translation/Synthetics/SyntheticType.cs
+++ b/src/Kvasir/Translation/Synthetics/SyntheticType.cs
@@ -190,13 +190,9 @@ namespace Kvasir.Translation {
 
             // These shenanigans are necessary to make sure that contextualized error messages display a string that is
             // consistent with that displayed for non-relation properties. In particular, the leading and trailing back
-            // ticks are omitted because they will be added by the Context class, but the interior ones are explicitly
-            // included.
-            var nameParts = tracker.Path.Split('.');
-            var first = tracker.Property.ReflectedType!.Name + '`';
-            var middle = nameParts.Skip(1).SkipLast(1).Select(n => $"`{n}`");
-            var last = "<synthetic> `" + nameParts[^1];
-            var name = string.Join(" → ", Enumerable.Repeat(first, 1).Concat(middle).Append(last));
+            // ticks are stripped because they will be added by the Context class, but the interior ones are kept.
+            var name = tracker.GetSyntheticTypenameOn(entity);
+            name = name[1..^1];
 
             return new SyntheticType(
                 name: name,

--- a/src/Kvasir/Translation/TranslateType.cs
+++ b/src/Kvasir/Translation/TranslateType.cs
@@ -80,7 +80,6 @@ namespace Kvasir.Translation {
             foreach (var property in source.GetProperties(flags).OrderBy(f => f.Name)) {
                 using var propGuard = context.Push(property);
                 var propType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
-                var propName = property.Name.Split('.')[^1];
 
                 var propCategory = property.TranslationCategory();
                 if (propCategory.Equals(PropertyCategory.Ambiguous)) {
@@ -124,7 +123,7 @@ namespace Kvasir.Translation {
                         performAssemblyCheck(propType);
                         var nestedGuard = context.Push(propType);
                         var fields = TranslateType(context, propType, allowRelations).Select(g => g.Clone()).ToList();
-                        var trackers = relationTrackersCache_[propType].Select(t => t.ExtendPath(propName)).ToList();
+                        var trackers = relationTrackersCache_[propType].Select(t => t.Extend(property)).ToList();
                         if (fields.IsEmpty() && trackers.IsEmpty()) {
                             throw new NotEnoughFieldsException(context, 1, 0);
                         }

--- a/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
+++ b/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
@@ -889,6 +889,21 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void RelationNestedWithinRelationNestedWithinAggregate_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(IntelligenceAgency);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NestedRelationException>()
+                .WithLocation("`IntelligenceAgency` → `Leadership` (from \"Board\") → <synthetic> `Roles` → Value")
+                .WithProblem("nested Relations are not supported")
+                .EndMessage();
+        }
+
         [TestMethod] public void RelationNestedWithinAggregateNestedWithinRelation_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -464,6 +464,23 @@ namespace UT.Kvasir.Translation {
             public RelationMap<string, RelationMap<string, double>> Measurements { get; init; } = new();
         }
 
+        // Test Scenario: Relation Nested Within Relation Nested Within Aggregate (✗not permitted✗)
+        public class IntelligenceAgency {
+            public struct Leadership {
+                public DateTime EffectiveStart { get; set; }
+                public DateTime? EffectiveEnd { get; set; }
+                public RelationMap<string, RelationSet<string>> Roles { get; }
+            }
+
+            [PrimaryKey] public string Name { get; set; } = "";
+            [PrimaryKey] public string Country { get; set; } = "";
+            public Leadership Board { get; set; }
+            public uint KnownAssassinations { get; set; }
+            public bool? PerformsCyberEspionage { get; set; }
+            public decimal Budget { get; set; }
+            public ulong Employees { get; set; }
+        }
+
         // Test Scenario: Relation Nested Within Aggregate Nested Within Relation (✗not permitted✗)
         public class Poll {
             public record struct Question(string Text, RelationSet<string> Answers);

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -568,6 +568,7 @@ Insurance Policy
 Integer
 Integer Sequence
 Integral
+Intelligence Agency
 Intern
 Internet Craze
 Interview


### PR DESCRIPTION
This commit fixes a bug that led to missing path information in error messages contextualizing Relations nested within Aggregates. The previous code implicitly assumed that the Relation was always on the top-level Entity, and could therefore get the first portion of the SyntheticType's typename from the reflected type of the RelationTracker's property. But this was wrong if the Relation was actually nested within an Aggregate; in that case, the reflected type was the Aggregate, and the Entity type (and any intermediate pathing) would be lost.

To solve this, I had to rework the RelationTracker a bit. A small amount was quality-of-life (specifically, the changs to the AnnotatedName) but the meat (specifically, extending via property and tracking both contextualized and decontextualized paths) were strictly necessary. I also moved some logic from other parts of the code base into the RelationTracker to avoid breaking encapsulation.