### PR TITLE
Switch to Using LONGTEXT for Unbounded String Fields in MySQL

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -1619,6 +1619,14 @@
         <member name="M:Kvasir.Providers.MySQL.Commands.DeleteCommand(System.Collections.Generic.IEnumerable{System.Collections.Generic.IReadOnlyList{Kvasir.Schema.DBValue}})">
             <inheritdoc/>
         </member>
+        <member name="T:Kvasir.Providers.MySQL.CommandsFactory">
+            <summary>
+              An implementation of the <see cref="T:Kvasir.Transaction.ICommandsFactory"/> interface for a MySQL provider.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Providers.MySQL.CommandsFactory.CreateCommands(Kvasir.Schema.ITable,System.Boolean)">
+            <inheritdoc/>
+        </member>
         <member name="T:Kvasir.Providers.MySQL.IConstraintDecl">
             <summary>
               A type tag to be used as the return value for a MySQL <see cref="T:Kvasir.Transcription.IConstraintDeclBuilder`1"/>
@@ -1731,7 +1739,7 @@
         <member name="T:Kvasir.Providers.MySQL.FieldDecl">
             <summary>
               An intermediate for a MySQL declaration of a Field that allows for changing the default textual backing type
-              from <c>TEXT</c> to <c>VARCHAR(N)</c>.
+              from <c>LONGTEXT</c> to <c>VARCHAR(N)</c>.
             </summary>
         </member>
         <member name="P:Kvasir.Providers.MySQL.FieldDecl.Name">

