### PR TITLE
Simplify Relation Interfaces

### DIFF
--- a/src/Kvasir/Relations/RelationList.cs
+++ b/src/Kvasir/Relations/RelationList.cs
@@ -52,8 +52,8 @@ namespace Kvasir.Relations {
     /// <seealso cref="RelationSet{T}"/>
     /// <seealso cref="RelationMap{TKey, TValue}"/>
     /// <seealso cref="RelationOrderedList{T}"/>
-    public sealed class RelationList<T> : ICollection<T>, IEnumerable, IEnumerable<T>, IList, IList<T>,
-        IReadOnlyCollection<T>, IReadOnlyList<T>, IReadOnlyRelationList<T>, IRelation where T : notnull {
+    public sealed class RelationList<T> : IList, IList<T>, IReadOnlyList<T>, IReadOnlyRelationList<T>, IRelation
+        where T : notnull {
 
         // *************************************** PROPERTIES ***************************************
 

--- a/src/Kvasir/Relations/RelationMap.cs
+++ b/src/Kvasir/Relations/RelationMap.cs
@@ -59,10 +59,8 @@ namespace Kvasir.Relations {
     /// <seealso cref="RelationList{T}"/>
     /// <seealso cref="RelationSet{T}"/>
     /// <seealso cref="RelationOrderedList{T}"/>
-    public sealed class RelationMap<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>>, IDictionary,
-        IDictionary<TKey, TValue>, IEnumerable<KeyValuePair<TKey, TValue>>,
-        IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>,
-        IReadOnlyRelationMap<TKey, TValue>, IRelation where TKey : notnull  {
+    public sealed class RelationMap<TKey, TValue> : IDictionary, IDictionary<TKey, TValue>,
+        IReadOnlyDictionary<TKey, TValue>, IReadOnlyRelationMap<TKey, TValue>, IRelation where TKey : notnull  {
 
         // *************************************** PROPERTIES ***************************************
 

--- a/src/Kvasir/Relations/RelationOrderedList.cs
+++ b/src/Kvasir/Relations/RelationOrderedList.cs
@@ -56,8 +56,8 @@ namespace Kvasir.Relations {
     /// <seealso cref="RelationList{T}"/>
     /// <seealso cref="RelationSet{T}"/>
     /// <seealso cref="RelationMap{TKey, TValue}"/>
-    public sealed class RelationOrderedList<T> : ICollection<T>, IEnumerable, IEnumerable<T>, IList, IList<T>,
-        IReadOnlyCollection<T>, IReadOnlyList<T>, IReadOnlyRelationOrderedList<T>, IRelation where T : notnull {
+    public sealed class RelationOrderedList<T> : IList, IList<T>, IReadOnlyList<T>, IReadOnlyRelationOrderedList<T>,
+        IRelation where T : notnull {
 
         // *************************************** PROPERTIES ***************************************
 

--- a/src/Kvasir/Relations/RelationSet.cs
+++ b/src/Kvasir/Relations/RelationSet.cs
@@ -47,8 +47,8 @@ namespace Kvasir.Relations {
     /// <seealso cref="RelationList{T}"/>
     /// <seealso cref="RelationMap{TKey, TValue}"/>
     /// <seealso cref="RelationOrderedList{T}"/>
-    public sealed class RelationSet<T> : ICollection<T>, IEnumerable<T>, IReadOnlyCollection<T>,
-        IReadOnlyRelationSet<T>, IReadOnlySet<T>, IRelation, ISet<T> where T : notnull {
+    public sealed class RelationSet<T> : IReadOnlyRelationSet<T>, IReadOnlySet<T>, IRelation, ISet<T>
+        where T : notnull {
 
         // *************************************** PROPERTIES ***************************************
 


### PR DESCRIPTION
This commit removes a number of interfaces explicitly listed for the four Relation containers, since those interfaces were already present through others. For example, IEnumerable<T> is implied by IList<T>, and therefore does not need to be listed in the file directly. There is no impact to correctness, only to brevity.