### PR TITLE
Insert Pre-Defined Rows on Table Creation

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -7307,7 +7307,8 @@
         </member>
         <member name="M:Kvasir.Transaction.Transactor.CreateTables">
             <summary>
-              Creates each of the constituent Principal and Relation Tables in the back-end database.
+              Creates each of the constituent Principal and Relation Tables in the back-end database. Any rows for
+              Pre-Defined Entities are inserted into their corresponding Principal Table.
             </summary>
             <exception cref="T:System.InvalidOperationException">
               if the transaction creating the necessary tables fails and is successfully rolled back.
@@ -11439,8 +11440,9 @@
             <param name="Extractor">The plan that can extract a row of data to be stored into the Principal Table.</param>
             <param name="Reconstitutor">The plan that can recreate a CLR object from a row of data stored in the Principal Table.</param>
             <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitute's the Primary Key in the Principal Table.</param>
+            <param name="PreDefinedInstances">The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</param>
         </member>
-        <member name="M:Kvasir.Translation.PrincipalTableDef.#ctor(Kvasir.Schema.ITable,Kvasir.Extraction.DataExtractionPlan,Kvasir.Reconstitution.DataReconstitutionPlan,Kvasir.Extraction.DataExtractionPlan)">
+        <member name="M:Kvasir.Translation.PrincipalTableDef.#ctor(Kvasir.Schema.ITable,Kvasir.Extraction.DataExtractionPlan,Kvasir.Reconstitution.DataReconstitutionPlan,Kvasir.Extraction.DataExtractionPlan,System.Collections.Generic.IReadOnlyList{System.Object})">
             <summary>
               The definition of a Principal Table.
             </summary>
@@ -11449,6 +11451,7 @@
             <param name="Extractor">The plan that can extract a row of data to be stored into the Principal Table.</param>
             <param name="Reconstitutor">The plan that can recreate a CLR object from a row of data stored in the Principal Table.</param>
             <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitute's the Primary Key in the Principal Table.</param>
+            <param name="PreDefinedInstances">The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</param>
         </member>
         <member name="P:Kvasir.Translation.PrincipalTableDef.Table">
             <summary>The schema model for the Principal Table.</summary>
@@ -11461,6 +11464,9 @@
         </member>
         <member name="P:Kvasir.Translation.PrincipalTableDef.KeyExtractor">
             <summary>The plan that can extract the subset of a row of data that constitute's the Primary Key in the Principal Table.</summary>
+        </member>
+        <member name="P:Kvasir.Translation.PrincipalTableDef.PreDefinedInstances">
+            <summary>The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</summary>
         </member>
         <member name="T:Kvasir.Translation.RelationTableDef">
             <summary>

--- a/src/Kvasir/Transaction/Transactor.cs
+++ b/src/Kvasir/Transaction/Transactor.cs
@@ -106,7 +106,8 @@ namespace Kvasir.Transaction {
         }
 
         /// <summary>
-        ///   Creates each of the constituent Principal and Relation Tables in the back-end database.
+        ///   Creates each of the constituent Principal and Relation Tables in the back-end database. Any rows for
+        ///   Pre-Defined Entities are inserted into their corresponding Principal Table.
         /// </summary>
         /// <exception cref="InvalidOperationException">
         ///   if the transaction creating the necessary tables fails and is successfully rolled back.
@@ -123,6 +124,13 @@ namespace Kvasir.Transaction {
                 command.ExecuteNonQuery();
             }
             TryCommitTransaction(transaction);
+
+            // Rather than do the ordering ourselves here, just let the insertion function handle it. This will also
+            // make everything on transaction, though that's not really super important.
+            var preDefineds = translations_.Values.SelectMany(translation => translation.Principal.PreDefinedInstances);
+            if (!preDefineds.IsEmpty()) {
+                Insert(preDefineds.ToList());
+            }
         }
 
         /// <summary>

--- a/src/Kvasir/Translation/TableDefs.cs
+++ b/src/Kvasir/Translation/TableDefs.cs
@@ -1,6 +1,7 @@
 ﻿using Kvasir.Extraction;
 using Kvasir.Reconstitution;
 using Kvasir.Schema;