--- a/src/Kvasir/Providers/MySQL/FieldBuilder.cs
+++ b/src/Kvasir/Providers/MySQL/FieldBuilder.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace Kvasir.Providers.MySQL {
     /// <summary>
     ///   An intermediate for a MySQL declaration of a Field that allows for changing the default textual backing type
-    ///   from <c>TEXT</c> to <c>VARCHAR(N)</c>.
+    ///   from <c>LONGTEXT</c> to <c>VARCHAR(N)</c>.
     /// </summary>
     internal struct FieldDecl {
         /// <summary>The name of the Field being declared.</summary>
@@ -38,10 +38,10 @@ namespace Kvasir.Providers.MySQL {
         ///   The maximum length.
         /// </param>
         public void EnforceMaximumLength(ulong maxLength) {
-            // We can't just do a find-and-replace of TEXT, even with spaces surrounding it, because that specific
+            // We can't just do a find-and-replace of LONGTEXT, even with spaces surrounding it, because that specific
             // sequence may appear in the literal default value. The C# string.Replace library method has no way to
             // indicate "replace only the first instance."
-            var startIdx = Name.Length + 7;         // +2 for the backticks, +1 for space, +4 for TEXT
+            var startIdx = Name.Length + 11;         // +2 for the backticks, +1 for space, +8 for LONGTEXT
             var varchar = $"VARCHAR({maxLength})";
             declaration_ = $"{Name.Render()} {varchar}{declaration_[startIdx..]}";
         }
@@ -121,7 +121,7 @@ namespace Kvasir.Providers.MySQL {
                 declaration_ = declaration_.Replace(TYPE_PLACEHOLDER, "FLOAT");
             }
             else if (dataType == DBType.Text) {
-                declaration_ = declaration_.Replace(TYPE_PLACEHOLDER, "TEXT");
+                declaration_ = declaration_.Replace(TYPE_PLACEHOLDER, "LONGTEXT");
             }
             else if (dataType == DBType.UInt16) {
                 declaration_ = declaration_.Replace(TYPE_PLACEHOLDER, "SMALLINT UNSIGNED");

--- a/test/UnitTests/Kvasir/Providers/MySQL.cs
+++ b/test/UnitTests/Kvasir/Providers/MySQL.cs
@@ -1534,7 +1534,7 @@ namespace UT.Kvasir.Providers {
 
             // Assert
             intermediate.Name.Should().Be(name.ToString());
-            decl.Should().Be($"`{name}` TEXT");
+            decl.Should().Be($"`{name}` LONGTEXT");
         }
 
         [TestMethod] public void Type_Varchar() {
@@ -1925,7 +1925,7 @@ namespace UT.Kvasir.Providers {
 
             // Assert
             intermediate.Name.Should().Be(name.ToString());
-            decl.Should().Be($"`{name}` TEXT DEFAULT \"{defaultValue}\"");
+            decl.Should().Be($"`{name}` LONGTEXT DEFAULT \"{defaultValue}\"");
         }
 
         [TestMethod] public void Default_Varchar() {
@@ -2064,12 +2064,12 @@ namespace UT.Kvasir.Providers {
             decl.Should().Be($"`{name}` BINARY(16) DEFAULT NULL");
         }
 
-        [TestMethod] public void VarcharWithUppercaseTextInDefaultValue() {
+        [TestMethod] public void VarcharWithUppercaseLongtextInDefaultValue() {
             // Arrange
             var name = new FieldName("Tartu");
             var type = DBType.Text;
             var maxLength = 4501UL;
-            var defaultValue = "DEFAULT CONTAINS THE WORD TEXT WITH SPACES";
+            var defaultValue = "DEFAULT CONTAINS THE WORD LONGTEXT WITH SPACES";
 
             // Act
             var builder = new FieldBuilder();
@@ -2150,8 +2150,8 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void VarcharFields() {
             // Arrange
             var name = new TableName("HaShulkhan");
-            var field0 = new FieldDecl(new FieldName("East Rutherford"), "`East Rutherford` TEXT NOT NULL");
-            var field1 = new FieldDecl(new FieldName("West Bloomfield"), "`West Bloomfield` TEXT NOT NULL");
+            var field0 = new FieldDecl(new FieldName("East Rutherford"), "`East Rutherford` LONGTEXT NOT NULL");
+            var field1 = new FieldDecl(new FieldName("West Bloomfield"), "`West Bloomfield` LONGTEXT NOT NULL");
             var constraint0 = new MaxLengthConstraintDecl(field0.Name, 153);
             var constraint1 = new MaxLengthConstraintDecl(field1.Name, 22);
             var pk = new SqlSnippet($"PRIMARY KEY (`{field0.Name}`, `{field1.Name}`)");
@@ -2178,7 +2178,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void CandidateKeys() {
             // Arrange
             var name = new TableName("LaMesa");
-            var field0 = new FieldDecl(new FieldName("Greenville"), "`Greenville` TEXT NOT NULL");
+            var field0 = new FieldDecl(new FieldName("Greenville"), "`Greenville` LONGTEXT NOT NULL");
             var field1 = new FieldDecl(new FieldName("Buffalo Grove"), "`Buffalo Grove` BIGINT UNSIGNED NOT NULL");
             var field2 = new FieldDecl(new FieldName("Grambling"), "`Grambling` FLOAT NOT NULL");
             var pk = new SqlSnippet($"PRIMARY KEY (`{field1.Name}`)");
@@ -2197,7 +2197,7 @@ namespace UT.Kvasir.Providers {
             // Assert
             decl.Should().Be(
                 $"CREATE TABLE IF NOT EXISTS `{name}`\n" +
-                "`Greenville` TEXT NOT NULL\n" +
+                "`Greenville` LONGTEXT NOT NULL\n" +
                 "`Buffalo Grove` BIGINT UNSIGNED NOT NULL\n" +
                 "`Grambling` FLOAT NOT NULL\n" +
                 $"{pk}\n" +
@@ -2236,7 +2236,7 @@ namespace UT.Kvasir.Providers {
             // Arrange
             var name = new TableName("ToTrapezi");
             var field0 = new FieldDecl(new FieldName("Santa Claus"), "`Santa Claus` INT UNSIGNED NOT NULL");
-            var field1 = new FieldDecl(new FieldName("Independence"), "`Independence` TEXT NOT NULL");
+            var field1 = new FieldDecl(new FieldName("Independence"), "`Independence` LONGTEXT NOT NULL");
             var pk = new SqlSnippet($"PRIMARY KEY (`{field0.Name}`");
             var check = new BasicConstraintDecl(new SqlSnippet($"CHECK (`{field0}` <= 200000)"));
 
@@ -2253,7 +2253,7 @@ namespace UT.Kvasir.Providers {
             decl.Should().Be(
                 $"CREATE TABLE IF NOT EXISTS `{name}`\n" +
                 "`Santa Claus` INT UNSIGNED NOT NULL\n" +
-                "`Independence` TEXT NOT NULL\n" +
+                "`Independence` LONGTEXT NOT NULL\n" +
                 $"{pk}\n" +
                 check.DDL.ToString()
             );
@@ -2263,10 +2263,10 @@ namespace UT.Kvasir.Providers {
             // Arrange
             var name = new TableName("IlTavolo");
             var field0 = new FieldDecl(new FieldName("Appomattox"), "`Appomattox` BIGINT UNSIGNED NOT NULL");
-            var field1 = new FieldDecl(new FieldName("Chickamauga"), "`Chickamauga` TEXT NOT NULL DEFAULT \"--none--\"");
+            var field1 = new FieldDecl(new FieldName("Chickamauga"), "`Chickamauga` LONGTEXT NOT NULL DEFAULT \"--none--\"");
             var field2 = new FieldDecl(new FieldName("Kitty Hawk"), "`Kitty Hawk` INT DEFAULT NULL");
             var field3 = new FieldDecl(new FieldName("Harpers Ferry"), "`Harpers Ferry` BOOLEAN NOT NULL");
-            var field4 = new FieldDecl(new FieldName("La Jolla"), "`La Jolla` TEXT NOT NULL");
+            var field4 = new FieldDecl(new FieldName("La Jolla"), "`La Jolla` LONGTEXT NOT NULL");
             var field5 = new FieldDecl(new FieldName("Compton"), "`Compton` INT UNSIGNED NOT NULL");
             var pk = new SqlSnippet($"PRIMARY KEY (`{field0.Name}`, `{field5.Name}`)");
             var ck0 = new SqlSnippet($"UNIQUE (`{field2.Name}`)");
@@ -2301,7 +2301,7 @@ namespace UT.Kvasir.Providers {
                 $"`Chickamauga` VARCHAR({check0.MaxLength}) NOT NULL DEFAULT \"--none--\"\n" +
                 "`Kitty Hawk` INT DEFAULT NULL\n" +
                 "`Harpers Ferry` BOOLEAN NOT NULL\n" +
-                "`La Jolla` TEXT NOT NULL\n" +
+                "`La Jolla` LONGTEXT NOT NULL\n" +
                 "`Compton` INT UNSIGNED NOT NULL\n" +
                 $"{pk}\n" +
                 $"{ck0}\n" +
@@ -2436,9 +2436,9 @@ namespace UT.Kvasir.Providers {
             command.CommandText.Should().Be(
                 $"CREATE TABLE IF NOT EXISTS `{table.Name}`\n" +
                 "`Date` DATETIME NOT NULL\n" +
-                "`Ship` TEXT NOT NULL\n" +
-                "`LeadMutineer` TEXT\n" +
-                "`OustedCaptain` TEXT NOT NULL\n" +
+                "`Ship` LONGTEXT NOT NULL\n" +
+                "`LeadMutineer` LONGTEXT\n" +
+                "`OustedCaptain` LONGTEXT NOT NULL\n" +
                 "`Casualties` INT UNSIGNED NOT NULL\n" +
                 "PRIMARY KEY (`Date`, `Ship`);"
             );
@@ -2460,7 +2460,7 @@ namespace UT.Kvasir.Providers {
             command.Transaction.Should().BeNull();
             command.CommandText.Should().Be(
                 $"CREATE TABLE IF NOT EXISTS `{relationTable.Name}`\n" +
-                "`CyrillicLetter.LetterName` TEXT NOT NULL\n" +
+                "`CyrillicLetter.LetterName` LONGTEXT NOT NULL\n" +
                 "`Key` BIGINT UNSIGNED NOT NULL\n" +
                 "`Value` CHAR(1) NOT NULL\n" +
                 "PRIMARY KEY (`CyrillicLetter.LetterName`, `Key`)\n" +
@@ -2483,8 +2483,8 @@ namespace UT.Kvasir.Providers {
             command.Transaction.Should().BeNull();
             command.CommandText.Should().Be(
                 $"CREATE TABLE IF NOT EXISTS `{table.Name}`\n" +
-                "`FirstName` TEXT NOT NULL\n" +
-                "`LastName` TEXT NOT NULL\n" +
+                "`FirstName` LONGTEXT NOT NULL\n" +
+                "`LastName` LONGTEXT NOT NULL\n" +
                 "`Birthdate` DATETIME NOT NULL\n" +
                 "PRIMARY KEY (`FirstName`, `LastName`);"
             );


### PR DESCRIPTION
This commit switches the MySQL translation of text-type Fields to be LONGTEXT by default, instead of TEXT. The rules for when such a Field becomes a VARCHAR have not changed. I'm doing this because LONGTEXT affords the largest amount of potential space, so that makes the most sense for something that is truly unbounded