### PR TITLE
When Deleting a Row of an Associative Relation during an Entity Update, Pass Only Primary Key Fields

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -7201,10 +7201,24 @@
               Implementations may, however, handle such events manually (such as if <c>ON DELETE</c> behavior is not
               supported.)
             </remarks>
-            <param name="rows">
-              The rows of data that should be deleted. Each row can either be the full row of data <i>OR</i> the Primary
-              Key of the "owning Entity."
+            <param name="keys">
+              The "Deletion Keys" of the rows of data that should be deleted. If the <see cref="T:Kvasir.Transaction.ICommands"/> instance is
+              responsible for a Principal Table, this should be the Primary Key; otherwise, it should be the Primary Key
+              of the "owning Entity" of the relation.
             </param>
+            <note>
+              The expected shape of the <paramref name="keys"/> depends on whether the <see cref="T:Kvasir.Transaction.ICommands"/> instance
+              is targeting a Principal Table or a Relation Table. Each element can always be the Primary Key of a single
+              row to be deleted; however, if the target is a Relation Table, each element can also be the Primary Key of
+              an owning Entity whose entire Relation is to be deleted. This represents an optimization opportunity over
+              performing several individual row deletes. Note that, in general, we cannot support accepting the full row
+              of data and then extracting the Primary Key; if we tried to do this, we would have an ambiguity in the
+              case where the full row is the Primary Key, but the Fields in the Primary Key are listed in a different
+              order than their columns naturally fall. In such a case, we'd be unable to determine which orientation the
+              values represent, especially if there isn't enough type-based information to discriminate (e.g. if all the
+              Fields are of the same type). If the Primary Key is, in fact, the full row, then obviously the full row
+              can be provided, though the Fields must be present in the order matching that of the Primary Key.
+            </note>
         </member>
         <member name="T:Kvasir.Transaction.ICommandsFactory">
             <summary>

--- a/src/Kvasir/Transaction/ICommands.cs
+++ b/src/Kvasir/Transaction/ICommands.cs
@@ -54,10 +54,24 @@ namespace Kvasir.Transaction {
         ///   Implementations may, however, handle such events manually (such as if <c>ON DELETE</c> behavior is not
         ///   supported.)
         /// </remarks>
-        /// <param name="rows">
-        ///   The rows of data that should be deleted. Each row can either be the full row of data <i>OR</i> the Primary
-        ///   Key of the "owning Entity."
+        /// <param name="keys">
+        ///   The "Deletion Keys" of the rows of data that should be deleted. If the <see cref="ICommands"/> instance is
+        ///   responsible for a Principal Table, this should be the Primary Key; otherwise, it should be the Primary Key
+        ///   of the "owning Entity" of the relation.
         /// </param>
-        IDbCommand DeleteCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
+        /// <note>
+        ///   The expected shape of the <paramref name="keys"/> depends on whether the <see cref="ICommands"/> instance
+        ///   is targeting a Principal Table or a Relation Table. Each element can always be the Primary Key of a single
+        ///   row to be deleted; however, if the target is a Relation Table, each element can also be the Primary Key of
+        ///   an owning Entity whose entire Relation is to be deleted. This represents an optimization opportunity over
+        ///   performing several individual row deletes. Note that, in general, we cannot support accepting the full row
+        ///   of data and then extracting the Primary Key; if we tried to do this, we would have an ambiguity in the
+        ///   case where the full row is the Primary Key, but the Fields in the Primary Key are listed in a different
+        ///   order than their columns naturally fall. In such a case, we'd be unable to determine which orientation the
+        ///   values represent, especially if there isn't enough type-based information to discriminate (e.g. if all the
+        ///   Fields are of the same type). If the Primary Key is, in fact, the full row, then obviously the full row
+        ///   can be provided, though the Fields must be present in the order matching that of the Primary Key.
+        /// </note>
+        IDbCommand DeleteCommand(IEnumerable<IReadOnlyList<DBValue>> keys);
     }
 }

--- a/src/Kvasir/Transaction/Transactor.cs
+++ b/src/Kvasir/Transaction/Transactor.cs
@@ -297,8 +297,9 @@ namespace Kvasir.Transaction {
                     foreach (var entity in mapping[translation.CLRSource]) {
                         var ownerFields = translation.Principal.KeyExtractor.ExtractFrom(entity);
                         var relationFields = relation.Extractor.ExtractFrom(entity);
+                        var relationPKFieldsCount = relation.Table.PrimaryKey.Fields.Count - ownerFields.Count();
 
-                        deleteRows.AddRange(relationFields.Deletions.Select(r => ownerFields.Concat(r).ToList()));
+                        deleteRows.AddRange(relationFields.Deletions.Select(r => ownerFields.Concat(r.Take(relationPKFieldsCount)).ToList()));
                         updateRows.AddRange(relationFields.Modifications.Select(r => ownerFields.Concat(r).ToList()));
                         insertRows.AddRange(relationFields.Insertions.Select(r => ownerFields.Concat(r).ToList()));
 

--- a/test/UnitTests/Kvasir/Transaction/_Entities.cs
+++ b/test/UnitTests/Kvasir/Transaction/_Entities.cs
@@ -807,13 +807,26 @@ namespace UT.Kvasir.Transaction {
             [Column(3)] public double TelevisionRating { get; set; }
         }
 
-        // Test Scenario: Single Instance of Single Entity with Scalar Relation of Deleted Elements
+        // Test Scenario: Single Instance of Single Entity with Scalar Non-Associative Relation of Deleted Elements
         public class Guacamole {
             [PrimaryKey, Column(0)] public Guid GuacamoleID { get; set; }
             [Column(1)] public string Preparer { get; set; } = "";
             [Column(2)] public ushort NumServings { get; set; }
             public RelationSet<string> Ingredients { get; init; } = new();
             [Column(3)] public bool MadeInMolcajete { get; set; }
+        }
+
+        // Test Scenario: Single Instance of Single Entity with Scalar Associative Relation of Deleted Elements
+        public class EyeDrops {
+            public enum Condition { Astigmatism, NearSightedness, FarSightedness, Glaucoma, Cataracts, Conjunctivitis }
+
+            [PrimaryKey, Column(0)] public Guid DropsID { get; set; }
+            [Column(1)] public string BrandName { get; set; } = "";
+            [Column(2)] public ulong Prescriptions { get; set; }
+            public RelationMap<Condition, bool> TreatmentPlan { get; init; } = new();
+            [Column(3)] public bool SafeForChildren { get; set; }
+            [Column(4)] public bool Dilatory { get; set; }
+            [Column(5)] public sbyte MaxDropsPerDay { get; set; }
         }
 
         // Test Scenario: Single Instance of Single Entity with Scalar Relation of New Elements

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -419,6 +419,7 @@ Existentialist
 Exorcism
 Experiment
 Expiration
+Eye Drops
 Eyeglasses
 Facebook Post
 Fact Check


### PR DESCRIPTION
This commit fixes a bug whereby we were passing too many Fields to the ICommand.Delete function when handling deleted rows of an associative Relation while updating an Entity. Previously, in such a circumstance, we passed the entire row to the Delete function; for Maps and OrderedLists, this included more than just the key/index, which is enough to uniquely identify the row to be deleted. This commit fixes that so the minimal amount of data is forwarded. In addition, this commit update the documentation of the ICommand.Delete function to make it clear exactly what is expected to be passed.