+using System.Collections.Generic;
 
 namespace Kvasir.Translation {
     /// <summary>
@@ -11,11 +12,13 @@ namespace Kvasir.Translation {
     /// <param name="Extractor">The plan that can extract a row of data to be stored into the Principal Table.</param>
     /// <param name="Reconstitutor">The plan that can recreate a CLR object from a row of data stored in the Principal Table.</param>
     /// <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitute's the Primary Key in the Principal Table.</param>
+    /// <param name="PreDefinedInstances">The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</param>
     internal sealed record class PrincipalTableDef(
         ITable Table,
         DataExtractionPlan Extractor,
         DataReconstitutionPlan Reconstitutor,
-        DataExtractionPlan KeyExtractor
+        DataExtractionPlan KeyExtractor,
+        IReadOnlyList<object> PreDefinedInstances
     );
 
     /// <summary>

--- a/src/Kvasir/Translation/TranslateEntity.cs
+++ b/src/Kvasir/Translation/TranslateEntity.cs
@@ -119,13 +119,13 @@ namespace Kvasir.Translation {
             if (!IsPreDefined(source)) {
                 var reconstitutor = ReconstitutionHelper.MakeCreator(context, source, fieldGroups, false);
                 var creator = new DataReconstitutionPlan(reconstitutor);
-                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor);
+                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor, new List<object>());
             }
             else {
                 var instances = GetPreDefinedInstances(context, source);
                 var matcher = new KeyMatcher(() => instances, pkExtractor);
                 var creator = MakePreDefinedReconstitutionPlan(context, table, matcher, source);
-                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor);
+                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor, instances.ToList());
             }
 
             principalTableCache_.Add(source, principal);

--- a/test/UnitTests/Kvasir/Transaction/TableCreation.cs
+++ b/test/UnitTests/Kvasir/Transaction/TableCreation.cs
@@ -1,7 +1,10 @@
 ﻿using FluentAssertions;
+using Kvasir.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 using static UT.Kvasir.Transaction.TableCreation;
 
@@ -154,6 +157,36 @@ namespace UT.Kvasir.Transaction {
             inversesCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered(matrixCmd, (eigenvaluesCmd, inversesCmd));
             fixture.Transaction.Received(1).Commit();
+        }
+
+        [TestMethod] public void PreDefinedEntity() {
+            // Arrange
+            var fixture = new TestFixture(typeof(Dashavatara));
+
+            // Act
+            fixture.Transactor.CreateTables();
+            var createCmd = fixture.PrincipalCommands<Dashavatara>().CreateTableCommand;
+            var insertCmd = fixture.PrincipalCommands<Dashavatara>().InsertCommand(Enumerable.Empty<IReadOnlyList<DBValue>>());
+            var inserts = fixture.InsertionsFor(insertCmd);
+
+            // Assert
+            createCmd.Connection.Should().Be(fixture.Connection);
+            createCmd.Transaction.Should().Be(fixture.Transaction);
+            insertCmd.Connection.Should().Be(fixture.Connection);
+            insertCmd.Transaction.Should().Be(fixture.Transaction);
+            inserts.Should().HaveCount(10);
+            inserts.Should().ContainRow(Dashavatara.Matsaya.Index, Dashavatara.Matsaya.Name, Dashavatara.Matsaya.Form);
+            inserts.Should().ContainRow(Dashavatara.Kurma.Index, Dashavatara.Kurma.Name, Dashavatara.Kurma.Form);
+            inserts.Should().ContainRow(Dashavatara.Varaha.Index, Dashavatara.Varaha.Name, Dashavatara.Varaha.Form);
+            inserts.Should().ContainRow(Dashavatara.Narasimha.Index, Dashavatara.Narasimha.Name, Dashavatara.Narasimha.Form);
+            inserts.Should().ContainRow(Dashavatara.Vamana.Index, Dashavatara.Vamana.Name, Dashavatara.Vamana.Form);
+            inserts.Should().ContainRow(Dashavatara.Parashurama.Index, Dashavatara.Parashurama.Name, Dashavatara.Parashurama.Form);
+            inserts.Should().ContainRow(Dashavatara.Rama.Index, Dashavatara.Rama.Name, Dashavatara.Rama.Form);
+            inserts.Should().ContainRow(Dashavatara.Krishna.Index, Dashavatara.Krishna.Name, Dashavatara.Krishna.Form);
+            inserts.Should().ContainRow(Dashavatara.Buddha.Index, Dashavatara.Buddha.Name, Dashavatara.Buddha.Form);
+            inserts.Should().ContainRow(Dashavatara.Kalki.Index, Dashavatara.Kalki.Name, Dashavatara.Kalki.Form);
+            fixture.ShouldBeOrdered(createCmd, insertCmd);
+            fixture.Transaction.Received(2).Commit();
         }
 
         [TestMethod] public void TransactionRolledBack() {

--- a/test/UnitTests/Kvasir/Transaction/_Entities.cs
+++ b/test/UnitTests/Kvasir/Transaction/_Entities.cs
@@ -141,6 +141,30 @@ namespace UT.Kvasir.Transaction {
             public Traits MatrixTraits { get; set; }
         }
 
+        // Test Scenario: Pre-Defined Entity
+        [PreDefined] public class Dashavatara {
+            [PrimaryKey, Column(0)] public int Index { get; private init; }
+            [Column(1)] public string Name { get; private init; }
+            [Column(2)] public string Form { get; private init; }
+
+            public static Dashavatara Matsaya { get; } = new Dashavatara(1, "Matsaya", "fish");
+            public static Dashavatara Kurma { get; } = new Dashavatara(2, "Kurma", "tortoise");
+            public static Dashavatara Varaha { get; } = new Dashavatara(3, "Varaha", "boar");
+            public static Dashavatara Narasimha { get; } = new Dashavatara(4, "Narasimha", "man-lion");
+            public static Dashavatara Vamana { get; } = new Dashavatara(5, "Vamana", "dwarf-god");
+            public static Dashavatara Parashurama { get; } = new Dashavatara(6, "Parashurama", "Brahmin warrior");
+            public static Dashavatara Rama { get; } = new Dashavatara(7, "Rama", "god");
+            public static Dashavatara Krishna { get; } = new Dashavatara(8, "Krishna", "god");
+            public static Dashavatara Buddha { get; } = new Dashavatara(9, "Buddha", "enlightened individual");
+            public static Dashavatara Kalki { get; } = new Dashavatara(10, "Kalki", "prophesied warrior");
+
+            private Dashavatara(int index, string name, string form) {
+                Index = index;
+                Name = name;
+                Form = form;
+            }
+        }
+
         // Test Scenario: Transaction Rolled Back
         public class Bond {
             public enum Category { Corporate, Municipal, Treasury, Foreign }

--- a/test/UnitTests/Kvasir/Translation/EntityShapes.cs
+++ b/test/UnitTests/Kvasir/Translation/EntityShapes.cs
@@ -25,6 +25,7 @@ namespace UT.Kvasir.Translation {
                 .HaveField("Green").OfTypeUInt8().BeingNonNullable().And
                 .HaveField("Blue").OfTypeUInt8().BeingNonNullable().And
                 .HaveNoOtherFields();
+            translation.Principal.PreDefinedInstances.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsPartialClass() {
@@ -47,6 +48,7 @@ namespace UT.Kvasir.Translation {
                 .HaveField("RepublicanPVs").OfTypeUInt64().BeingNonNullable().And
                 .HaveField("RepublicanEVs").OfTypeUInt16().BeingNonNullable().And
                 .HaveNoOtherFields();
+            translation.Principal.PreDefinedInstances.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsStaticClass_IsError() {
@@ -81,6 +83,7 @@ namespace UT.Kvasir.Translation {
                 .HaveField("Message").OfTypeText().BeingNonNullable().And
                 .HaveField("Timestamp").OfTypeDateTime().BeingNonNullable().And
                 .HaveNoOtherFields();
+            translation.Principal.PreDefinedInstances.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsInternal() {
@@ -100,6 +103,7 @@ namespace UT.Kvasir.Translation {
                 .HaveField("NumHoles").OfTypeInt8().BeingNonNullable().And
                 .HaveField("IsBuckled").OfTypeBoolean().BeingNonNullable().And
                 .HaveNoOtherFields();
+            translation.Principal.PreDefinedInstances.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsStruct_IsError() {

--- a/test/UnitTests/Kvasir/Translation/PreDefinedEntities.cs
+++ b/test/UnitTests/Kvasir/Translation/PreDefinedEntities.cs
@@ -18,7 +18,6 @@ namespace UT.Kvasir.Translation {
             var translate = () => translator[source];
 
             // Assert
-            // Assert
             translate.Should().FailWith<NotEnoughInstancesException>()
                 .WithLocation("`StainedGlassWindow`")
                 .WithProblem("expected at least 2 pre-defined instances, but found 0")
@@ -33,7 +32,6 @@ namespace UT.Kvasir.Translation {
             // Act
             var translate = () => translator[source];
 
-            // Assert
             // Assert
             translate.Should().FailWith<NotEnoughInstancesException>()
                 .WithLocation("`Gulf`")
@@ -61,6 +59,19 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherCandidateKeys().And
                 .HaveNoOtherForeignKeys().And
                 .HaveNoOtherForeignKeys();
+            translation.Principal.PreDefinedInstances.Should().HaveCount(12);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.SimonI);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.Andrew);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.JamesI);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.John);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.Philip);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.Bartholomew);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.Thomas);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.Matthew);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.JamesII);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.Thaddeus);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.SimonII);
+            translation.Principal.PreDefinedInstances.Should().Contain(Disciple.Judas);
         }
 
         [TestMethod] public void PubliclyWriteableFieldProperty_IsError() {
@@ -127,6 +138,16 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherCandidateKeys().And
                 .HaveNoOtherForeignKeys().And
                 .HaveNoOtherForeignKeys();
+            translation.Principal.PreDefinedInstances.Should().HaveCount(9);
+            translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.QuestionMark);
+            translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.ExclamationMark);
+            translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.Period);
+            translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.Comma);
+            translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.QuotationMark);
+            translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.Apostrophe);
+            translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.Hyphen);
+            translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.OpenParenthesis);
+            translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.CloseParenthesis);
         }
 
         [TestMethod] public void PublicConstructor_IsError() {
@@ -173,6 +194,17 @@ namespace UT.Kvasir.Translation {
                     .WithOnDeleteBehavior(OnDelete.Cascade)
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
+            translation.Principal.PreDefinedInstances.Should().HaveCount(10);
+            translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Azorius);
+            translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Dimir);
+            translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Rakdos);
+            translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Gruul);
+            translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Selesnya);
+            translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Orzhov);
+            translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Izzet);
+            translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Golgari);
+            translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Boros);
+            translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Simic);
         }
 
         [TestMethod] public void AggregateNestedReferenceToPreDefinedEntity() {
@@ -200,6 +232,12 @@ namespace UT.Kvasir.Translation {
                     .WithOnDeleteBehavior(OnDelete.Cascade)
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
+            translation.Principal.PreDefinedInstances.Should().HaveCount(5);
+            translation.Principal.PreDefinedInstances.Should().Contain(MarxBrother.Chico);
+            translation.Principal.PreDefinedInstances.Should().Contain(MarxBrother.Harpo);
+            translation.Principal.PreDefinedInstances.Should().Contain(MarxBrother.Groucho);
+            translation.Principal.PreDefinedInstances.Should().Contain(MarxBrother.Gummo);
+            translation.Principal.PreDefinedInstances.Should().Contain(MarxBrother.Zeppo);
         }
 
         [TestMethod] public void RelationToPreDefinedEntity() {

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -328,6 +328,7 @@ D&D Spell
 D&D Weapon
 Dalai Lama
 Dam
+Dashavatara
 Data Center
 Data Structure
 Database Field


### PR DESCRIPTION
This commit updates the logic for the CreateTable function of the Transactor to insert all rows for all Pre-Defined Entities at the same time. To do this, the pre-defined instances are now stored as a list of objects on the PrincipalTableDef; for regular Entities, this list is empty. All pre-defined instances are inserted as a single transaction after the transaction to create the tables is commited; this way, any database providers that don't support concurrent transactions or mixing of DDL and DML are satisfied.

This resolves #133.