### PR TITLE
Translation of Localizations

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -1564,6 +1564,150 @@
               A triple of lists describing the data <see cref="T:Kvasir.Extraction.RelationExtractionPlan">extracted from a Relation</see>.
             </summary>
         </member>
+        <member name="T:Kvasir.Localization.ILocalization">
+            <summary>
+              The internal framework interface denoting a custom collection type that serves as a mapping of localized
+              values.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Localization.ILocalization.Triplet">
+            <summary>
+              The type of the Localization triplet. This should be three-element tuple where the first constituent type
+              is the type of the localization key, the second is the type of the locale, and the third is the type of
+              the localized value.
+            </summary>
+            <remarks>
+              A few notes about this. We need something that is <see langword="static"/> so that we can access its value
+              via reflection when holding just the type, which is the situation we find ourself in when doing
+              Translation. However, for mocking purposes, we also need to be able to use <see cref="T:Kvasir.Localization.ILocalization"/> as
+              a generic type parameter, which we cannot do if this property were <see langword="abstract"/>. We
+              therefore make it regular <see langword="virtual"/> with an error-throwing base implementation. While this
+              isn't ideal (technically, an implementation could choose not to override the base functionality), it's not
+              a huge deal because the property is <c>internal</c>, and we can write exhaustive tests for the
+              implementations authored within Kvasir itself.
+            </remarks>
+        </member>
+        <member name="T:Kvasir.Localization.Localization`3">
+            <summary>
+              A collection of localized data that tracks the state of its locale-value mappings for interaction with a
+              back-end database.
+            </summary>
+            <remarks>
+              <para>
+                The <see cref="T:Kvasir.Localization.Localization`3"/> class is a first-class data structure in Kvasir for
+                representing semantics that have different values in different circumstances. The canonical example of this
+                is text, which changes according to language; other examples may be measurements in imperial versus metric
+                or dates according to different calendars. These modes are called "locales" and the value of a semantic in
+                a particular locale the "localized value" or "localization." The semantic being localized is known as the
+                "localization key" and is simply an identifier by which the localizations are grouped.
+              </para>
+              <para>
+                Every locale-value pair in a <see cref="T:Kvasir.Localization.Localization`3"/> is in one of three states:
+                <c>NEW</c>, <c>SAVED</c>, or <c>DELETED</c>. Each state corresponds to the action or actions that should be
+                taken with respect to that item to synchronize the back-end database table corresponding to the
+                Localization. An item enters the <c>NEW</c> state when it is first added; when the collection is
+                canonicalized, each <c>NEW</c> item transitions to the <c>SAVED</c> state, indicating that it does not need
+                to be written to the database on the next write. When a <c>SAVED</c> item is removed from the collection, it
+                transitions to the <c>DELETED</c> state; <c>NEW</c> items do not transition to <c>DELETED</c>. Note that if
+                a <c>SAVED</c> item is deleted and then re-added, it will be re-added in the <c>SAVED</c> state.
+              </para>
+              <para>
+                The <see cref="T:Kvasir.Localization.Localization`3"/> does not support the <c>MODIFIED</c> state; instead,
+                each locale-value pair is treated as its own unit. This means that changing the value localized for an
+                existing locale results in two separate operations in the back-end database: first a removal of the old
+                locale-value pair, then an insertion of the new one. This behavior <i>may</i> change in the future, so
+                clients should not rely on it. The guarantee, however, is that Kvasir will properly respond to an overwrite
+                by ensuring that the resulting back-end database contains only the new locale-value pair.
+              </para>
+              <para>
+                Items used for the value in a <see cref="T:Kvasir.Localization.Localization`3"/> should be immutable:
+                structs, <see cref="T:System.String"/>, etc. This is because read access is <i>not</i> tracked: when using mutable
+                values, it is possible for the user to access an item (e.g. through <c>operator[]</c>) and mutate that value
+                without the collection knowing, preventing the change from being reflected in the back-end database. This
+                also means that actions that convert the collection into another form will <i>copy</i> the elements,
+                ensuring that the tracing data remains up-to-date.
+              </para>
+              <para>
+                A <see cref="T:Kvasir.Localization.Localization`3"/> does not permit duplicate locales, but it does support
+                duplicate values.
+              </para>
+            </remarks>
+            <typeparam name="TKey">
+              The type of the "localization key" for the Localization.
+            </typeparam>
+            <typeparam name="TLocale">
+              The type of the locale for which values in the Localization are localized.
+            </typeparam>
+            <typeparam name="TValue">
+              The type of the localized values.
+            </typeparam>
+        </member>
+        <member name="P:Kvasir.Localization.Localization`3.Key">
+            <summary>
+              The localization key of the Localization.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Localization.Localization`3.Item(`1)">
+            <summary>
+              Gets or sets the localized value for a specified locale.
+            </summary>
+            <remarks>
+              By default, a <see cref="T:Kvasir.Localization.Localization`3"/> is read-only. (This is just an annoying
+              artifact of the overall design and limitations within C#.) Derived classes are encouraged to enable
+              writeability by providing a <c>new</c> implementation of the <c>this[]</c> operator and delegating to the
+              base class.
+            </remarks>
+            <param name="locale">
+              [GET] The locale of the localized value to return.
+              [SET] The locale of the new localized value.
+            </param>
+            <returns>
+              [GET] The value localized for <paramref name="locale"/>.
+            </returns>
+            <exception cref="T:System.ArgumentException">
+              [GET] If there is no localization for <paramref name="locale"/>.
+            </exception>
+        </member>
+        <member name="P:Kvasir.Localization.Localization`3.Relation">
+            <summary>
+              The change-tracked collection of localizations.
+            </summary>
+            <remarks>
+              This property is <c>internal</c> so that it is inaccessible to derived classes but accessible to Kvasir.
+              This is the property through which change tracking occurs, and therefore the property through which the
+              framework implements extraction and reconstitution.
+            </remarks>
+        </member>
+        <member name="M:Kvasir.Localization.Localization`3.#ctor(`0)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Localization.Localization`3"/>.
+            </summary>
+            <param name="localizationKey">
+              The <see cref="P:Kvasir.Localization.Localization`3.Key">localization key</see> of the new Localization.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+              if <paramref name="localizationKey"/> is <see langword="null"/>.
+            </exception>
+        </member>
+        <member name="P:Kvasir.Localization.Localization`3.Localizations">
+            <summary>
+              The collection of localized values, as a read-only mapping.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Localization.Localization`3.op_Implicit(Kvasir.Localization.Localization{`0,`1,`2})~`0">
+            <summary>
+              Implicitly converts a Localization to its localization key.
+            </summary>
+            <param name="localization">
+              The <see cref="T:Kvasir.Localization.Localization`3"/> to convert.
+            </param>
+            <returns>
+              The <see cref="P:Kvasir.Localization.Localization`3.Key">localization key</see> of <paramref name="localization"/>.
+            </returns>
+        </member>
+        <member name="P:Kvasir.Localization.Localization`3.Kvasir#Localization#ILocalization#Triplet">
+            <inheritdoc/>
+        </member>
         <member name="T:Kvasir.Providers.MySQL.BuilderFactory">
             <summary>
               An implementation of the <see cref="T:Kvasir.Transcription.IBuilderFactory`5"/>
@@ -8056,6 +8200,44 @@
               a <c>[NonNullable]</c> annotation applied.
             </exception>
         </member>
+        <member name="M:Kvasir.Translation.Translator.TranslateLocalizationTables(System.Type)">
+            <summary>
+              Translates the Localization Tables referenced by an Entity Type.
+            </summary>
+            <remarks>
+              Localization Tables exist per type of Localization, meaning that the same Localization Type present on
+              multiple Entities will produce the same shared Table. Therefore, each Localization is translated only the
+              first time the Localization Type is encountered. There is, however, a unique Extraction and Reconstitution
+              Plan associated with each instance of a Localization to ensure that data is properly handled.
+            </remarks>
+            <param name="source">
+              The referencing Entity Type.
+            </param>
+            <returns>
+              A collection of <see cref="F:Kvasir.Translation.Translator.localizationTableCache_">Table definitions</see>, in no particular order, for
+              the Localization Tables referenced by <paramref name="source"/>.
+            </returns>
+            <exception cref="T:Kvasir.Translation.DuplicateNameException">
+              if the name of any of the Localization Tables referenced by <paramref name="source"/> is already taken by
+              another Entity's Principal Table, by a Relation Table, or by some other Localization Table.
+            </exception>
+            <exception cref="T:Kvasir.Translation.NestedLocalizationException">
+              if the Locale or Value type of any of the Localization Tables referenced by <paramref name="source"/> is
+              a Localization.
+            </exception>
+            <exception cref="T:Kvasir.Translation.NestedRelationException">
+              if the Locale or Value type of any of the Localization Tables referenced by <paramref name="source"/> is
+              a Relation.
+            </exception>
+            <exception cref="T:Kvasir.Translation.InvalidPropertyInDataModelException">
+              if any of the Localization Tables referenced by <paramref name="source"/> would have Fields beyond the
+              Key, Locale, and Value Fields defined by the base <see cref="T:Kvasir.Localization.Localization`3"/> class.
+            </exception>
+            <exception cref="T:Kvasir.Translation.InvalidNativeNullabilityException">
+              if any of the Localization types referenced by <paramref name="source"/> have a Key or Locale property
+              that is natively nullable.
+            </exception>
+        </member>
         <member name="M:Kvasir.Translation.Translator.GetTableName(Kvasir.Translation.Context,System.Type)">
             <summary>
               Determines the name of the Principal Table for an Entity Type.
@@ -8266,7 +8448,7 @@
               if any of the constructors of <paramref name="source"/> is annotated with <c>[ReconstitueThrough]</c>.
             </exception>
         </member>
-        <member name="M:Kvasir.Translation.Translator.TranslateType(Kvasir.Translation.Context,System.Type,System.Boolean,System.Boolean)">
+        <member name="M:Kvasir.Translation.Translator.TranslateType(Kvasir.Translation.Context,System.Type,Kvasir.Translation.Translator.TranslationTraits)">
             <summary>
               Translates a single CLR type.
             </summary>
@@ -8277,14 +8459,9 @@
             <param name="source">
               The CLR type to translate.
             </param>
-            <param name="allowRelations">
-              <see langword="true"/> if Relations should be allowed as valid (e.g. when translating a real Entity Type);
-              <see langword="false"/> if Relations should be disallowed (e.g. when translating a Relation).
-            </param>
-            <param name="requirePreDefined">
-              <see langword="true"/> if only References to Pre-Defined Entities should be allowed as valid (e.g. when
-              translating a Pre-Defined Entity or a type referenced therefrom); <see langword="false"/> if References to
-              regular Entities are valid (e.g. when translating anything else).
+            <param name="traits">
+              The <see cref="T:Kvasir.Translation.Translator.TranslationTraits"/> describing how to treat Relations, Localizations, and Pre-Defined
+              Entities.
             </param>
             <returns>
               The unordered (but column-assigned) Fields that make up the data model for <paramref name="source"/>, with
@@ -8314,13 +8491,23 @@
               model.
             </exception>
             <exception cref="T:Kvasir.Translation.NestedRelationException">
-              if <paramref name="allowRelations"/> is <see langword="false"/> and <paramref name="source"/> has a
-              Relation-type Field that would be included in the data model.
+              if the <see cref="F:Kvasir.Translation.Translator.TranslationTraits.AllowRelations"/> flag of <paramref name="traits"/> is not set and
+              <paramref name="source"/> has a Relation-type Field that would be included in the data model.
+            </exception>
+            <exception cref="T:Kvasir.Translation.NestedLocalizationException">
+              if the <see cref="F:Kvasir.Translation.Translator.TranslationTraits.AllowLocalizations"/> flag of <paramref name="traits"/> is not set and
+              <paramref name="source"/> has a Localization-type Field that would be included in the data model.
             </exception>
             <exception cref="T:Kvasir.Translation.PreDefinedReferenceException">
-              if <paramref name="requirePreDefined"/> is <see langword="true"/> and <paramref name="source"/> is not a
-              Pre-Defined Entity type.
+              if the <see cref="F:Kvasir.Translation.Translator.TranslationTraits.RequirePreDefined"/> flag of <paramref name="traits"/> is set and
+              <paramref name="source"/> is not a Pre-Defined Entity type.
             </exception>
+        </member>
+        <member name="T:Kvasir.Translation.Translator.TranslationTraits">
+            <summary>
+              Traits controlling the validity of different categories of properties when translating a Type. Essentially
+              a collection of Boolean flags.
+            </summary>
         </member>
         <member name="P:Kvasir.Translation.Translator.Item(System.Type)">
             <summary>
@@ -8422,17 +8609,28 @@
               The initial <see cref="T:System.Type"/> whose translation will be tracked by the new <see cref="T:Kvasir.Translation.Context"/>.
             </param>
         </member>
-        <member name="M:Kvasir.Translation.Context.#ctor(Kvasir.Translation.Context)">
+        <member name="M:Kvasir.Translation.Context.#ctor(Kvasir.Translation.Context,System.Boolean)">
             <summary>
               Constructs a frozen (i.e. immutable) copy of another <see cref="T:Kvasir.Translation.Context"/>.
             </summary>
             <param name="source">
               The source <see cref="T:Kvasir.Translation.Context"/>.
             </param>
+            <param name="frozen">
+              Whether or not the new <see cref="T:Kvasir.Translation.Context"/> should be frozen (i.e. immutable).
+            </param>
+        </member>
+        <member name="M:Kvasir.Translation.Context.Clone">
+            <summary>
+              Constructs a non-frozen (i.e. mutable) copy of another <see cref="T:Kvasir.Translation.Context"/>.
+            </summary>
+            <returns>
+              A deep copy of this <see cref="T:Kvasir.Translation.Context"/> that can be pushed onto and/or popped from
+            </returns>
         </member>
         <member name="M:Kvasir.Translation.Context.Freeze">
             <summary>
-              Creates a frozen (i.e. immutable) copy of this <see cref="T:Kvasir.Translation.Context"/>.
+              Creates a copy of this <see cref="T:Kvasir.Translation.Context"/>.
             </summary>
             <returns>
               A deep copy of this <see cref="T:Kvasir.Translation.Context"/> that cannot be pushed onto or popped from.
@@ -8478,6 +8676,18 @@
               finished translating.
             </remarks>
         </member>
+        <member name="M:Kvasir.Translation.Context.Concat(Kvasir.Translation.Context)">
+            <summary>
+              Concatenates two <see cref="T:Kvasir.Translation.Context">Contexts</see>.
+            </summary>
+            <param name="suffix">
+              The <see cref="T:Kvasir.Translation.Context"/> to be appended onto this one.
+            </param>
+            <returns>
+              A new <see cref="T:Kvasir.Translation.Context"/> consisting of the state of the current one followed by the state of
+              <paramref name="suffix"/>.
+            </returns>
+        </member>
         <member name="M:Kvasir.Translation.Context.ToString">
             <summary>
               Produces a human-readable string representation of the <see cref="T:Kvasir.Translation.Context"/>.
@@ -8498,32 +8708,118 @@
               The name of <paramref name="property"/>.
             </returns>
         </member>
+        <member name="T:Kvasir.Translation.PrincipalTableDef">
+            <summary>
+              The definition of a Principal Table.
+            </summary>
+            
+            <param name="Table">The schema model for the Principal Table.</param>
+            <param name="Extractor">The plan that can extract a row of data to be stored into the Principal Table.</param>
+            <param name="Reconstitutor">The plan that can recreate a CLR object from a row of data stored in the Principal Table.</param>
+            <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitute's the Primary Key in the Principal Table.</param>
+            <param name="PreDefinedInstances">The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</param>
+        </member>
+        <member name="M:Kvasir.Translation.PrincipalTableDef.#ctor(Kvasir.Schema.ITable,Kvasir.Extraction.DataExtractionPlan,Kvasir.Reconstitution.DataReconstitutionPlan,Kvasir.Extraction.DataExtractionPlan,System.Collections.Generic.IReadOnlyList{System.Object})">
+            <summary>
+              The definition of a Principal Table.
+            </summary>
+            
+            <param name="Table">The schema model for the Principal Table.</param>
+            <param name="Extractor">The plan that can extract a row of data to be stored into the Principal Table.</param>
+            <param name="Reconstitutor">The plan that can recreate a CLR object from a row of data stored in the Principal Table.</param>
+            <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitute's the Primary Key in the Principal Table.</param>
+            <param name="PreDefinedInstances">The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</param>
+        </member>
+        <member name="P:Kvasir.Translation.PrincipalTableDef.Table">
+            <summary>The schema model for the Principal Table.</summary>
+        </member>
+        <member name="P:Kvasir.Translation.PrincipalTableDef.Extractor">
+            <summary>The plan that can extract a row of data to be stored into the Principal Table.</summary>
+        </member>
+        <member name="P:Kvasir.Translation.PrincipalTableDef.Reconstitutor">
+            <summary>The plan that can recreate a CLR object from a row of data stored in the Principal Table.</summary>
+        </member>
+        <member name="P:Kvasir.Translation.PrincipalTableDef.KeyExtractor">
+            <summary>The plan that can extract the subset of a row of data that constitute's the Primary Key in the Principal Table.</summary>
+        </member>
+        <member name="P:Kvasir.Translation.PrincipalTableDef.PreDefinedInstances">
+            <summary>The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</summary>
+        </member>
+        <member name="T:Kvasir.Translation.RelationTableDef">
+            <summary>
+              The definition of a Relation Table.
+            </summary>
+            
+            <param name="Table">The schema model for the Relation Table.</param>
+            <param name="Extractor">The plan that can extract the element-specific data to be stored in the Relation Table.</param>
+            <param name="Repopulator">The plan that can populate elements into a CLR Relation from a row of data stored in the Relation Table.</param>
+        </member>
+        <member name="M:Kvasir.Translation.RelationTableDef.#ctor(Kvasir.Schema.ITable,Kvasir.Extraction.RelationExtractionPlan,Kvasir.Reconstitution.RelationRepopulationPlan)">
+            <summary>
+              The definition of a Relation Table.
+            </summary>
+            
+            <param name="Table">The schema model for the Relation Table.</param>
+            <param name="Extractor">The plan that can extract the element-specific data to be stored in the Relation Table.</param>
+            <param name="Repopulator">The plan that can populate elements into a CLR Relation from a row of data stored in the Relation Table.</param>
+        </member>
+        <member name="P:Kvasir.Translation.RelationTableDef.Table">
+            <summary>The schema model for the Relation Table.</summary>
+        </member>
+        <member name="P:Kvasir.Translation.RelationTableDef.Extractor">
+            <summary>The plan that can extract the element-specific data to be stored in the Relation Table.</summary>
+        </member>
+        <member name="P:Kvasir.Translation.RelationTableDef.Repopulator">
+            <summary>The plan that can populate elements into a CLR Relation from a row of data stored in the Relation Table.</summary>
+        </member>
+        <member name="T:Kvasir.Translation.LocalizationDef">
+            <summary>
+              The definition of a Field on an Entity that is a Localization.
+            </summary>
+            
+            <param name="Table">The schema model for the Localization Table.</param>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationDef.#ctor(Kvasir.Schema.ITable)">
+            <summary>
+              The definition of a Field on an Entity that is a Localization.
+            </summary>
+            
+            <param name="Table">The schema model for the Localization Table.</param>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationDef.Table">
+            <summary>The schema model for the Localization Table.</summary>
+        </member>
         <member name="T:Kvasir.Translation.EntityTranslation">
             <summary>
               A translation of a single CLR type.
             </summary>
             
-            <param name="CLRSource">The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.EntityTranslation"/></param>
-            <param name="Principal">The definition of the Principal Table</param>
-            <param name="Relations">The definitions of any Relation Tables</param>
+            <param name="CLRSource">The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.EntityTranslation"/>.</param>
+            <param name="Principal">The definition of the Principal Table.</param>
+            <param name="Relations">The definitions of any Relation Tables.</param>
+            <param name="Localizations">The definition of any Localizations.</param>
         </member>
-        <member name="M:Kvasir.Translation.EntityTranslation.#ctor(System.Type,Kvasir.Translation.PrincipalTableDef,System.Collections.Generic.IReadOnlyList{Kvasir.Translation.RelationTableDef})">
+        <member name="M:Kvasir.Translation.EntityTranslation.#ctor(System.Type,Kvasir.Translation.PrincipalTableDef,System.Collections.Generic.IReadOnlyList{Kvasir.Translation.RelationTableDef},System.Collections.Generic.IReadOnlyList{Kvasir.Translation.LocalizationDef})">
             <summary>
               A translation of a single CLR type.
             </summary>
             
-            <param name="CLRSource">The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.EntityTranslation"/></param>
-            <param name="Principal">The definition of the Principal Table</param>
-            <param name="Relations">The definitions of any Relation Tables</param>
+            <param name="CLRSource">The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.EntityTranslation"/>.</param>
+            <param name="Principal">The definition of the Principal Table.</param>
+            <param name="Relations">The definitions of any Relation Tables.</param>
+            <param name="Localizations">The definition of any Localizations.</param>
         </member>
         <member name="P:Kvasir.Translation.EntityTranslation.CLRSource">
-            <summary>The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.EntityTranslation"/></summary>
+            <summary>The CLR <see cref="T:System.Type"/> that produced this <see cref="T:Kvasir.Translation.EntityTranslation"/>.</summary>
         </member>
         <member name="P:Kvasir.Translation.EntityTranslation.Principal">
-            <summary>The definition of the Principal Table</summary>
+            <summary>The definition of the Principal Table.</summary>
         </member>
         <member name="P:Kvasir.Translation.EntityTranslation.Relations">
-            <summary>The definitions of any Relation Tables</summary>
+            <summary>The definitions of any Relation Tables.</summary>
+        </member>
+        <member name="P:Kvasir.Translation.EntityTranslation.Localizations">
+            <summary>The definition of any Localizations.</summary>
         </member>
         <member name="T:Kvasir.Translation.AmbiguousNullabilityException">
             <summary>
@@ -8722,7 +9018,7 @@
         <member name="M:Kvasir.Translation.InapplicableAnnotationException.#ctor(Kvasir.Translation.Context,System.Type,System.Type,Kvasir.Translation.MultiKind)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.InapplicableAnnotationException"/> caused by a non-constraint annotation being
-              placed on an Aggregate property, a Reference property, or a Relation property.
+              placed on an Aggregate property, a Reference property, a Relation property, or a Localization property.
             </summary>
             <param name="context">
               The <see cref="T:Kvasir.Translation.Context"/> in which the inapplicable annotation was encountered.
@@ -9049,6 +9345,27 @@
               <i>overload discriminator</i>
             </param>
         </member>
+        <member name="T:Kvasir.Translation.InvalidLocalizationKeyException">
+            <summary>
+              An exception that is raised when the type of a localization key is not a primitive, built-in type.
+            </summary>
+            <seealso cref="T:Kvasir.Translation.NestedLocalizationException"/>
+        </member>
+        <member name="M:Kvasir.Translation.InvalidLocalizationKeyException.#ctor(Kvasir.Translation.Context,System.Type,Kvasir.Translation.TypeCategory)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.InvalidLocalizationKeyException"/> caused by the localization key being
+              something other than a primitive, built-in type.
+            </summary>
+            <param name="context">
+              The <see cref="T:Kvasir.Translation.Context"/> in which the invalid localization key type was encountered.
+            </param>
+            <param name="type">
+              The invalid localization key type.
+            </param>
+            <param name="category">
+              The category into which the invalid localization key type falls.
+            </param>
+        </member>
         <member name="T:Kvasir.Translation.InvalidNameException">
             <summary>
               An exception that is raised when a user-provided name is invalid.
@@ -9267,6 +9584,33 @@
             </param>
             <param name="_">
               <i>overload discriminator</i>
+            </param>
+        </member>
+        <member name="M:Kvasir.Translation.InvalidPropertyInDataModelException.#ctor(Kvasir.Translation.Context,Kvasir.Translation.DerivedLocalizationTag)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.InvalidPropertyInDataModelException"/> caused by a property in a derived
+              Localization.
+            </summary>
+            <param name="context">
+              The <see cref="T:Kvasir.Translation.Context"/> in which the writeable property was encountered.
+            </param>
+            <param name="_">
+              <i>overload discriminator</i>
+            </param>
+        </member>
+        <member name="T:Kvasir.Translation.NestedLocalizationException">
+            <summary>
+              An exception that is raised when the locale type or value type of a Localization is itself, another
+              Localization.
+            </summary>
+            <seealso cref="T:Kvasir.Translation.InvalidLocalizationKeyException"/>
+        </member>
+        <member name="M:Kvasir.Translation.NestedLocalizationException.#ctor(Kvasir.Translation.Context)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.NestedLocalizationException"/>.
+            </summary>
+            <param name="context">
+              The <see cref="T:Kvasir.Translation.Context"/> in which the nested Localization was encountered.
             </param>
         </member>
         <member name="T:Kvasir.Translation.NestedRelationException">
@@ -9629,6 +9973,19 @@
             </param>
             <param name="reason">
               The reason that <paramref name="annotation"/> is unsatisfiable.
+            </param>
+        </member>
+        <member name="T:Kvasir.Translation.WriteableLocalizationException">
+            <summary>
+              An exception that is raised when a freely writeable Localization-type property is included in the data model.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.WriteableLocalizationException.#ctor(Kvasir.Translation.Context)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.WriteableLocalizationException"/>.
+            </summary>
+            <param name="context">
+              The <see cref="T:Kvasir.Translation.Context"/> in which the freely writeable Localization-type property was encountered.
             </param>
         </member>
         <member name="T:Kvasir.Translation.WriteableRelationException">
@@ -10508,6 +10865,130 @@
               <see langword="null"/>.
             </exception>
         </member>
+        <member name="T:Kvasir.Translation.LocalizationKeyFieldGroup">
+            <summary>
+              A <see cref = "T:Kvasir.Translation.FieldGroup" /> backed by a scalar or enumeration CLR property, and therefore corresponding to
+              exactly one Field, that was taken from the key type of a Localization.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationKeyFieldGroup.Size">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationKeyFieldGroup.AllNullable">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationKeyFieldGroup.IsNativelyNullable">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationKeyFieldGroup.ReconstitutionArgumentName">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationKeyFieldGroup.Item(System.Int32)">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationKeyFieldGroup.Extractor">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationKeyFieldGroup.Creator">
+            <inheritdoc/>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationKeyFieldGroup.KeyType">
+            <summary>
+              The type of the key for the Localization that the <see cref="T:Kvasir.Translation.LocalizationKeyFieldGroup"/> backs.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.#ctor(Kvasir.Translation.Context,System.Reflection.PropertyInfo)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.LocalizationKeyFieldGroup"/>.
+            </summary>
+            <param name="context">
+              The <see cref="T:Kvasir.Translation.Context"/> in which <paramref name="source"/> was accessed via reflection. This context
+              should include that property.
+            </param>
+            <param name="source">
+              The CLR property backing the new <see cref="T:Kvasir.Translation.LocalizationKeyFieldGroup"/>.
+            </param>
+            <exception cref="T:Kvasir.Translation.InvalidLocalizationKeyException">
+              if the <see cref="P:Kvasir.Translation.LocalizationKeyFieldGroup.KeyType"/> of the Localization represented by <paramref name="source"/> is not a type
+              natively supported by Kvasir.
+            </exception>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.#ctor(Kvasir.Translation.LocalizationKeyFieldGroup)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.LocalizationKeyFieldGroup"/> that is largely identical to another.
+            </summary>
+            <param name="source">
+              The source <see cref="T:Kvasir.Translation.LocalizationKeyFieldGroup"/>.
+            </param>
+            <seealso cref="M:Kvasir.Translation.FieldGroup.Clone"/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.#ctor(Kvasir.Translation.LocalizationKeyFieldGroup,Kvasir.Translation.FieldGroup.ResetTag)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.LocalizationKeyFieldGroup"/> that is largely identical to another, but with the
+              constituent Field reset.
+            </summary>
+            <param name="source">
+              The source <see cref="T:Kvasir.Translation.LocalizationKeyFieldGroup"/>.
+            </param>
+            <param name="_">
+              <i>overload discriminator</i>
+            </param>
+            <seealso cref="M:Kvasir.Translation.LocalizationKeyFieldGroup.Reset"/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.ApplyConstraint(Kvasir.Translation.Context,Kvasir.Translation.Nested{Kvasir.Annotations.CheckAttribute})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.ApplyConstraint(Kvasir.Translation.Context,Kvasir.Translation.Nested{Kvasir.Annotations.Check.ComparisonAttribute})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.ApplyConstraint(Kvasir.Translation.Context,Kvasir.Translation.Nested{Kvasir.Annotations.Check.InclusionAttribute})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.ApplyConstraint(Kvasir.Translation.Context,Kvasir.Translation.Nested{Kvasir.Annotations.Check.SignednessAttribute})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.ApplyConstraint(Kvasir.Translation.Context,Kvasir.Translation.Nested{Kvasir.Annotations.Check.StringLengthAttribute})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.Clone">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.Filter(System.Collections.Generic.IEnumerable{Kvasir.Translation.FieldDescriptor})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.GetEnumerator">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.References">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.Reset">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.SetDefault(Kvasir.Translation.Context,Kvasir.Translation.Nested{Kvasir.Annotations.DefaultAttribute})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.SetInCandidateKey(Kvasir.Translation.Context,Kvasir.Translation.Nested{Kvasir.Annotations.UniqueAttribute})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.SetInPrimaryKey(Kvasir.Translation.Context,Kvasir.Translation.Nested{Kvasir.Annotations.PrimaryKeyAttribute},System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.SetName(Kvasir.Translation.Context,Kvasir.Translation.Nested{Kvasir.Annotations.NameAttribute})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.SetNamePrefix(Kvasir.Translation.Context,System.Collections.Generic.IEnumerable{System.String})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.SetNullability(Kvasir.Translation.Context,System.Boolean)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.ProcessNativeNullability(Kvasir.Translation.Context)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationKeyFieldGroup.ProcessAnnotations(Kvasir.Translation.Context)">
+            <inheritdoc/>
+        </member>
         <member name="T:Kvasir.Translation.MultiFieldGroup">
             <summary>
               The intermediate base class for a <see cref="T:Kvasir.Translation.FieldGroup"/> backed by an Aggregate, Reference, or Relation
@@ -10989,6 +11470,32 @@
               and <see cref="T:Kvasir.Annotations.NumericAttribute">[Numeric]</see>.
             </exception>
         </member>
+        <member name="T:Kvasir.Translation.LocalizationTracker">
+            <summary>
+              A utility for tracking the presence of Localizations.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationTracker.Source">
+            <summary>
+              The source property.
+            </summary>
+        </member>
+        <member name="P:Kvasir.Translation.LocalizationTracker.Context">
+            <summary>
+              The <see cref="P:Kvasir.Translation.LocalizationTracker.Context"/> in which the property sourcing the tracker was encountered.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationTracker.#ctor(System.Reflection.PropertyInfo,Kvasir.Translation.Context)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.LocalizationTracker"/>.
+            </summary>
+            <param name="source">
+              The source property.
+            </param>
+            <param name="context">
+              The <see cref="P:Kvasir.Translation.LocalizationTracker.Context"/> of <paramref name="source"/>.
+            </param>
+        </member>
         <member name="T:Kvasir.Translation.ReconstitutionHelper">
             <summary>
               A helper class for evaluating a type's constructors for usability in Reconstitution.
@@ -11291,7 +11798,7 @@
         </member>
         <member name="T:Kvasir.Translation.SyntheticPropertyInfo">
             <summary>
-              The reflection representation of a property on a <see cref="T:Kvasir.Translation.SyntheticType"/>.
+              The reflection representation of a property that doesn't actually exist in the CLR.
             </summary>
         </member>
         <member name="P:Kvasir.Translation.SyntheticPropertyInfo.CanRead">
@@ -11312,7 +11819,7 @@
         <member name="P:Kvasir.Translation.SyntheticPropertyInfo.ReflectedType">
             <inheritdoc/>
         </member>
-        <member name="M:Kvasir.Translation.SyntheticPropertyInfo.#ctor(System.String,Kvasir.Translation.SyntheticType,System.Type,System.Collections.Generic.IEnumerable{System.Attribute})">
+        <member name="M:Kvasir.Translation.SyntheticPropertyInfo.#ctor(System.String,System.Type,System.Type,System.Collections.Generic.IEnumerable{System.Attribute})">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.SyntheticPropertyInfo"/>.
             </summary>
@@ -11320,7 +11827,7 @@
               The <see cref="P:Kvasir.Translation.SyntheticPropertyInfo.Name"/> of the property.
             </param>
             <param name="source">
-              The <see cref="T:Kvasir.Translation.SyntheticType"/> on which the property resides.
+              The <see cref="T:System.Type"/> on which the property resides (even though it doesn't exist).
             </param>
             <param name="propertyType">
               The <see cref="P:Kvasir.Translation.SyntheticPropertyInfo.PropertyType">type</see> of the property.
@@ -11404,7 +11911,7 @@
         <member name="P:Kvasir.Translation.SyntheticType.UnderlyingSystemType">
             <inheritdoc/>
         </member>
-        <member name="M:Kvasir.Translation.SyntheticType.#ctor(System.String,System.String,System.Reflection.Assembly,System.Func{Kvasir.Translation.SyntheticType,System.Collections.Generic.IEnumerable{Kvasir.Translation.SyntheticPropertyInfo}},System.Type,System.Boolean)">
+        <member name="M:Kvasir.Translation.SyntheticType.#ctor(System.String,System.String,System.Reflection.Assembly,System.Func{Kvasir.Translation.SyntheticType,System.Collections.Generic.IEnumerable{Kvasir.Translation.SyntheticPropertyInfo}},System.Type,System.Boolean,System.Boolean)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.SyntheticType"/>.
             </summary>
@@ -11424,6 +11931,10 @@
             </param>
             <param name="actualType">
               The <see cref="T:System.Type"/> that the new <see cref="T:Kvasir.Translation.SyntheticType"/> is a façade for.
+            </param>
+            <param name="isLocalization">
+              Whether the new <see cref="T:Kvasir.Translation.SyntheticType"/> represents a Localization (<see langword="true"/>) or a
+              Relation <see langword="false"/>).
             </param>
             <param name="nativelyNullable">
               Whether or not the new <see cref="T:Kvasir.Translation.SyntheticType"/> is considered
@@ -11448,7 +11959,7 @@
         </member>
         <member name="M:Kvasir.Translation.SyntheticType.MakeSyntheticType(System.Type,Kvasir.Translation.RelationTracker)">
             <summary>
-              Creates a new <see cref="T:Kvasir.Translation.SyntheticType"/>.
+              Creates a new <see cref="T:Kvasir.Translation.SyntheticType"/> as a façade for a Relation.
             </summary>
             <param name="entity">
               The type of the owning Entity, which defines the first property on the new <see cref="T:Kvasir.Translation.SyntheticType"/>.
@@ -11457,6 +11968,23 @@
               The <see cref="T:Kvasir.Translation.RelationTracker"/> containing the metadata for the property that forms the rest of the
               <see cref="T:Kvasir.Translation.SyntheticType"/>.
             </param>
+        </member>
+        <member name="M:Kvasir.Translation.SyntheticType.MakeSyntheticType(Kvasir.Translation.LocalizationTracker)">
+            <summary>
+              Creates a new <see cref="T:Kvasir.Translation.SyntheticType"/> as a façade for a Localization.
+            </summary>
+            <param name="tracker">
+              The <see cref="T:Kvasir.Translation.LocalizationTracker"/> containing the metadata for the type that defines the Localization
+              underneath the <see cref="T:Kvasir.Translation.SyntheticType"/>.
+            </param>
+            <exception cref="T:Kvasir.Translation.InvalidPropertyInDataModelException">
+              if the Localization represented by <paramref name="tracker"/> has a Field in the data model beyond the Key
+              Locale, and Value Fields defined by the base <see cref="T:Kvasir.Localization.Localization`3"/> class.
+            </exception>
+            <exception cref="T:Kvasir.Translation.InvalidNativeNullabilityException">
+              if the Key or Locale type of the Localization represented by <paramref name="tracker"/> is natively
+              nullable.
+            </exception>
         </member>
         <member name="M:Kvasir.Translation.SyntheticType.GetCustomAttributes(System.Type,System.Boolean)">
             <inheritdoc/>
@@ -11538,70 +12066,6 @@
         </member>
         <member name="M:Kvasir.Translation.SyntheticType.IsPrimitiveImpl">
             <inheritdoc/>
-        </member>
-        <member name="T:Kvasir.Translation.PrincipalTableDef">
-            <summary>
-              The definition of a Principal Table.
-            </summary>
-            
-            <param name="Table">The schema model for the Principal Table.</param>
-            <param name="Extractor">The plan that can extract a row of data to be stored into the Principal Table.</param>
-            <param name="Reconstitutor">The plan that can recreate a CLR object from a row of data stored in the Principal Table.</param>
-            <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitute's the Primary Key in the Principal Table.</param>
-            <param name="PreDefinedInstances">The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</param>
-        </member>
-        <member name="M:Kvasir.Translation.PrincipalTableDef.#ctor(Kvasir.Schema.ITable,Kvasir.Extraction.DataExtractionPlan,Kvasir.Reconstitution.DataReconstitutionPlan,Kvasir.Extraction.DataExtractionPlan,System.Collections.Generic.IReadOnlyList{System.Object})">
-            <summary>
-              The definition of a Principal Table.
-            </summary>
-            
-            <param name="Table">The schema model for the Principal Table.</param>
-            <param name="Extractor">The plan that can extract a row of data to be stored into the Principal Table.</param>
-            <param name="Reconstitutor">The plan that can recreate a CLR object from a row of data stored in the Principal Table.</param>
-            <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitute's the Primary Key in the Principal Table.</param>
-            <param name="PreDefinedInstances">The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</param>
-        </member>
-        <member name="P:Kvasir.Translation.PrincipalTableDef.Table">
-            <summary>The schema model for the Principal Table.</summary>
-        </member>
-        <member name="P:Kvasir.Translation.PrincipalTableDef.Extractor">
-            <summary>The plan that can extract a row of data to be stored into the Principal Table.</summary>
-        </member>
-        <member name="P:Kvasir.Translation.PrincipalTableDef.Reconstitutor">
-            <summary>The plan that can recreate a CLR object from a row of data stored in the Principal Table.</summary>
-        </member>
-        <member name="P:Kvasir.Translation.PrincipalTableDef.KeyExtractor">
-            <summary>The plan that can extract the subset of a row of data that constitute's the Primary Key in the Principal Table.</summary>
-        </member>
-        <member name="P:Kvasir.Translation.PrincipalTableDef.PreDefinedInstances">
-            <summary>The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</summary>
-        </member>
-        <member name="T:Kvasir.Translation.RelationTableDef">
-            <summary>
-              The definition of a Relation Table.
-            </summary>
-            
-            <param name="Table">The schema model for the Relation Table.</param>
-            <param name="Extractor">The plan that can extract the element-specific data to be stored in the Relation Table.</param>
-            <param name="Repopulator">The plan that can populate elements into a CLR Relation from a row of data stored in the Relation Table.</param>
-        </member>
-        <member name="M:Kvasir.Translation.RelationTableDef.#ctor(Kvasir.Schema.ITable,Kvasir.Extraction.RelationExtractionPlan,Kvasir.Reconstitution.RelationRepopulationPlan)">
-            <summary>
-              The definition of a Relation Table.
-            </summary>
-            
-            <param name="Table">The schema model for the Relation Table.</param>
-            <param name="Extractor">The plan that can extract the element-specific data to be stored in the Relation Table.</param>
-            <param name="Repopulator">The plan that can populate elements into a CLR Relation from a row of data stored in the Relation Table.</param>
-        </member>
-        <member name="P:Kvasir.Translation.RelationTableDef.Table">
-            <summary>The schema model for the Relation Table.</summary>
-        </member>
-        <member name="P:Kvasir.Translation.RelationTableDef.Extractor">
-            <summary>The plan that can extract the element-specific data to be stored in the Relation Table.</summary>
-        </member>
-        <member name="P:Kvasir.Translation.RelationTableDef.Repopulator">
-            <summary>The plan that can populate elements into a CLR Relation from a row of data stored in the Relation Table.</summary>
         </member>
         <member name="T:Kvasir.Translation.Bound">
             <summary>
@@ -11820,6 +12284,32 @@
             <returns>
               A representation of the <see cref="T:Kvasir.Translation.Interval"/> in mathematical notation, with an absent endpoint being
               indicated by the infinity symbol.
+            </returns>
+        </member>
+        <!-- Badly formed XML comment ignored for member "T:Kvasir.Translation.LocalizationMetadata" -->
+        <!-- Badly formed XML comment ignored for member "M:Kvasir.Translation.LocalizationMetadata.#ctor(System.Reflection.PropertyInfo,System.Type,System.Type,System.Type,System.Boolean,System.Boolean,System.Boolean,System.Reflection.PropertyInfo)" -->
+        <!-- Badly formed XML comment ignored for member "P:Kvasir.Translation.LocalizationMetadata.KeyProperty" -->
+        <!-- Badly formed XML comment ignored for member "P:Kvasir.Translation.LocalizationMetadata.KeyType" -->
+        <!-- Badly formed XML comment ignored for member "P:Kvasir.Translation.LocalizationMetadata.LocaleType" -->
+        <!-- Badly formed XML comment ignored for member "P:Kvasir.Translation.LocalizationMetadata.ValueType" -->
+        <!-- Badly formed XML comment ignored for member "P:Kvasir.Translation.LocalizationMetadata.IsKeyNullable" -->
+        <!-- Badly formed XML comment ignored for member "P:Kvasir.Translation.LocalizationMetadata.IsLocaleNullable" -->
+        <!-- Badly formed XML comment ignored for member "P:Kvasir.Translation.LocalizationMetadata.IsValueNullable" -->
+        <!-- Badly formed XML comment ignored for member "P:Kvasir.Translation.LocalizationMetadata.FirstDerivedProperty" -->
+        <member name="T:Kvasir.Translation.LocalizationHelper">
+            <summary>
+              A collection of helper functions for performing translation operations on Localization types.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.LocalizationHelper.Reflect(System.Type)">
+            <summary>
+              Reflects over a Localization type, extracting the important properties, types, and nullability statuses.
+            </summary>
+            <param name="localization">
+              The Localization type.
+            </param>
+            <returns>
+              A <see cref="T:Kvasir.Translation.LocalizationMetadata"/> for <paramref name="localization"/>.
             </returns>
         </member>
         <member name="T:Kvasir.Translation.Nested`1">

--- a/src/Kvasir/Localization/ILocalization.cs
+++ b/src/Kvasir/Localization/ILocalization.cs
@@ -1,0 +1,33 @@
+﻿using Kvasir.Relations;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kvasir.Localization {
+    /// <summary>
+    ///   The internal framework interface denoting a custom collection type that serves as a mapping of localized
+    ///   values.
+    /// </summary>
+    public interface ILocalization {
+        /// <summary>
+        ///   The type of the Localization triplet. This should be three-element tuple where the first constituent type
+        ///   is the type of the localization key, the second is the type of the locale, and the third is the type of
+        ///   the localized value.
+        /// </summary>
+        /// <remarks>
+        ///   A few notes about this. We need something that is <see langword="static"/> so that we can access its value
+        ///   via reflection when holding just the type, which is the situation we find ourself in when doing
+        ///   Translation. However, for mocking purposes, we also need to be able to use <see cref="ILocalization"/> as
+        ///   a generic type parameter, which we cannot do if this property were <see langword="abstract"/>. We
+        ///   therefore make it regular <see langword="virtual"/> with an error-throwing base implementation. While this
+        ///   isn't ideal (technically, an implementation could choose not to override the base functionality), it's not
+        ///   a huge deal because the property is <c>internal</c>, and we can write exhaustive tests for the
+        ///   implementations authored within Kvasir itself.
+        /// </remarks>
+        [ExcludeFromCodeCoverage]
+        internal static virtual Type Triplet => throw new NotImplementedException();
+    }
+}

--- a/src/Kvasir/Localization/Localization.cs
+++ b/src/Kvasir/Localization/Localization.cs
@@ -1,0 +1,144 @@
+﻿using Ardalis.GuardClauses;
+using Kvasir.Relations;
+using System;
+using System.Collections.Generic;
+
+namespace Kvasir.Localization {
+    /// <summary>
+    ///   A collection of localized data that tracks the state of its locale-value mappings for interaction with a
+    ///   back-end database.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     The <see cref="Localization{TKey, TLocale, TValue}"/> class is a first-class data structure in Kvasir for
+    ///     representing semantics that have different values in different circumstances. The canonical example of this
+    ///     is text, which changes according to language; other examples may be measurements in imperial versus metric
+    ///     or dates according to different calendars. These modes are called "locales" and the value of a semantic in
+    ///     a particular locale the "localized value" or "localization." The semantic being localized is known as the
+    ///     "localization key" and is simply an identifier by which the localizations are grouped.
+    ///   </para>
+    ///   <para>
+    ///     Every locale-value pair in a <see cref="Localization{TKey, TLocale, TValue}"/> is in one of three states:
+    ///     <c>NEW</c>, <c>SAVED</c>, or <c>DELETED</c>. Each state corresponds to the action or actions that should be
+    ///     taken with respect to that item to synchronize the back-end database table corresponding to the
+    ///     Localization. An item enters the <c>NEW</c> state when it is first added; when the collection is
+    ///     canonicalized, each <c>NEW</c> item transitions to the <c>SAVED</c> state, indicating that it does not need
+    ///     to be written to the database on the next write. When a <c>SAVED</c> item is removed from the collection, it
+    ///     transitions to the <c>DELETED</c> state; <c>NEW</c> items do not transition to <c>DELETED</c>. Note that if
+    ///     a <c>SAVED</c> item is deleted and then re-added, it will be re-added in the <c>SAVED</c> state.
+    ///   </para>
+    ///   <para>
+    ///     The <see cref="Localization{TKey, TLocale, TValue}"/> does not support the <c>MODIFIED</c> state; instead,
+    ///     each locale-value pair is treated as its own unit. This means that changing the value localized for an
+    ///     existing locale results in two separate operations in the back-end database: first a removal of the old
+    ///     locale-value pair, then an insertion of the new one. This behavior <i>may</i> change in the future, so
+    ///     clients should not rely on it. The guarantee, however, is that Kvasir will properly respond to an overwrite
+    ///     by ensuring that the resulting back-end database contains only the new locale-value pair.
+    ///   </para>
+    ///   <para>
+    ///     Items used for the value in a <see cref="Localization{TKey, TLocale, TValue}"/> should be immutable:
+    ///     structs, <see cref="string"/>, etc. This is because read access is <i>not</i> tracked: when using mutable
+    ///     values, it is possible for the user to access an item (e.g. through <c>operator[]</c>) and mutate that value
+    ///     without the collection knowing, preventing the change from being reflected in the back-end database. This
+    ///     also means that actions that convert the collection into another form will <i>copy</i> the elements,
+    ///     ensuring that the tracing data remains up-to-date.
+    ///   </para>
+    ///   <para>
+    ///     A <see cref="Localization{TKey, TLocale, TValue}"/> does not permit duplicate locales, but it does support
+    ///     duplicate values.
+    ///   </para>
+    /// </remarks>
+    /// <typeparam name="TKey">
+    ///   The type of the "localization key" for the Localization.
+    /// </typeparam>
+    /// <typeparam name="TLocale">
+    ///   The type of the locale for which values in the Localization are localized.
+    /// </typeparam>
+    /// <typeparam name="TValue">
+    ///   The type of the localized values.
+    /// </typeparam>
+    public abstract class Localization<TKey, TLocale, TValue> : ILocalization
+        where TKey : notnull where TLocale : notnull {
+        
+        /// <summary>
+        ///   The localization key of the Localization.
+        /// </summary>
+        public TKey Key { get; }
+
+        /// <summary>
+        ///   Gets or sets the localized value for a specified locale.
+        /// </summary>
+        /// <remarks>
+        ///   By default, a <see cref="Localization{TKey, TLocale, TValue}"/> is read-only. (This is just an annoying
+        ///   artifact of the overall design and limitations within C#.) Derived classes are encouraged to enable
+        ///   writeability by providing a <c>new</c> implementation of the <c>this[]</c> operator and delegating to the
+        ///   base class.
+        /// </remarks>
+        /// <param name="locale">
+        ///   [GET] The locale of the localized value to return.
+        ///   [SET] The locale of the new localized value.
+        /// </param>
+        /// <returns>
+        ///   [GET] The value localized for <paramref name="locale"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   [GET] If there is no localization for <paramref name="locale"/>.
+        /// </exception>
+        public TValue this[TLocale locale] {
+            get {
+                return Relation[locale];
+            }
+            protected set {
+                Relation[locale] = value;
+            }
+        }
+
+        /// <summary>
+        ///   The change-tracked collection of localizations.
+        /// </summary>
+        /// <remarks>
+        ///   This property is <c>internal</c> so that it is inaccessible to derived classes but accessible to Kvasir.
+        ///   This is the property through which change tracking occurs, and therefore the property through which the
+        ///   framework implements extraction and reconstitution.
+        /// </remarks>
+        internal RelationMap<TLocale, TValue> Relation { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="Localization{TKey, TLocale, TValue}"/>.
+        /// </summary>
+        /// <param name="localizationKey">
+        ///   The <see cref="Key">localization key</see> of the new Localization.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   if <paramref name="localizationKey"/> is <see langword="null"/>.
+        /// </exception>
+        protected Localization(TKey localizationKey) {
+            Guard.Against.Null(localizationKey);
+
+            Key = localizationKey;
+            Relation = new RelationMap<TLocale, TValue>();
+        }
+
+        /// <summary>
+        ///   The collection of localized values, as a read-only mapping.
+        /// </summary>
+        public IReadOnlyDictionary<TLocale, TValue> Localizations => Relation;
+
+        /// <summary>
+        ///   Implicitly converts a Localization to its localization key.
+        /// </summary>
+        /// <param name="localization">
+        ///   The <see cref="Localization{TKey, TLocale, TValue}"/> to convert.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="Key">localization key</see> of <paramref name="localization"/>.
+        /// </returns>
+        public static implicit operator TKey(Localization<TKey, TLocale, TValue> localization) {
+            Guard.Against.Null(localization);
+            return localization.Key;
+        }
+
+        /// <inheritdoc/>
+        static Type ILocalization.Triplet => typeof(Tuple<TKey, TLocale, TValue>);
+    }
+}

--- a/src/Kvasir/Reconstitution/ConstructingCreator.cs
+++ b/src/Kvasir/Reconstitution/ConstructingCreator.cs
@@ -35,7 +35,6 @@ namespace Kvasir.Reconstitution {
             Debug.Assert(ctor.ReflectedType is not null);
             Debug.Assert(argumentCreators is not null);
             Debug.Assert(argumentCreators.Count() == ctor.GetParameters().Length);
-            Debug.Assert(argumentCreators.All((i, c) => c.ResultType.IsInstanceOf(ctor.GetParameters()[i].ParameterType)));
 
             constructFromAllNulls_ = allowAllNulls;
             constructor_ = ctor;

--- a/src/Kvasir/Translation/Categorization.cs
+++ b/src/Kvasir/Translation/Categorization.cs
@@ -1,5 +1,6 @@
 ﻿using Cybele.Extensions;
 using Kvasir.Annotations;
+using Kvasir.Localization;
 using Kvasir.Relations;
 using Kvasir.Schema;
 using System;
@@ -25,12 +26,19 @@ namespace Kvasir.Translation {
             if (self.IsByRef) {
                 return TypeCategory.ByRef;
             }
-            if (self == typeof(IRelation)) {
+            else if (self == typeof(IRelation)) {
                 return TypeCategory.IRelation;
+            }
+            else if (self == typeof(ILocalization)) {
+                return TypeCategory.ILocalization;
             }
             else if (self.IsInstanceOf(typeof(IRelation))) {
                 // `IRelation` is an instance of itself, so this must come later
                 return TypeCategory.Relation;
+            }
+            else if (self.IsInstanceOf(typeof(ILocalization))) {
+                // `ILocalization` is an instance of itself, so this must come later
+                return TypeCategory.Localization;
             }
             else if (self.IsGenericTypeDefinition) {
                 return TypeCategory.OpenGeneric;
@@ -128,8 +136,10 @@ namespace Kvasir.Translation {
         public static TypeCategory ClosedGeneric { get; } = new TypeCategory("a closed generic type");
         public static TypeCategory Delegate { get; } = new TypeCategory("a delegate");
         public static TypeCategory Enumeration { get; } = new TypeCategory("an enumeration type");
+        public static TypeCategory ILocalization { get; } = new TypeCategory("the `ILocalization` interface");
         public static TypeCategory Interface { get; } = new TypeCategory("an interface");
         public static TypeCategory IRelation { get; } = new TypeCategory("the `IRelation` interface");
+        public static TypeCategory Localization { get; } = new TypeCategory("an implementation of the `ILocalization` interface");
         public static TypeCategory Object { get; set; } = new TypeCategory("`object` (or `dynamic`)");
         public static TypeCategory OpenGeneric { get; set; } = new TypeCategory("an open generic type");
         public static TypeCategory Pointer { get; } = new TypeCategory("a pointer type");

--- a/src/Kvasir/Translation/Defs.cs
+++ b/src/Kvasir/Translation/Defs.cs
@@ -33,4 +33,13 @@ namespace Kvasir.Translation {
         RelationExtractionPlan Extractor,
         RelationRepopulationPlan Repopulator
     );
+
+    /// <summary>
+    ///   The definition of a Field on an Entity that is a Localization.
+    /// </summary>
+    /// 
+    /// <param name="Table">The schema model for the Localization Table.</param>
+    internal sealed record class LocalizationDef(
+        ITable Table
+    );
 }

--- a/src/Kvasir/Translation/EntityTranslation.cs
+++ b/src/Kvasir/Translation/EntityTranslation.cs
@@ -6,12 +6,14 @@ namespace Kvasir.Translation {
     ///   A translation of a single CLR type.
     /// </summary>
     /// 
-    /// <param name="CLRSource">The CLR <see cref="Type"/> that produced this <see cref="EntityTranslation"/></param>
-    /// <param name="Principal">The definition of the Principal Table</param>
-    /// <param name="Relations">The definitions of any Relation Tables</param>
+    /// <param name="CLRSource">The CLR <see cref="Type"/> that produced this <see cref="EntityTranslation"/>.</param>
+    /// <param name="Principal">The definition of the Principal Table.</param>
+    /// <param name="Relations">The definitions of any Relation Tables.</param>
+    /// <param name="Localizations">The definition of any Localizations.</param>
     internal sealed record class EntityTranslation(
         Type CLRSource,
         PrincipalTableDef Principal,
-        IReadOnlyList<RelationTableDef> Relations
+        IReadOnlyList<RelationTableDef> Relations,
+        IReadOnlyList<LocalizationDef> Localizations
     );
 }

--- a/src/Kvasir/Translation/Exceptions/InapplicableAnnotationException.cs
+++ b/src/Kvasir/Translation/Exceptions/InapplicableAnnotationException.cs
@@ -10,7 +10,7 @@ namespace Kvasir.Translation {
     internal sealed class InapplicableAnnotationException : TranslationException {
         /// <summary>
         ///   Constructs a new <see cref="InapplicableAnnotationException"/> caused by a non-constraint annotation being
-        ///   placed on an Aggregate property, a Reference property, or a Relation property.
+        ///   placed on an Aggregate property, a Reference property, a Relation property, or a Localization property.
         /// </summary>
         /// <param name="context">
         ///   The <see cref="Context"/> in which the inapplicable annotation was encountered.
@@ -180,7 +180,7 @@ namespace Kvasir.Translation {
 
 
     // Discrimination types
-    internal enum MultiKind { Aggregate, Reference, Relation }
+    internal enum MultiKind { Aggregate, Reference, Relation, Localization }
     internal readonly struct UnsignedTag {}
     internal readonly struct PreDefinedTag {}
 }

--- a/src/Kvasir/Translation/Exceptions/InvalidLocalizationKeyException.cs
+++ b/src/Kvasir/Translation/Exceptions/InvalidLocalizationKeyException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Kvasir.Translation {
+    /// <summary>
+    ///   An exception that is raised when the type of a localization key is not a primitive, built-in type.
+    /// </summary>
+    /// <seealso cref="NestedLocalizationException"/>
+    internal sealed class InvalidLocalizationKeyException : TranslationException {
+        /// <summary>
+        ///   Constructs a new <see cref="InvalidLocalizationKeyException"/> caused by the localization key being
+        ///   something other than a primitive, built-in type.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="Context"/> in which the invalid localization key type was encountered.
+        /// </param>
+        /// <param name="type">
+        ///   The invalid localization key type.
+        /// </param>
+        /// <param name="category">
+        ///   The category into which the invalid localization key type falls.
+        /// </param>
+        public InvalidLocalizationKeyException(Context context, Type type, TypeCategory category)
+            : base(
+                new Location(context.ToString()),
+                new Problem($"type {type.DisplayName()} is {category} and cannot be the type of a Localization Key")
+              )
+        {}
+    }
+}

--- a/src/Kvasir/Translation/Exceptions/InvalidPropertyInDataModelException.cs
+++ b/src/Kvasir/Translation/Exceptions/InvalidPropertyInDataModelException.cs
@@ -80,5 +80,25 @@ namespace Kvasir.Translation {
                 new Problem("a writeable property cannot be included in the data model for a Pre-Defined Entity")
               )
         {}
+
+        /// <summary>
+        ///   Constructs a new <see cref="InvalidPropertyInDataModelException"/> caused by a property in a derived
+        ///   Localization.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="Context"/> in which the writeable property was encountered.
+        /// </param>
+        /// <param name="_">
+        ///   <i>overload discriminator</i>
+        /// </param>
+        public InvalidPropertyInDataModelException(Context context, DerivedLocalizationTag _)
+            : base(
+                new Location(context.ToString()),
+                new Problem("a property in a derived Localization class cannot be included in the data model")
+              )
+        {}
     }
+
+    // Discrimination types
+    internal readonly struct DerivedLocalizationTag {}
 }

--- a/src/Kvasir/Translation/Exceptions/NestedLocalizationException.cs
+++ b/src/Kvasir/Translation/Exceptions/NestedLocalizationException.cs
@@ -1,0 +1,21 @@
+﻿namespace Kvasir.Translation {
+    /// <summary>
+    ///   An exception that is raised when the locale type or value type of a Localization is itself, another
+    ///   Localization.
+    /// </summary>
+    /// <seealso cref="InvalidLocalizationKeyException"/>
+    internal sealed class NestedLocalizationException : TranslationException {
+        /// <summary>
+        ///   Constructs a new <see cref="NestedLocalizationException"/>.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="Context"/> in which the nested Localization was encountered.
+        /// </param>
+        public NestedLocalizationException(Context context)
+            : base(
+                new Location(context.ToString()),
+                new Problem("nested Localizations (i.e. within another Localization) are not supported")
+              )
+        {}
+    }
+}

--- a/src/Kvasir/Translation/Exceptions/NestedRelationException.cs
+++ b/src/Kvasir/Translation/Exceptions/NestedRelationException.cs
@@ -13,7 +13,7 @@
         public NestedRelationException(Context context)
             : base(
                 new Location(context.ToString()),
-                new Problem("nested Relations are not supported")
+                new Problem("nested Relations (i.e. within a Localization or another Relation) are not supported")
               )
         {}
     }

--- a/src/Kvasir/Translation/Exceptions/PreDefinedReferenceException.cs
+++ b/src/Kvasir/Translation/Exceptions/PreDefinedReferenceException.cs
@@ -25,7 +25,7 @@ namespace Kvasir.Translation {
                 new Location(context.ToString()),
                 new Problem(
                     "a Pre-Defined Entity cannot " +
-                    (isReference ? "reference " : "contain a Relation involving ") +
+                    (isReference ? "reference " : "contain a Relation or a Localization involving ") +
                     $"non-Pre-Defined Entity type {entityType.DisplayName()}"
                 )
               )

--- a/src/Kvasir/Translation/Exceptions/WriteableLocalizationException.cs
+++ b/src/Kvasir/Translation/Exceptions/WriteableLocalizationException.cs
@@ -1,0 +1,19 @@
+﻿namespace Kvasir.Translation {
+    /// <summary>
+    ///   An exception that is raised when a freely writeable Localization-type property is included in the data model.
+    /// </summary>
+    internal sealed class WriteableLocalizationException : TranslationException {
+        /// <summary>
+        ///   Constructs a new <see cref="WriteableLocalizationException"/>.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="Context"/> in which the freely writeable Localization-type property was encountered.
+        /// </param>
+        public WriteableLocalizationException(Context context)
+            : base(
+                new Location(context.ToString()),
+                new Problem("if a Localization-type property has a setter, is must be init-only")
+              )
+        {}
+    }
+}

--- a/src/Kvasir/Translation/FieldGroups/FieldGroup.cs
+++ b/src/Kvasir/Translation/FieldGroups/FieldGroup.cs
@@ -3,6 +3,7 @@ using Kvasir.Annotations;
 using Kvasir.Extraction;
 using Kvasir.Reconstitution;
 using Optional;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Kvasir/Translation/FieldGroups/LocalizationKeyFieldGroup.cs
+++ b/src/Kvasir/Translation/FieldGroups/LocalizationKeyFieldGroup.cs
@@ -1,0 +1,261 @@
+﻿using Cybele.Core;
+using Cybele.Extensions;
+using Kvasir.Annotations;
+using Kvasir.Extraction;
+using Kvasir.Localization;
+using Kvasir.Reconstitution;
+using Kvasir.Schema;
+using Optional;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    /// <summary>
+    ///   A <see cref = "FieldGroup" /> backed by a scalar or enumeration CLR property, and therefore corresponding to
+    ///   exactly one Field, that was taken from the key type of a Localization.
+    /// </summary>
+    internal sealed class LocalizationKeyFieldGroup : FieldGroup {
+        /// <inheritdoc/>
+        public sealed override int Size => 1;
+
+        /// <inheritdoc/>
+        public sealed override bool AllNullable => false;
+
+        /// <inheritdoc/>
+        public sealed override bool IsNativelyNullable => false;
+
+        /// <inheritdoc/>
+        public sealed override string ReconstitutionArgumentName => impl_.ReconstitutionArgumentName;
+
+        /// <inheritdoc/>
+        public sealed override string this[int column] => impl_[column];
+
+        /// <inheritdoc/>
+        public sealed override ISingleExtractor Extractor { get; }
+
+        /// <inheritdoc/>
+        public sealed override Option<ICreator> Creator { get; protected init; }
+
+        /// <summary>
+        ///   The type of the key for the Localization that the <see cref="LocalizationKeyFieldGroup"/> backs.
+        /// </summary>
+        public Type KeyType { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="LocalizationKeyFieldGroup"/>.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="Context"/> in which <paramref name="source"/> was accessed via reflection. This context
+        ///   should include that property.
+        /// </param>
+        /// <param name="source">
+        ///   The CLR property backing the new <see cref="LocalizationKeyFieldGroup"/>.
+        /// </param>
+        /// <exception cref="InvalidLocalizationKeyException">
+        ///   if the <see cref="KeyType"/> of the Localization represented by <paramref name="source"/> is not a type
+        ///   natively supported by Kvasir.
+        /// </exception>
+        public LocalizationKeyFieldGroup(Context context, PropertyInfo source)
+            : base(source) {
+
+            var metadata = LocalizationHelper.Reflect(source.PropertyType);
+            KeyType = metadata.KeyType;
+            if (!DBType.IsSupported(KeyType)) {
+                context.Push(source.PropertyType);
+                context.Push(metadata.KeyProperty);
+                var category = KeyType.TranslationCategory();
+                throw new InvalidLocalizationKeyException(context, KeyType, category);
+            }
+
+            // We use the `Key` property for the underlying SingleFieldGroup because this gives us the correct type and
+            // contributes no native annotations. All annotations on the Localization property itself will be forwarded
+            // as appropriate by the LocalizationFieldGroup.
+            impl_ = new SingleFieldGroup(context, metadata.KeyProperty);
+            ProcessAnnotations(context);
+
+            if (impl_.IsNativelyNullable) {
+                context.Push(source.PropertyType);
+                context.Push(metadata.KeyProperty);
+                throw new InvalidNativeNullabilityException(context, "the Localization Key type of a Localization");
+            }
+
+            Extractor = new ReadPropertyExtractor(new PropertyChain(source).Append(metadata.KeyProperty));
+            var reconstitutionGroup = new SingleFieldGroup(context, metadata.KeyProperty);
+            reconstitutionGroup.SetColumn(context, 0);
+            var groups = Enumerable.Repeat(reconstitutionGroup, 1);
+            Creator = Option.Some<ICreator>(ReconstitutionHelper.MakeCreator(context, Source.PropertyType, groups, false));
+        }
+
+        /// <summary>
+        ///   Constructs a new <see cref="LocalizationKeyFieldGroup"/> that is largely identical to another.
+        /// </summary>
+        /// <param name="source">
+        ///   The source <see cref="LocalizationKeyFieldGroup"/>.
+        /// </param>
+        /// <seealso cref="FieldGroup.Clone"/>
+        private LocalizationKeyFieldGroup(LocalizationKeyFieldGroup source)
+            : base(source) {
+
+            impl_ = source.impl_.Clone();
+            nameAnnotated_ = source.nameAnnotated_;
+            annotatedNonNullable_ = source.annotatedNonNullable_;
+            Extractor = source.Extractor;
+            Creator = source.Creator;
+            KeyType = source.KeyType;
+        }
+
+        /// <summary>
+        ///   Constructs a new <see cref="LocalizationKeyFieldGroup"/> that is largely identical to another, but with the
+        ///   constituent Field reset.
+        /// </summary>
+        /// <param name="source">
+        ///   The source <see cref="LocalizationKeyFieldGroup"/>.
+        /// </param>
+        /// <param name="_">
+        ///   <i>overload discriminator</i>
+        /// </param>
+        /// <seealso cref="Reset"/>
+        private LocalizationKeyFieldGroup(LocalizationKeyFieldGroup source, ResetTag _)
+            : base(source) {
+
+            impl_ = source.impl_.Reset();
+            nameAnnotated_ = false;
+            annotatedNonNullable_ = false;
+            KeyType = source.KeyType;
+            Extractor = source.Extractor;
+            Creator = source.Creator;
+        }
+
+        /// <inheritdoc/>
+        public sealed override void ApplyConstraint(Context context, Nested<CheckAttribute> annotation) {
+            impl_.ApplyConstraint(context, annotation);
+        }
+
+        /// <inheritdoc/>
+        public sealed override void ApplyConstraint(Context context, Nested<Check.ComparisonAttribute> annotation) {
+            impl_.ApplyConstraint(context, annotation);
+        }
+
+        /// <inheritdoc/>
+        public sealed override void ApplyConstraint(Context context, Nested<Check.InclusionAttribute> annotation) {
+            impl_.ApplyConstraint(context, annotation);
+        }
+
+        /// <inheritdoc/>
+        public sealed override void ApplyConstraint(Context context, Nested<Check.SignednessAttribute> annotation) {
+            impl_.ApplyConstraint(context, annotation);
+        }
+
+        /// <inheritdoc/>
+        public sealed override void ApplyConstraint(Context context, Nested<Check.StringLengthAttribute> annotation) {
+            impl_.ApplyConstraint(context, annotation);
+        }
+
+        /// <inheritdoc/>
+        public sealed override LocalizationKeyFieldGroup Clone() {
+            return new LocalizationKeyFieldGroup(this);
+        }
+
+        /// <inheritdoc/>
+        public sealed override Option<FieldGroup> Filter(IEnumerable<FieldDescriptor> constituents) {
+            return impl_.Filter(constituents).Map<FieldGroup>(_ => this);
+        }
+
+        /// <inheritdoc/>
+        public sealed override IEnumerator<FieldDescriptor> GetEnumerator() {
+            return impl_.GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        public sealed override IEnumerable<ReferenceFieldGroup> References() {
+            return impl_.References();
+        }
+
+        /// <inheritdoc/>
+        public sealed override LocalizationKeyFieldGroup Reset() {
+            return new LocalizationKeyFieldGroup(this, RESET);
+        }
+
+        /// <inheritdoc/>
+        public sealed override void SetDefault(Context context, Nested<DefaultAttribute> annotation) {
+            impl_.SetDefault(context, annotation);
+        }
+
+        /// <inheritdoc/>
+        public sealed override void SetInCandidateKey(Context context, Nested<UniqueAttribute> annotation) {
+            impl_.SetInCandidateKey(context, annotation);
+        }
+
+        /// <inheritdoc/>
+        public sealed override void SetInPrimaryKey(Context context, Nested<PrimaryKeyAttribute> annotation, string cascadePath) {
+            impl_.SetInPrimaryKey(context, annotation, cascadePath);
+        }
+
+        /// <inheritdoc/>
+        public sealed override void SetName(Context context, Nested<NameAttribute> annotation) {
+            impl_.SetName(context, annotation);
+            nameAnnotated_ = true;
+        }
+
+        /// <inheritdoc/>
+        public sealed override void SetNamePrefix(Context context, IEnumerable<string> prefix) {
+            impl_.SetNamePrefix(context, prefix);
+        }
+
+        /// <inheritdoc/>
+        public sealed override void SetNullability(Context context, bool nullable) {
+            if (nullable) {
+                throw new InapplicableAnnotationException(context, typeof(NullableAttribute), Source.PropertyType, MultiKind.Localization);
+            }
+            else {
+                annotatedNonNullable_ = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected sealed override void ProcessNativeNullability(Context context) {
+            bool nativelyNullable = new NullabilityInfoContext().Create(Source).ReadState == NullabilityState.Nullable;
+            if (!annotatedNonNullable_ && nativelyNullable) {
+                throw new InvalidNativeNullabilityException(context, "a property of Localization type");
+            }
+        }
+
+        /// <inheritdoc/>
+        protected sealed override void ProcessAnnotations(Context context) {
+            base.ProcessAnnotations(context);
+
+            // Data Converters are not allowed on Localization properties because it would break the inherent Foreign
+            // Key relation. The data for the Localization will be stored in a single Table shared by all instances of
+            // that Localization, so the data in the individual Entity Tables must match exactly - there's no way to
+            // change the data type for just some data but not others.
+            if (Source.HasAttribute<DataConverterAttribute>()) {
+                var type = typeof(DataConverterAttribute);
+                throw new InapplicableAnnotationException(context, type, Source.PropertyType, MultiKind.Localization);
+            }
+            else if (Source.HasAttribute<NumericAttribute>()) {
+                var type = typeof(NumericAttribute);
+                throw new InapplicableAnnotationException(context, type, Source.PropertyType, MultiKind.Localization);
+            }
+            else if (Source.HasAttribute<AsStringAttribute>()) {
+                var type = typeof(AsStringAttribute);
+                throw new InapplicableAnnotationException(context, type, Source.PropertyType, MultiKind.Localization);
+            }
+
+            // We use the `Key` property of the Localization to create the underlying SingleFieldGroup, since this gets
+            // us the correct property type and has no inherent annotations. However, the name implied by this property
+            // is just "Key" and that isn't right: if the Localization property is not itself annotated with a [Name]
+            // attribute, then it should have the name of the property itself.
+            if (!nameAnnotated_) {
+                var name = new NameAttribute(Source.Name);
+                impl_.SetName(context, name);
+            }
+        }
+
+
+        private readonly SingleFieldGroup impl_;
+        private bool nameAnnotated_;
+        private bool annotatedNonNullable_;
+    }
+}

--- a/src/Kvasir/Translation/LocalizationTracker.cs
+++ b/src/Kvasir/Translation/LocalizationTracker.cs
@@ -1,0 +1,39 @@
+﻿using Cybele.Extensions;
+using Kvasir.Localization;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    /// <summary>
+    ///   A utility for tracking the presence of Localizations.
+    /// </summary>
+    internal sealed class LocalizationTracker {
+        /// <summary>
+        ///   The source property.
+        /// </summary>
+        public PropertyInfo Source { get; }
+
+        /// <summary>
+        ///   The <see cref="Context"/> in which the property sourcing the tracker was encountered.
+        /// </summary>
+        public Context Context { get; }
+
+        /// <summary>
+        ///   Constructs a new <see cref="LocalizationTracker"/>.
+        /// </summary>
+        /// <param name="source">
+        ///   The source property.
+        /// </param>
+        /// <param name="context">
+        ///   The <see cref="Context"/> of <paramref name="source"/>.
+        /// </param>
+        public LocalizationTracker(PropertyInfo source, Context context) {
+            Debug.Assert(source is not null);
+            Debug.Assert(context is not null);
+            Debug.Assert(source.PropertyType.IsInstanceOf(typeof(ILocalization)) && source.PropertyType != typeof(ILocalization));
+
+            Source = source;
+            Context = context.Clone();
+        }
+    }
+}

--- a/src/Kvasir/Translation/Reconstitution.cs
+++ b/src/Kvasir/Translation/Reconstitution.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Kvasir.Translation {
@@ -35,7 +34,7 @@ namespace Kvasir.Translation {
             // Strip any nullability wrapper from the source type
             source = Nullable.GetUnderlyingType(source) ?? source;
 
-            // We need to ignore [Calculated] Fields, which have to `Creator`
+            // We need to ignore [Calculated] Fields, which have no `Creator`
             var nonCalculatedFields = fields.Where(g => g.Creator.HasValue);
 
             Candidate MakeCandidate(ConstructorInfo constructor) {
@@ -137,6 +136,12 @@ namespace Kvasir.Translation {
             // to account for `Nullable<T>`, which is different than `T`.
             var paramType = Nullable.GetUnderlyingType(parameter.ParameterType) ?? parameter.ParameterType;
             var argType = Nullable.GetUnderlyingType(argument.Source.PropertyType) ?? argument.Source.PropertyType;
+
+            // Localizations are implicitly convertible to their key type, and we expect that constructors will accept
+            // the key rather than a full Localization.
+            if (paramType != argType && argument is LocalizationKeyFieldGroup lfg) {
+                argType = Nullable.GetUnderlyingType(lfg.KeyType) ?? lfg.KeyType;
+            }
             return paramType == argType;
         }
 

--- a/src/Kvasir/Translation/Synthetics/SyntheticPropertyInfo.cs
+++ b/src/Kvasir/Translation/Synthetics/SyntheticPropertyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 
 namespace Kvasir.Translation {
     /// <summary>
-    ///   The reflection representation of a property on a <see cref="SyntheticType"/>.
+    ///   The reflection representation of a property that doesn't actually exist in the CLR.
     /// </summary>
     internal sealed partial class SyntheticPropertyInfo : PropertyInfo {
         /// <inheritdoc/>
@@ -37,7 +37,7 @@ namespace Kvasir.Translation {
         ///   The <see cref="Name"/> of the property.
         /// </param>
         /// <param name="source">
-        ///   The <see cref="SyntheticType"/> on which the property resides.
+        ///   The <see cref="Type"/> on which the property resides (even though it doesn't exist).
         /// </param>
         /// <param name="propertyType">
         ///   The <see cref="PropertyType">type</see> of the property.
@@ -45,7 +45,7 @@ namespace Kvasir.Translation {
         /// <param name="annotations">
         ///   The set of <see cref="Attribute">annotations</see> applied to the property, in any order.
         /// </param>
-        public SyntheticPropertyInfo(string name, SyntheticType source, Type propertyType, IEnumerable<Attribute> annotations) {
+        public SyntheticPropertyInfo(string name, Type source, Type propertyType, IEnumerable<Attribute> annotations) {
             Debug.Assert(name is not null && name != "");
             Debug.Assert(source is not null);
             Debug.Assert(propertyType is not null);

--- a/src/Kvasir/Translation/Translator.cs
+++ b/src/Kvasir/Translation/Translator.cs
@@ -35,8 +35,9 @@ namespace Kvasir.Translation {
                 var context = new Context(source);
                 var principal = TranslatePrincipalTable(context, source);
                 var relations = TranslateRelationTables(source);
+                var localizations = TranslateLocalizationTables(source);
 
-                var result = new EntityTranslation(CLRSource: source, Principal: principal, Relations: relations);
+                var result = new EntityTranslation(source, principal, relations, localizations);
                 translationCache_[source] = result;
                 return result;
             }
@@ -80,9 +81,11 @@ namespace Kvasir.Translation {
             typeCache_ = new Dictionary<Type, IReadOnlyList<FieldGroup>>();
             translationCache_ = new Dictionary<Type, EntityTranslation>();
             principalTableCache_ = new Dictionary<Type, PrincipalTableDef>();
+            localizationTableCache_ = new Dictionary<Type, ITable>();
             tableNameCache_ = new Dictionary<TableName, Type>();
             pkCache_ = new Dictionary<Type, IReadOnlyList<FieldGroup>>();
             relationTrackersCache_ = new Dictionary<Type, IReadOnlyList<RelationTracker>>();
+            localizationTrackersCache_ = new Dictionary<Type, IReadOnlyList<LocalizationTracker>>();
             keyMatchers_ = new Dictionary<Type, KeyMatcher>();
         }
 
@@ -93,9 +96,11 @@ namespace Kvasir.Translation {
         private readonly Dictionary<Type, IReadOnlyList<FieldGroup>> typeCache_;
         private readonly Dictionary<Type, EntityTranslation> translationCache_;
         private readonly Dictionary<Type, PrincipalTableDef> principalTableCache_;
+        private readonly Dictionary<Type, ITable> localizationTableCache_;
         private readonly Dictionary<TableName, Type> tableNameCache_;
         private readonly Dictionary<Type, IReadOnlyList<FieldGroup>> pkCache_;
         private readonly Dictionary<Type, IReadOnlyList<RelationTracker>> relationTrackersCache_;
+        private readonly Dictionary<Type, IReadOnlyList<LocalizationTracker>> localizationTrackersCache_;
         private readonly Dictionary<Type, KeyMatcher> keyMatchers_;
     }
 }

--- a/src/Kvasir/Translation/Utility/Localization.cs
+++ b/src/Kvasir/Translation/Utility/Localization.cs
@@ -1,0 +1,77 @@
+﻿using Cybele.Extensions;
+using Kvasir.Localization;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace Kvasir.Translation {
+    /// <summary>
+    ///   The metadata describing the translation of a Localization type.
+    /// </summary>
+    ///
+    /// <param name="KeyProperty">The property defining the Localization Key.</param>
+    /// <param name="KeyType">The type of the Localization Key.</param>
+    /// <param name="LocaleType">The type of the Localization Locale.</param>
+    /// <param name="ValueType">The type of the Localization Value.</param>
+    /// <param name="IsKeyNullable"><see langword="true"/> if the Localization Key is nullable; otherwise, <see langword="false"/>.</param>
+    /// <param name="IsLocaleNullable"><see langword="true"/> if the Localization Locale is nullable; otherwise, <see langword="false"/>./param>
+    /// <param name="IsKeyNullable"><see langword="true"/> if the Localization Value is nullable; otherwise, <see langword="false"/>./param>
+    /// <param name="FirstDerivedProperty">The first derived property that is included in the data model, if any.</param>
+    internal readonly record struct LocalizationMetadata(
+        PropertyInfo KeyProperty,
+        Type KeyType,
+        Type LocaleType,
+        Type ValueType,
+        bool IsKeyNullable,
+        bool IsLocaleNullable,
+        bool IsValueNullable,
+        PropertyInfo? FirstDerivedProperty
+    );
+
+    /// <summary>
+    ///   A collection of helper functions for performing translation operations on Localization types.
+    /// </summary>
+    internal static class LocalizationHelper {
+        /// <summary>
+        ///   Reflects over a Localization type, extracting the important properties, types, and nullability statuses.
+        /// </summary>
+        /// <param name="localization">
+        ///   The Localization type.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="LocalizationMetadata"/> for <paramref name="localization"/>.
+        /// </returns>
+        public static LocalizationMetadata Reflect(Type localization) {
+            Debug.Assert(localization.IsInstanceOf(typeof(ILocalization)) && localization != typeof(ILocalization));
+
+            var flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.FlattenHierarchy;
+            var properties = localization.GetProperties(flags);
+            var baseProperties = properties.Where(p => p.DeclaringType!.IsGenericType && p.DeclaringType.GetGenericTypeDefinition() == typeof(Localization<,,>));
+            var derivedProperties = properties.Where(p => !baseProperties.Contains(p) && p.TranslationCategory().Equals(PropertyCategory.InDataModel));
+
+            // The `Key` and `Relation` properties are directly on the base Localization<> type, so we need to make sure
+            // to pull them from there to avoid picking up derived properties. The `Relation` type has a bunch of
+            // properties inherited from the base collection interfaces; the one at index [5] is the `ConnectionType`,
+            // which holds the key-value pair from which we can extract the `Locale` and the `Value`.
+            var keyProperty = baseProperties.Where(p => p.Name == "Key").First();
+            var relationProperty = baseProperties.Where(p => p.Name == "Relation").First();
+            var localeProperty = ((Type)relationProperty.PropertyType.GetProperties(flags)[5]!.GetValue(null)!).GetProperty("Key", flags)!;
+            var valueProperty = ((Type)relationProperty.PropertyType.GetProperties(flags)[5]!.GetValue(null)!).GetProperty("Value", flags)!;
+
+            var keyNullabilityInfo = new NullabilityInfoContext().Create(keyProperty);
+            var relationNullabilityInfo = new NullabilityInfoContext().Create(relationProperty);
+
+            return new LocalizationMetadata() {
+                KeyProperty = keyProperty,
+                KeyType = keyProperty.PropertyType,
+                LocaleType = localeProperty.PropertyType,
+                ValueType = valueProperty.PropertyType,
+                IsKeyNullable = keyNullabilityInfo.ReadState == NullabilityState.Nullable,
+                IsLocaleNullable = relationNullabilityInfo.GenericTypeArguments[0].ReadState == NullabilityState.Nullable,
+                IsValueNullable = relationNullabilityInfo.GenericTypeArguments[1].ReadState == NullabilityState.Nullable,
+                FirstDerivedProperty = derivedProperties.OrderBy(p => p.Name).FirstOrDefault()
+            };
+        }
+    }
+}

--- a/test/UnitTests/Kvasir/Translation/CandidateKeys.cs
+++ b/test/UnitTests/Kvasir/Translation/CandidateKeys.cs
@@ -2,8 +2,8 @@
 using Kvasir.Translation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using static UT.Kvasir.Translation.Globals;
 using static UT.Kvasir.Translation.CandidateKeys;
+using static UT.Kvasir.Translation.Globals;
 
 namespace UT.Kvasir.Translation {
     [TestClass, TestCategory("Candidate Keys")]
@@ -401,6 +401,39 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherCandidateKeys();
         }
 
+        [TestMethod] public void LocalizationInCandidateKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(ToDoList);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveAnonymousCandidateKey().OfFields(
+                    "Deadline"
+                ).And
+                .HaveNoOtherCandidateKeys();
+        }
+
+        [TestMethod] public void NestedLocalizationInCandidateKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Hexagon);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveCandidateKey("Center").OfFields(
+                    "CenterPoint.X",
+                    "CenterPoint.Y"
+                ).And
+                .HaveNoOtherCandidateKeys();
+        }
+
         [TestMethod] public void ScalarAndNestedFieldsInSameCandidateKey() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -647,6 +680,38 @@ namespace UT.Kvasir.Translation {
             translate.Should().FailWith<InapplicableAnnotationException>()
                 .WithLocation("`LimboCompetition` → <synthetic> `Heights`")
                 .WithProblem("the annotation cannot be applied to a property of Relation type `IReadOnlyRelationMap<string, float>`")
+                .WithAnnotations("[Unique]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(GameChanger);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`GameChanger` → AirDate")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Unique]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Ramen);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Ramen` → Name")
+                .WithProblem("the path \"Value\" does not exist")
                 .WithAnnotations("[Unique]")
                 .EndMessage();
         }

--- a/test/UnitTests/Kvasir/Translation/ColumnOrdering.cs
+++ b/test/UnitTests/Kvasir/Translation/ColumnOrdering.cs
@@ -131,6 +131,41 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void LocalizationTableOrdering() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(MemoryLeak);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Localizations[0].Table.Should()
+                .HaveField("Key").AtColumn(0).And
+                .HaveField("Locale").AtColumn(1).And
+                .HaveField("Value").AtColumn(2).And
+                .HaveNoOtherFields();
+        }
+
+        [TestMethod] public void LocalizationFieldsOrdered() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Merger);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("AbsorbingCompany").AtColumn(2).And
+                .HaveField("AbsorbedCompany").AtColumn(0).And
+                .HaveField("StockSplit").AtColumn(5).And
+                .HaveField("Cost").AtColumn(4).And
+                .HaveField("Date").AtColumn(1).And
+                .HaveField("AntitrustExemption").AtColumn(3).And
+                .HaveNoOtherFields();
+        }
+
         [TestMethod] public void PreDefinedInstanceOrdered_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);

--- a/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
@@ -4,12 +4,12 @@ using Kvasir.Translation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-using static UT.Kvasir.Translation.Globals;
-using static UT.Kvasir.Translation.ComparisonConstraints.IsGreaterThan;
-using static UT.Kvasir.Translation.ComparisonConstraints.IsLessThan;
 using static UT.Kvasir.Translation.ComparisonConstraints.IsGreaterOrEqualTo;
+using static UT.Kvasir.Translation.ComparisonConstraints.IsGreaterThan;
 using static UT.Kvasir.Translation.ComparisonConstraints.IsLessOrEqualTo;
+using static UT.Kvasir.Translation.ComparisonConstraints.IsLessThan;
 using static UT.Kvasir.Translation.ComparisonConstraints.IsNot;
+using static UT.Kvasir.Translation.Globals;
 
 namespace UT.Kvasir.Translation {
     [TestClass, TestCategory("Constraints - Comparison")]
@@ -122,6 +122,38 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`Orisha` → BelongsTo")
                 .WithProblem("the annotation cannot be applied to a Field of non-orderable type `Culture`")
                 .WithAnnotations("[Check.IsGreaterThan")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsGreaterThan_LocalizationFieldWithApplicableKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(IsraeliPrimeMinister);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("DomesticApproval", ComparisonOperator.GT, (short)17).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsGreaterThan_LocalizationFieldWithInapplicableKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(ArconiaMurder);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`ArconiaMurder` → Date")
+                .WithProblem("the annotation cannot be applied to a Field of non-orderable type `Guid`")
+                .WithAnnotations("[Check.IsGreaterThan]")
                 .EndMessage();
         }
 
@@ -247,6 +279,39 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`BloodDrive` → SponsoredBy")
                 .WithPath("Hospital")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Hospital`")
+                .WithAnnotations("[Check.IsGreaterThan]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsGreaterThan_NestedLocalizationWithApplicableKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Valkyrie);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Identifier.Name", ComparisonOperator.GT, "ytnavc").And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsGreaterThan_NestedLocalizationWithInapplicableKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(LibraryCard);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`LibraryCard` → DateOf")
+                .WithPath("Expiration")
+                .WithProblem("the annotation cannot be applied to a Field of non-orderable type `Guid`")
                 .WithAnnotations("[Check.IsGreaterThan]")
                 .EndMessage();
         }
@@ -680,6 +745,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsGreaterThan_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(AmericanNinjaWarrior);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`AmericanNinjaWarrior` → Height")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsGreaterThan]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsGreaterThan_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Camel);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Camel` → Name")
+                .WithProblem("the path \"Value\" does not exist")
+                .WithAnnotations("[Check.IsGreaterThan]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsGreaterThan_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -824,6 +921,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsLessThan_LocalizationFieldWithApplicableKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(BuildABearWorkshop);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Revenue", ComparisonOperator.LT, "zswueal").And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsLessThan_LocalizationFieldWithInapplicableKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(HookahBar);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`HookahBar` → Groundbreaking")
+                .WithProblem("the annotation cannot be applied to a Field of non-orderable type `Guid`")
+                .WithAnnotations("[Check.IsLessThan]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsLessThan_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -948,6 +1077,39 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`Hallucination` → Reason")
                 .WithPath("Drug")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Drug`")
+                .WithAnnotations("[Check.IsLessThan]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsLessThan_NestedLocalizationWithApplicableKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(CivVITechnology);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("ResearchCost.Science", ComparisonOperator.LT, 761023UL).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsLessThan_NestedLocalizationWithInapplicableKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(MakeAWish);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`MakeAWish` → Status")
+                .WithPath("WishMade")
+                .WithProblem("the annotation cannot be applied to a Field of non-orderable type `Guid`")
                 .WithAnnotations("[Check.IsLessThan]")
                 .EndMessage();
         }
@@ -1382,6 +1544,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsLessThan_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Isotope);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Isotope` → AtomicWeight")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsLessThan]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsLesThan_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(WorldBaseballClassic);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`WorldBaseballClassic` → ChampionCountry")
+                .WithProblem("the path \"Key\" does not exist")
+                .WithAnnotations("[Check.IsLessThan]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsLessThan_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -1526,6 +1720,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsGreaterOrEqualTo_LocalizationFieldWithApplicableKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(PrisonerOfWar);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("War", ComparisonOperator.GTE, "yauqw").And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsGreaterOrEqualTo_LocalizationFieldWithInapplicableKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Diadochos);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Diadochos` → Commissioned")
+                .WithProblem("the annotation cannot be applied to a Field of non-orderable type `Guid`")
+                .WithAnnotations("[Check.IsGreaterOrEqualTO]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsGreaterOrEqualTo_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -1648,6 +1874,39 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`Barbie` → Relationships")
                 .WithPath("Boyfriend.Ken")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Ken`")
+                .WithAnnotations("[Check.IsGreaterOrEqualTo]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsGreaterOrEqualTo_NestedLocalizationWithApplicableKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Commander);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Identity.Name", ComparisonOperator.GTE, "bvafyral").And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsGreaterOrEqualTo_NestedLocalizationWithInapplicableKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(BuffaloWildWingsSauce);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`BuffaloWildWingsSauce` → History")
+                .WithPath("Discontinued")
+                .WithProblem("the annotation cannot be applied to a Field of non-orderable type `Guid`")
                 .WithAnnotations("[Check.IsGreaterOrEqualTo]")
                 .EndMessage();
         }
@@ -2079,6 +2338,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsGreaterOrEqualTo_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(PlasticSurgery);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`PlasticSurgery` → Cost")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsGreaterOrEqualTo]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsGreaterOrEqualTo_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Landfill);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Landfill` → Area")
+                .WithProblem("the path \"Locale\" does not exist")
+                .WithAnnotations("[Check.IsGreaterOrEqualTo]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsGreaterOrEqualTo_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -2224,6 +2515,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsLessOrEqualTo_LocalizationFieldWithApplicableKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(CrabRangoon);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Calories", ComparisonOperator.LTE, 10891UL).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsLessOrEqualTo_LocalizationFieldWithInapplicableKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Flamethrower);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Flamethrower` → SoldOn")
+                .WithProblem("the annotation cannot be applied to a Field of non-orderable type `Guid`")
+                .WithAnnotations("[Check.IsLessOrEqualTo]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsLessOrEqualTo_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -2345,6 +2668,39 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`Ransomware` → Extortion")
                 .WithPath("Ransom")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Ransom`")
+                .WithAnnotations("[Check.IsLessOrEqualTo]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsLessOrEqualTo_NestedLocalizationWithApplicableKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Coconut);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Measures.Volume", ComparisonOperator.LTE, 6172182904UL).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsLessOrEqualTo_NestedLocalizationWithInapplicableKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(SpecialVictim);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`SpecialVictim` → ImportantDates")
+                .WithPath("ArrestMade")
+                .WithProblem("the annotation cannot be applied to a Field of non-orderable type `Guid`")
                 .WithAnnotations("[Check.IsLessOrEqualTo]")
                 .EndMessage();
         }
@@ -2775,6 +3131,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsLessThanOrEqualTo_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(GolfCart);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`GolfCart` → TopSpeed")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsLessOrEqualTo]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsLessThanOrEqualTo_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(DDayBeach);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`DDayBeach` → Name")
+                .WithProblem("the path \"Key\" does not exist")
+                .WithAnnotations("[Check.IsLessOrEqualTo]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsLessOrEqualTo_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -2927,6 +3315,23 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
+        [TestMethod] public void IsNot_LocalizationField() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Catacombs);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Length", ComparisonOperator.NE, 541102UL).And
+                .HaveConstraint("Depth", ComparisonOperator.NE, 8UL).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void IsNot_AggregateNestedScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -3021,6 +3426,22 @@ namespace UT.Kvasir.Translation {
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Company`")
                 .WithAnnotations("[Check.IsNot]")
                 .EndMessage();
+        }
+
+        [TestMethod] public void IsNot_NestedLocalization() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Shtetl);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Demographics.Population", ComparisonOperator.NE, 6513UL).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void IsNot_RelationNestedScalar() {
@@ -3471,6 +3892,38 @@ namespace UT.Kvasir.Translation {
             translate.Should().FailWith<InapplicableAnnotationException>()
                 .WithLocation("`BachelorParty` → <synthetic> `Destinations`")
                 .WithProblem("the annotation cannot be applied to a property of Relation type `RelationList<Destination>`")
+                .WithAnnotations("[Check.IsNot]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNot_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Pitmaster);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Pitmaster` → AnnualRevenue")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsNot]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNot_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Skirt);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Skirt` → Length")
+                .WithProblem("the path \"Locale\" does not exist")
                 .WithAnnotations("[Check.IsNot]")
                 .EndMessage();
         }

--- a/test/UnitTests/Kvasir/Translation/CustomConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/CustomConstraints.cs
@@ -824,5 +824,32 @@ namespace UT.Kvasir.Translation {
                 .WithAnnotations("[Check.Complex]")
                 .EndMessage();
         }
+
+        [TestMethod] public void ComplexCheck_OnLocalization() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(MahjongTile);
+
+            // Act
+            var translation = translator[source];
+            var table = translation.Localizations[0].Table;
+
+            // Assert
+            table.CheckConstraints.Should().HaveCount(1);
+            table.CheckConstraints[0].Condition.Should().BeSameAs(CustomCheck.Clause);
+            table.CheckConstraints[0].Name.Should().NotHaveValue();
+            CustomCheck.LastCtorArgs.Should().BeEmpty();
+            CustomCheck.Generator.Received(1).MakeConstraint(
+                NArg.IsSameSequence<IEnumerable<IField>>(
+                    new IField[] {
+                        table[new NameOfField("Key")],
+                        table[new NameOfField("Locale")],
+                        table[new NameOfField("Value")]
+                    }
+                ),
+                Arg.Is<IEnumerable<DataConverter>>(s => s.Count() == 3),
+                Settings.Default
+            );
+        }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/DataConverters.cs
+++ b/test/UnitTests/Kvasir/Translation/DataConverters.cs
@@ -269,6 +269,22 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void ConverterOnLocalizationField_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(RiskTerritory);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`RiskTerritory` → Name")
+                .WithProblem("the annotation cannot be applied to a property of Localization type `LocalizedText`")
+                .WithAnnotations("[DataConverter]")
+                .EndMessage();
+        }
+
         [TestMethod] public void ConverterOnPreDefinedInstance_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -546,6 +562,22 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void NumericConverterOnLocalizationField_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(JapanesePrefecture);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`JapanesePrefecture` → Name")
+                .WithProblem("the annotation cannot be applied to a property of Localization type `LocalizedText`")
+                .WithAnnotations("[Numeric]")
+                .EndMessage();
+        }
+
         [TestMethod] public void NumericConverterOnPreDefinedInstance_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -702,6 +734,22 @@ namespace UT.Kvasir.Translation {
             translate.Should().FailWith<InvalidDataConverterException>()
                 .WithLocation("`Cryptogram` → <synthetic> `Solution`")
                 .WithProblem("the annotation cannot be applied to a property of non-enumeration type `RelationMap<char, char>`")
+                .WithAnnotations("[AsString]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void AsStringConverterOnLocalizationField_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(PettingZoo);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`PettingZoo` → GrandOpening")
+                .WithProblem("the annotation cannot be applied to a property of Localization type `LocalizedDate`")
                 .WithAnnotations("[AsString]")
                 .EndMessage();
         }

--- a/test/UnitTests/Kvasir/Translation/DefaultValues.cs
+++ b/test/UnitTests/Kvasir/Translation/DefaultValues.cs
@@ -322,6 +322,55 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherFields();
         }
 
+        [TestMethod] public void DefaultOnLocalizationField() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(ConfidentialInformant);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("InformantID").WithNoDefault().And
+                .HaveField("ManagingCop").WithNoDefault().And
+                .HaveField("ForImmunity").WithNoDefault().And
+                .HaveField("ArrestsFacilitated").WithNoDefault().And
+                .HaveField("TotalCompensation").WithDefault("localized-currency").And
+                .HaveNoOtherFields();
+            translation.Localizations[0].Table.Should()
+                .HaveField("Key").WithNoDefault().And
+                .HaveField("Locale").WithNoDefault().And
+                .HaveField("Value").WithNoDefault().And
+                .HaveNoOtherFields();
+        }
+
+        [TestMethod] public void DefaultOnNestedLocalizationField() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Cantrip);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("SpellName").WithNoDefault().And
+                .HaveField("Effect.Damage").WithNoDefault().And
+                .HaveField("Effect.DamageAmount").WithDefault(1000UL).And
+                .HaveField("Effect.IsHealing").WithNoDefault().And
+                .HaveField("Range").WithNoDefault().And
+                .HaveField("MagicSchool").WithNoDefault().And
+                .HaveField("Prevalence").WithNoDefault().And
+                .HaveNoOtherFields();
+            translation.Localizations[0].Table.Should()
+                .HaveField("Key").WithNoDefault().And
+                .HaveField("Locale").WithNoDefault().And
+                .HaveField("Value.Value").WithNoDefault().And
+                .HaveField("Value.Unit").WithNoDefault().And
+                .HaveNoOtherFields();
+        }
+
         [TestMethod] public void NullDefaultOnNonNullableScalar_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -884,6 +933,38 @@ namespace UT.Kvasir.Translation {
             translate.Should().FailWith<InapplicableAnnotationException>()
                 .WithLocation("`LaundryDetergent` → <synthetic> `Ingredients`")
                 .WithProblem("the annotation cannot be applied to a property of Relation type `RelationSet<string>`")
+                .WithAnnotations("[Default]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(SportsCenter);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`SportsCenter` → AirDate")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Default]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Caddie);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Caddie` → CarryingCapacity")
+                .WithProblem("the path \"Value\" does not exist")
                 .WithAnnotations("[Default]")
                 .EndMessage();
         }

--- a/test/UnitTests/Kvasir/Translation/DiscretenessConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/DiscretenessConstraints.cs
@@ -142,6 +142,24 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
+        [TestMethod] public void IsOneOf_LocalizationField() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Zeppelin);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("FuelEfficiency", InclusionOperator.In,
+                    5UL, 18UL, 39UL, 196UL
+                ).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void IsOneOf_AggregateNestedScalarField() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -206,6 +224,24 @@ namespace UT.Kvasir.Translation {
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Observatory`")
                 .WithAnnotations("[Check.IsOneOf]")
                 .EndMessage();
+        }
+
+        [TestMethod] public void IsOneOf_NestedLocalizationField() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(TemperatureScale);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("WaterMeasures.Freezing", InclusionOperator.In,
+                    0UL, 317UL, 22UL
+                ).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void IsOneOf_RelationNestedScalarField() {
@@ -729,6 +765,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsOneOf_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Bailiff);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Bailiff` → Courthouse")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsOneOf]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsOneOf_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(NavalBase);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`NavalBase` → OperatingCountry")
+                .WithProblem("the path \"Key\" does not exist")
+                .WithAnnotations("[Check.IsOneOf]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsOneOf_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -894,6 +962,24 @@ namespace UT.Kvasir.Translation {
                 .HaveNoOtherConstraints();
         }
 
+        [TestMethod] public void IsNotOneOf_LocalizationField() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(SECShort);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("VideoDuration", InclusionOperator.NotIn,
+                    0UL, 1UL, 2UL
+                ).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
         [TestMethod] public void IsNotOneOf_AggregateNestedScalarField() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -987,6 +1073,22 @@ namespace UT.Kvasir.Translation {
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Character`")
                 .WithAnnotations("[Check.IsNotOneOf]")
                 .EndMessage();
+        }
+
+        [TestMethod] public void IsNotOneOf_NestedLocalizationField() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(GregorianChant);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Dates.Written", ComparisonOperator.NE, new Guid("e8383177-3142-4a24-adef-ddfb6f644919")).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
         }
 
         [TestMethod] public void IsNotOneOf_RelationNestedScalarField() {
@@ -1483,6 +1585,38 @@ namespace UT.Kvasir.Translation {
             translate.Should().FailWith<InapplicableAnnotationException>()
                 .WithLocation("`QRCode` → <synthetic> `Vertical`")
                 .WithProblem("the annotation cannot be applied to a property of Relation type `RelationList<bool>`")
+                .WithAnnotations("[Check.IsNotOneOf]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNotOneOf_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Bedouin);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Bedouin` → Tribe")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsNotOneOf]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNotOneOf_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(RubiksCube);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`RubiksCube` → Difficulty")
+                .WithProblem("the path \"Locale\" does not exist")
                 .WithAnnotations("[Check.IsNotOneOf]")
                 .EndMessage();
         }

--- a/test/UnitTests/Kvasir/Translation/FieldNaming.cs
+++ b/test/UnitTests/Kvasir/Translation/FieldNaming.cs
@@ -606,6 +606,54 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void ChangeNameOfLocalizationField() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Shiva);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("Decedent").OfTypeText().BeingNonNullable().And
+                .HaveField("ShivaAddress").OfTypeText().BeingNonNullable().And
+                .HaveField("Date").OfTypeDate().BeingNonNullable().And
+                .HaveField("IsBuffet").OfTypeBoolean().BeingNonNullable().And
+                .HaveField("Attendees").OfTypeUInt16().BeingNonNullable().And
+                .HaveField("Judaism").OfTypeEnumeration(
+                    Shiva.Denomination.Reform,
+                    Shiva.Denomination.Conservative,
+                    Shiva.Denomination.Orthodox,
+                    Shiva.Denomination.Haredi,
+                    Shiva.Denomination.Secular
+                ).BeingNonNullable().And
+                .HaveNoOtherFields();
+        }
+
+        [TestMethod] public void ChangeNameOfNestedLocalizationField() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(BollywoodMovie);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("IMDbID").OfTypeUInt64().BeingNonNullable().And
+                .HaveField("DanceNumbers").OfTypeUInt16().BeingNonNullable().And
+                .HaveField("DirectorsGuild").OfTypeText().BeingNonNullable().And
+                .HaveField("FilmDirector.Name").OfTypeText().BeingNonNullable().And
+                .HaveField("FilmDirector.DirectorNumber").OfTypeUInt64().BeingNonNullable().And
+                .HaveField("RuntimeMinutes").OfTypeUInt32().BeingNonNullable().And
+                .HaveField("Year").OfTypeUInt16().BeingNonNullable().And
+                .HaveField("Budget").OfTypeDecimal().BeingNonNullable().And
+                .HaveField("BoxOffice").OfTypeDecimal().BeingNonNullable().And
+                .HaveField("StarsShahRukhKhan").OfTypeBoolean().BeingNonNullable().And
+                .HaveNoOtherFields();
+        }
+
         [TestMethod] public void NameChangeOnAggregateNestedFieldOverridesOriginalNameChange() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -729,6 +777,26 @@ namespace UT.Kvasir.Translation {
                     .WithOnDeleteBehavior(OnDelete.Cascade)
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
+        }
+
+        [TestMethod] public void NameChangeOnNestedLocalizationOverridesOriginalNameChange() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(MovingCompany);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("ID").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Company.License").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Trademark").OfTypeText().BeingNonNullable().And
+                .HaveField("Founding").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Employees").OfTypeUInt64().BeingNonNullable().And
+                .HaveField("FleetSize").OfTypeUInt16().BeingNonNullable().And
+                .HaveField("YearlyRevenue").OfTypeDecimal().BeingNonNullable().And
+                .HaveNoOtherFields();
         }
 
         [TestMethod] public void MultipleNameChangesOnNestedProperty_IsError() {
@@ -938,6 +1006,38 @@ namespace UT.Kvasir.Translation {
             translate.Should().FailWith<InvalidPathException>()
                 .WithLocation("`Yeshiva` → <synthetic> `Students`")
                 .WithProblem("the path \"Yeshiva.City\" does not exist")
+                .WithAnnotations("[Name]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Slushy);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Slushy` → Flavor")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Name]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Spoonerism);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Spoonerism` → SpoonerizedText")
+                .WithProblem("the path \"Locale\" does not exist")
                 .WithAnnotations("[Name]")
                 .EndMessage();
         }

--- a/test/UnitTests/Kvasir/Translation/Nullability.cs
+++ b/test/UnitTests/Kvasir/Translation/Nullability.cs
@@ -341,7 +341,7 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
-        [TestMethod] public void RelationMarkedNonNullable_Redundant() {
+        [TestMethod] public void RelationMarkedNonNullable() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
             var source = typeof(Squintern);
@@ -411,6 +411,120 @@ namespace UT.Kvasir.Translation {
                 .WithProblem("the annotation cannot be applied to a pre-defined instance property")
                 .WithAnnotations("[Nullable]")
                 .EndMessage();
+        }
+
+        [TestMethod] public void NullableLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Madrigal);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidNativeNullabilityException>()
+                .WithLocation("`Madrigal` → Gift")
+                .WithProblem("a property of Localization type cannot be nullable");
+        }
+
+        [TestMethod] public void LocalizationWithNullableValue() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(HolocaustMuseum);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Localizations[0].Table.Should()
+                .HaveField("Key").OfTypeText().BeingNonNullable().And
+                .HaveField("Locale").OfTypeEnumeration(
+                    TestLocalizations.Language.English,
+                    TestLocalizations.Language.Spanish,
+                    TestLocalizations.Language.French,
+                    TestLocalizations.Language.Hebrew,
+                    TestLocalizations.Language.Hindi,
+                    TestLocalizations.Language.German,
+                    TestLocalizations.Language.Arabic,
+                    TestLocalizations.Language.Japanese,
+                    TestLocalizations.Language.Esperanto,
+                    TestLocalizations.Language.Italian
+                ).BeingNonNullable().And
+                .HaveField("Value").OfTypeText().BeingNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+        }
+
+        [TestMethod] public void LocalizationWithNullableKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(ClassActionLawsuit);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidNativeNullabilityException>()
+                .WithLocation("`ClassActionLawsuit` → `LocalizedName` (from \"Case\") → Key")
+                .WithProblem("the Localization Key type of a Localization cannot be nullable");
+        }
+
+        [TestMethod] public void LocalizationWithNullableLocale_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Halide);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidNativeNullabilityException>()
+                .WithLocation("`Halide` → `LocalizedElement` (from \"Halogen\") → Locale")
+                .WithProblem("the Locale type of a Localization cannot be nullable");
+        }
+
+        [TestMethod] public void LocalizationMarkedNonNullable() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(CivVIPolicy);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Localizations[0].Table.Should()
+                .HaveField("Key").OfTypeText().BeingNonNullable().And
+                .HaveField("Locale").OfTypeEnumeration(
+                    TestLocalizations.Language.English,
+                    TestLocalizations.Language.Spanish,
+                    TestLocalizations.Language.French,
+                    TestLocalizations.Language.Hebrew,
+                    TestLocalizations.Language.Hindi,
+                    TestLocalizations.Language.German,
+                    TestLocalizations.Language.Arabic,
+                    TestLocalizations.Language.Japanese,
+                    TestLocalizations.Language.Esperanto,
+                    TestLocalizations.Language.Italian
+                ).BeingNonNullable().And
+                .HaveField("Value").OfTypeText().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+            translation.Localizations[1].Table.Should().Be(translation.Localizations[0].Table);
+        }
+
+        [TestMethod] public void LocalizationMarkedNullable_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Superintendent);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Superintendent` → District")
+                .WithProblem("the annotation cannot be applied to a property of Localization type `LocalizedText`")
+                .WithAnnotations("[Nullable]");
         }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
+++ b/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
@@ -21,7 +21,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("Byte").OfTypeUInt8().BeingNonNullable().And
                 .HaveField("Char").OfTypeCharacter().BeingNonNullable().And
@@ -41,6 +40,8 @@ namespace UT.Kvasir.Translation {
                 .HaveField("UShort").OfTypeUInt16().BeingNonNullable().And
                 .HaveNoOtherFields().And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void NullableScalars() {
@@ -52,7 +53,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("Byte").OfTypeUInt8().BeingNullable().And
                 .HaveField("Char").OfTypeCharacter().BeingNullable().And
@@ -73,6 +73,8 @@ namespace UT.Kvasir.Translation {
                 .HaveField("PrimaryKey").OfTypeInt32().BeingNonNullable().And
                 .HaveNoOtherFields().And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void PropertyTypeIsDelegate_IsError() {
@@ -321,7 +323,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("Name").OfTypeText().BeingNonNullable().And
                 .HaveField("Charisma").OfTypeUInt8().BeingNonNullable().And
@@ -331,6 +332,8 @@ namespace UT.Kvasir.Translation {
                 .HaveField("Strength").OfTypeUInt8().BeingNonNullable().And
                 .HaveField("Wisdom").OfTypeUInt8().BeingNonNullable().And
                 .HaveNoOtherFields();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void Enumerations() {
@@ -342,7 +345,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("Name").OfTypeText().BeingNonNullable().And
                 .HaveField("AttackBonus").OfTypeUInt16().BeingNonNullable().And
@@ -380,6 +382,8 @@ namespace UT.Kvasir.Translation {
                 ).BeingNullable().And
                 .HaveNoOtherFields().And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void NonNullableAggregates() {
@@ -391,7 +395,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("Name").OfTypeText().BeingNonNullable().And
                 .HaveField("Founder.Name").OfTypeText().BeingNonNullable().And
@@ -405,6 +408,8 @@ namespace UT.Kvasir.Translation {
                 .HaveField("Capital.Name").OfTypeText().BeingNonNullable().And
                 .HaveNoOtherFields().And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void NullableAggregates() {
@@ -416,7 +421,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("ID").OfTypeGuid().BeingNonNullable().And
                 .HaveField("Brand").OfTypeText().BeingNonNullable().And
@@ -433,6 +437,8 @@ namespace UT.Kvasir.Translation {
                 ).BeingNonNullable().And
                 .HaveNoOtherFields().And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void NestedAggregates() {
@@ -444,7 +450,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("Species").OfTypeText().BeingNonNullable().And
                 .HaveField("Stats.STR").OfTypeUInt8().BeingNullable().And
@@ -477,6 +482,8 @@ namespace UT.Kvasir.Translation {
                 .HaveField("LegendaryActions").OfTypeUInt8().BeingNonNullable().And
                 .HaveNoOtherFields().And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void NonNullableReferences() {
@@ -488,7 +495,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("CommonName").OfTypeText().BeingNonNullable().And
                 .HaveField("Genus.Genus").OfTypeText().BeingNonNullable().And
@@ -502,6 +508,8 @@ namespace UT.Kvasir.Translation {
                     .WithOnDeleteBehavior(OnDelete.Cascade)
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void NullableReferences() {
@@ -513,7 +521,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("RegistrationNumber").OfTypeGuid().BeingNonNullable().And
                 .HaveField("PassengerCapacity").OfTypeUInt64().BeingNullable().And
@@ -540,6 +547,8 @@ namespace UT.Kvasir.Translation {
                     .WithOnDeleteBehavior(OnDelete.Cascade)
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void ReferencesNestedWithinAggregates() {
@@ -551,7 +560,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("ID").OfTypeGuid().BeingNonNullable().And
                 .HaveField("Airing.Month").OfTypeEnumeration(
@@ -597,6 +605,8 @@ namespace UT.Kvasir.Translation {
                     .WithOnDeleteBehavior(OnDelete.Cascade)
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void ReferencesNestedWithinReferencesNonPrimaryKey() {
@@ -608,7 +618,6 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Relations.Should().BeEmpty();
             translation.Principal.Table.Should()
                 .HaveField("Name").OfTypeText().BeingNonNullable().And
                 .HaveField("Powers").OfTypeEnumeration(
@@ -626,6 +635,8 @@ namespace UT.Kvasir.Translation {
                     .WithOnDeleteBehavior(OnDelete.Cascade)
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void ReferencesNestedWithinReferencesPrimaryKey() {
@@ -655,6 +666,8 @@ namespace UT.Kvasir.Translation {
                     .WithOnDeleteBehavior(OnDelete.Cascade)
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void NonNullableRelationsOfNonNullableElements() {
@@ -823,7 +836,22 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<NestedRelationException>()
                 .WithLocation("`BlackHole` → <synthetic> `Measurements` → Value")
-                .WithProblem("nested Relations are not supported")
+                .WithProblem("nested Relations (i.e. within a Localization or another Relation) are not supported")
+                .EndMessage();
+        }
+
+        [TestMethod] public void RelationNestedWithinLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Fondue);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NestedRelationException>()
+                .WithLocation("`Fondue` → `LocalizedIngredients` (from \"Ingredients\") → Value")
+                .WithProblem("nested Relations (i.e. within a Localization or another Relation) are not supported")
                 .EndMessage();
         }
 
@@ -838,7 +866,22 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<NestedRelationException>()
                 .WithLocation("`IntelligenceAgency` → `Leadership` (from \"Board\") → <synthetic> `Roles` → Value")
-                .WithProblem("nested Relations are not supported")
+                .WithProblem("nested Relations (i.e. within a Localization or another Relation) are not supported")
+                .EndMessage();
+        }
+
+        [TestMethod] public void RelationNestedWithinLocalizationNestedWithinAggregate_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(AmicusBrief);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NestedRelationException>()
+                .WithLocation("`AmicusBrief` → `Contributors` (from \"Authors\") → `LocalizedAuthors` (from \"Secondary\") → Value")
+                .WithProblem("nested Relations (i.e. within a Localization or another Relation) are not supported")
                 .EndMessage();
         }
 
@@ -853,7 +896,22 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<NestedRelationException>()
                 .WithLocation("`Poll` → <synthetic> `Questions` → `Question` (from \"Item\") → Answers")
-                .WithProblem("nested Relations are not supported")
+                .WithProblem("nested Relations (i.e. within a Localization or another Relation) are not supported")
+                .EndMessage();
+        }
+
+        [TestMethod] public void RelationNestedWithinAggregateNestedWithinLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(PreprocessorMacro);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NestedRelationException>()
+                .WithLocation("`PreprocessorMacro` → `LocalizedArgs` (from \"Arguments\") → `Argument` (from \"Value\") → Concepts")
+                .WithProblem("nested Relations (i.e. within a Localization or another Relation) are not supported")
                 .EndMessage();
         }
 
@@ -868,7 +926,22 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<NestedRelationException>()
                 .WithLocation("`Quinceanera` → <synthetic> `Presents` → `Gift` (from \"Value\") → Adjectives")
-                .WithProblem("nested Relations are not supported")
+                .WithProblem("nested Relations (i.e. within a Localization or another Relation) are not supported")
+                .EndMessage();
+        }
+
+        [TestMethod] public void RelationNestedWithinAggregateNestedWithinLocalization_PostMemoization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Parable);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NestedRelationException>()
+                .WithLocation("`Parable` → `LocalizedCitation` (from \"Mentions\") → `Citation` (from \"Value\") → Verses")
+                .WithProblem("nested Relations (i.e. within a Localization or another Relation) are not supported")
                 .EndMessage();
         }
 
@@ -884,6 +957,21 @@ namespace UT.Kvasir.Translation {
             translate.Should().FailWith<InvalidPropertyInDataModelException>()
                 .WithLocation("`Caricature` → <synthetic> `SaleHistory` → Item")
                 .WithProblem("type `KeyValuePair<DateTime, decimal>` is a closed generic type and cannot be the backing type of a property")
+                .EndMessage();
+        }
+
+        [TestMethod] public void PropertyTypeIsListSetOfThreeValueTuple_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(StirFry);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPropertyInDataModelException>()
+                .WithLocation("`StirFry` → <synthetic> `Ingredients` → Item")
+                .WithProblem("type `Tuple<int, string, string>` is a closed generic type and cannot be the backing type of a property")
                 .EndMessage();
         }
 
@@ -956,6 +1044,374 @@ namespace UT.Kvasir.Translation {
                     .WithOnDeleteBehavior(OnDelete.Cascade)
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
+        }
+
+        [TestMethod] public void NonNullableLocalizationsOfNonNullableElements() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Retrovirus);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("VirusID").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Variety").OfTypeEnumeration(
+                    Retrovirus.Class.Lentivirus,
+                    Retrovirus.Class.Oncoretrovirus,
+                    Retrovirus.Class.Spumavirus
+                ).BeingNonNullable().And
+                .HaveField("Name").OfTypeText().BeingNonNullable().And
+                .HaveField("Incidence").OfTypeDouble().BeingNonNullable().And
+                .HaveField("FirstIdentified").OfTypeGuid().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().HaveCount(2);
+            translation.Localizations[0].Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestLocalizations+LocalizedDateTable").And
+                .HaveField("Key").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Locale").OfTypeEnumeration(
+                    TestLocalizations.Calendar.Julian,
+                    TestLocalizations.Calendar.Gregorian
+                ).BeingNonNullable().And
+                .HaveField("Value").OfTypeDate().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+            translation.Localizations[1].Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestLocalizations+LocalizedTextTable").And
+                .HaveField("Key").OfTypeText().BeingNonNullable().And
+                .HaveField("Locale").OfTypeEnumeration(
+                    TestLocalizations.Language.English,
+                    TestLocalizations.Language.Spanish,
+                    TestLocalizations.Language.French,
+                    TestLocalizations.Language.Hebrew,
+                    TestLocalizations.Language.Hindi,
+                    TestLocalizations.Language.German,
+                    TestLocalizations.Language.Arabic,
+                    TestLocalizations.Language.Japanese,
+                    TestLocalizations.Language.Esperanto,
+                    TestLocalizations.Language.Italian
+                ).BeingNonNullable().And
+                .HaveField("Value").OfTypeText().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+        }
+
+        [TestMethod] public void ReadOnlyLocalizations() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Debate);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("DebateID").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Participant1").OfTypeText().BeingNonNullable().And
+                .HaveField("Participant2").OfTypeText().BeingNonNullable().And
+                .HaveField("Topic").OfTypeText().BeingNonNullable().And
+                .HaveField("NumJudges").OfTypeUInt8().BeingNonNullable().And
+                .HaveField("RebuttalsAllowed").OfTypeBoolean().BeingNonNullable().And
+                .HaveField("DurationMinutes").OfTypeDouble().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().HaveCount(1);
+            translation.Localizations[0].Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestLocalizations+LocalizedReadOnlyTextTable").And
+                .HaveField("Key").OfTypeText().BeingNonNullable().And
+                .HaveField("Locale").OfTypeEnumeration(
+                    TestLocalizations.Language.English,
+                    TestLocalizations.Language.Spanish,
+                    TestLocalizations.Language.French,
+                    TestLocalizations.Language.Hebrew,
+                    TestLocalizations.Language.Hindi,
+                    TestLocalizations.Language.German,
+                    TestLocalizations.Language.Arabic,
+                    TestLocalizations.Language.Japanese,
+                    TestLocalizations.Language.Esperanto,
+                    TestLocalizations.Language.Italian
+                ).BeingNonNullable().And
+                .HaveField("Value").OfTypeText().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+        }
+
+        [TestMethod] public void LocalizationsNestedWithinAggregates() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Bodybuilder);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveField("ID").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Birthdate").OfTypeDate().BeingNonNullable().And
+                .HaveField("Stats.Height").OfTypeUInt64().BeingNonNullable().And
+                .HaveField("Stats.Weight").OfTypeUInt64().BeingNonNullable().And
+                .HaveField("Stats.BMI").OfTypeSingle().BeingNonNullable().And
+                .HaveField("WonOlympiaCompetition").OfTypeBoolean().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+            translation.Relations.Should().BeEmpty();
+            translation.Localizations.Should().HaveCount(2);
+            translation.Localizations[0].Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestLocalizations+LocalizedMeasureTable").And
+                .HaveField("Key").OfTypeUInt64().BeingNonNullable().And
+                .HaveField("Locale").OfTypeEnumeration(
+                    TestLocalizations.System.Imperial,
+                    TestLocalizations.System.Metric,
+                    TestLocalizations.System.Celsius,
+                    TestLocalizations.System.Fahrenheit,
+                    TestLocalizations.System.Kelvin
+                ).BeingNonNullable().And
+                .HaveField("Value.Value").OfTypeDouble().BeingNonNullable().And
+                .HaveField("Value.Unit").OfTypeText().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+            translation.Localizations[1].Table.Should().Be(translation.Localizations[0].Table);
+        }
+
+        [TestMethod] public void LocalizationsNestedWithinRelations() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(AdventCalendar);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Relations.Should().HaveCount(1);
+            translation.Relations[0].Table.Should()
+                .HaveName("UT.Kvasir.Translation.PropertyTypes+AdventCalendar.GiftsTable").And
+                .HaveField("AdventCalendar.CalendarID").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Key").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Value").OfTypeText().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveForeignKey("AdventCalendar.CalendarID")
+                    .Against(translation.Principal.Table)
+                    .WithOnDeleteBehavior(OnDelete.Cascade)
+                    .WithOnUpdateBehavior(OnUpdate.Cascade).And
+                .HaveNoOtherForeignKeys();
+            translation.Localizations.Should().HaveCount(1);
+            translation.Localizations[0].Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestLocalizations+LocalizedDateTable").And
+                .HaveField("Key").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Locale").OfTypeEnumeration(
+                    TestLocalizations.Calendar.Julian,
+                    TestLocalizations.Calendar.Gregorian
+                ).BeingNonNullable().And
+                .HaveField("Value").OfTypeDate().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+        }
+
+        [TestMethod] public void LocalizationNestedWithinLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Execution);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NestedLocalizationException>()
+                .WithLocation("`Execution` → `LocalizedCrime` (from \"ExecutedFor\") → Locale")
+                .WithProblem("nested Localizations (i.e. within another Localization) are not supported")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LocalizationsNestedWithinRelationNestedWithinAggregate() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Chiropractor);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Relations.Should().HaveCount(1);
+            translation.Relations[0].Table.Should()
+                .HaveName("UT.Kvasir.Translation.PropertyTypes+Chiropractor.Licensure.DegreesTable").And
+                .HaveField("Chiropractor.DoctorID").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Key").OfTypeEnumeration(
+                    Chiropractor.Degree.HighSchoolDiploma,
+                    Chiropractor.Degree.Undergrad,
+                    Chiropractor.Degree.Masters,
+                    Chiropractor.Degree.PhD,
+                    Chiropractor.Degree.MD,
+                    Chiropractor.Degree.JD
+                ).BeingNonNullable().And
+                .HaveField("Value").OfTypeGuid().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveForeignKey("Chiropractor.DoctorID")
+                    .Against(translation.Principal.Table)
+                    .WithOnDeleteBehavior(OnDelete.Cascade)
+                    .WithOnUpdateBehavior(OnUpdate.Cascade).And
+                .HaveNoOtherForeignKeys();
+            translation.Localizations.Should().HaveCount(1);
+            translation.Localizations[0].Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestLocalizations+LocalizedDateTable").And
+                .HaveField("Key").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Locale").OfTypeEnumeration(
+                    TestLocalizations.Calendar.Julian,
+                    TestLocalizations.Calendar.Gregorian
+                ).BeingNonNullable().And
+                .HaveField("Value").OfTypeDate().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+        }
+
+        [TestMethod] public void LocalizationNestedWithinLocalizationNestedWithinAggregate_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Coffee);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NestedLocalizationException>()
+                .WithLocation("`Coffee` → `Trademark` (from \"ID\") → `LocalizedName` (from \"Name\") → Value")
+                .WithProblem("nested Localizations (i.e. within another Localization) are not supported")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LocalizationsNestedWithinAggregateNestedWithinRelation() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Triumvirate);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Relations.Should().HaveCount(1);
+            translation.Relations[0].Table.Should()
+                .HaveName("UT.Kvasir.Translation.PropertyTypes+Triumvirate.MembersTable").And
+                .HaveField("Triumvirate.TriumvirateID").OfTypeGuid().BeingNonNullable().And
+                .HaveField("Item.Ranking").OfTypeUInt8().BeingNonNullable().And
+                .HaveField("Item.Name").OfTypeText().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveForeignKey("Triumvirate.TriumvirateID")
+                    .Against(translation.Principal.Table)
+                    .WithOnDeleteBehavior(OnDelete.Cascade)
+                    .WithOnUpdateBehavior(OnUpdate.Cascade).And
+                .HaveNoOtherForeignKeys();
+            translation.Localizations.Should().HaveCount(1);
+            translation.Localizations[0].Table.Should()
+                .HaveName("UT.Kvasir.Translation.TestLocalizations+LocalizedTextTable").And
+                .HaveField("Key").OfTypeText().BeingNonNullable().And
+                .HaveField("Locale").OfTypeEnumeration(
+                    TestLocalizations.Language.English,
+                    TestLocalizations.Language.Spanish,
+                    TestLocalizations.Language.French,
+                    TestLocalizations.Language.Hebrew,
+                    TestLocalizations.Language.Hindi,
+                    TestLocalizations.Language.German,
+                    TestLocalizations.Language.Arabic,
+                    TestLocalizations.Language.Japanese,
+                    TestLocalizations.Language.Esperanto,
+                    TestLocalizations.Language.Italian
+                ).BeingNonNullable().And
+                .HaveField("Value").OfTypeText().BeingNonNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
+        }
+
+        [TestMethod] public void LocalizationNestedWithinAggregateNestedWithinLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Laundromat);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NestedLocalizationException>()
+                .WithLocation("`Laundromat` → `LocalizedCost` (from \"Charges\") → `Service` (from \"Locale\") → Cost")
+                .WithProblem("nested Localizations (i.e. within another Localization) are not supported")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LocalizationNestedWithinAggregateNestedWithinLocalization_PostMemoization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Sommelier);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NestedLocalizationException>()
+                .WithLocation("`Sommelier` → `LocalizedWine` (from \"LeastFavoriteWine\") → `Vintage` (from \"Value\") → Name")
+                .WithProblem("nested Localizations (i.e. within another Localization) are not supported")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LocalizationWithAggregateKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(ParoleHearing);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidLocalizationKeyException>()
+                .WithLocation("`ParoleHearing` → `LocalizedPrisoner` (from \"Parolee\") → Key")
+                .WithProblem("type `Sentence` is a struct or a record struct and cannot be the type of a Localization Key")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LocalizationWithReferenceKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Cocktail);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidLocalizationKeyException>()
+                .WithLocation("`Cocktail` → `LocalizedBooze` (from \"PrimaryAlcohol\") → Key")
+                .WithProblem("type `Alcohol` is a class or a record class and cannot be the type of a Localization Key")
+                .EndMessage();
+        }
+
+        [TestMethod] public void PropertyTypeIsILocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(OvarianCyst);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPropertyInDataModelException>()
+                .WithLocation("`OvarianCyst` → Pain")
+                .WithProblem("type `ILocalization` is the `ILocalization` interface and cannot be the backing type of a property")
+                .EndMessage();
+        }
+
+        [TestMethod] public void PropertyTypeIsWriteableLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(SlimeMold);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<WriteableLocalizationException>()
+                .WithLocation("`SlimeMold` → PetName")
+                .WithProblem("if a Localization-type property has a setter, is must be init-only")
+                .EndMessage();
         }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/ReferenceCycles.cs
+++ b/test/UnitTests/Kvasir/Translation/ReferenceCycles.cs
@@ -199,5 +199,50 @@ namespace UT.Kvasir.Translation {
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
         }
+
+        [TestMethod] public void SelfReferentialLocalizationViaKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(BirthdayParty);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidLocalizationKeyException>()
+                .WithLocation("`BirthdayParty` → `LocalizedAverage` (from \"AverageGiftCost\") → Key")
+                .WithProblem("type `BirthdayParty` is a class or a record class and cannot be the type of a Localization Key")
+                .EndMessage();
+        }
+
+        [TestMethod] public void SelfReferentialLocalizationViaLocale_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(DuelingPianos);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<ReferenceCycleException>()
+                .WithLocation("`DuelingPianos` → `LocalizedRandomization` (from \"RandomGuid\") → `DuelingPianos` (from \"Locale\")")
+                .WithProblem("reference cycle detected")
+                .EndMessage();
+        }
+
+        [TestMethod] public void SelfReferentialLocalizationViaValue_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(CareerFair);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<ReferenceCycleException>()
+                .WithLocation("`CareerFair` → `LocalizedEvent` (from \"SisterFair\") → `CareerFair` (from \"Value\")")
+                .WithProblem("reference cycle detected")
+                .EndMessage();
+        }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/SignednessConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/SignednessConstraints.cs
@@ -4,9 +4,9 @@ using Kvasir.Translation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
-using static UT.Kvasir.Translation.SignednessConstraints.IsPositive;
 using static UT.Kvasir.Translation.SignednessConstraints.IsNegative;
 using static UT.Kvasir.Translation.SignednessConstraints.IsNonZero;
+using static UT.Kvasir.Translation.SignednessConstraints.IsPositive;
 
 namespace UT.Kvasir.Translation {
     [TestClass, TestCategory("Constraints - Signedness")]
@@ -139,6 +139,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsPositive_LocalizationWithNumericKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Argonaut);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("DaysAtSea", ComparisonOperator.GT, 0UL).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsPositive_LocalizationWithNonNumericKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Microscope);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Microscope` → ManufacturedOn")
+                .WithProblem("the annotation cannot be applied to a Field of non-numeric type `Guid`")
+                .WithAnnotations("[Check.IsPositive]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsPositive_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -232,6 +264,39 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`Lamp` → Power")
                 .WithPath("Unit")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Unit`")
+                .WithAnnotations("[Check.IsPositive]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsPositive_NestedLocalizationWithNumericKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(StockSplit);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Metadata.SharesOutstanding", ComparisonOperator.GT, 0UL).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsPositive_NestedLocalizationWithNonNumericKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Famine);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Famine` → Dates")
+                .WithPath("End")
+                .WithProblem("the annotation cannot be applied to a Field of non-numeric type `Guid`")
                 .WithAnnotations("[Check.IsPositive]")
                 .EndMessage();
         }
@@ -519,6 +584,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsPositive_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Well);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Well` → Depth")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsPositive]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsPositive_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Diacritic);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Diacritic` → Name")
+                .WithProblem("the path \"Locale\" does not exist")
+                .WithAnnotations("[Check.IsPositive]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsPositive_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -698,6 +795,54 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsNegative_LocalizationWithSignedNumericKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Snowman);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Rating", ComparisonOperator.LT, (short)0).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNegative_LocalizationWithUnsignedNumericKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Tortellini);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Tortellini` → WeightPer")
+                .WithProblem("the annotation cannot be applied to a Field of unsigned numeric type `ulong`")
+                .WithAnnotations("[Check.IsNegative]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNegative_LocalizationWithNonNumericKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Quark);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Quark` → Name")
+                .WithProblem("the annotation cannot be applied to a Field of non-numeric type `string`")
+                .WithAnnotations("[Check.IsNegative]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsNegative_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -790,6 +935,56 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`AirBNB` → HouseAddress")
                 .WithPath("State")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `State`")
+                .WithAnnotations("[Check.IsNegative]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNegative_NestedLocalizationWithSignedNumericKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(RapeKit);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("History.EvidenceGrade", ComparisonOperator.LT, (short)0).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNegative_NestedLocalizationWithUnsignedNumericKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(LogicPuzzle);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`LogicPuzzle` → SolveRecords")
+                .WithPath("AverageSolveTime")
+                .WithProblem("the annotation cannot be applied to a Field of unsigned numeric type `ulong`")
+                .WithAnnotations("[Check.IsNegative]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNegative_NestedLocalizationWithNonNumericKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Rainbow);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Rainbow` → ColorScheme")
+                .WithPath("Gradient")
+                .WithProblem("the annotation cannot be applied to a Field of non-numeric type `string`")
                 .WithAnnotations("[Check.IsNegative]")
                 .EndMessage();
         }
@@ -1075,6 +1270,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsNegative_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Jester);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Jester` → Commissioned")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsNegative]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNegative_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Reservation);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Reservation` → Tribe")
+                .WithProblem("the path \"Value\" does not exist")
+                .WithAnnotations("[Check.IsNegative]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsNegative_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -1240,6 +1467,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsNonZero_LocalizationWithNumericKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Plumber);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("YelpRating", ComparisonOperator.NE, (short)0).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNonZero_LocalizationWithNonNumericKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(EggRoll);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`EggRoll` → Cost")
+                .WithProblem("the annotation cannot be applied to a Field of non-numeric type `string`")
+                .WithAnnotations("[Check.IsNonZero]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsNonZero_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -1365,6 +1624,40 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`Galaxy` → Discovery")
                 .WithPath("Astronomer")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Person`")
+                .WithAnnotations("[Check.IsNonZero]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNonZero_NestedLocalizationWithNumericKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Megafauna);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint("Measurements.Height", ComparisonOperator.NE, 0UL).And
+                .HaveConstraint("Measurements.Weight", ComparisonOperator.NE, 0UL).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNonZero_NestedLocalizationWithNonNumericKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(VenusFlyTrap);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`VenusFlyTrap` → Taxonomy")
+                .WithPath("Common")
+                .WithProblem("the annotation cannot be applied to a Field of non-numeric type `string`")
                 .WithAnnotations("[Check.IsNonZero]")
                 .EndMessage();
         }
@@ -1617,6 +1910,38 @@ namespace UT.Kvasir.Translation {
             translate.Should().FailWith<InapplicableAnnotationException>()
                 .WithLocation("`GarbageTruck` → <synthetic> `RouteStops`")
                 .WithProblem("the annotation cannot be applied to a property of Relation type `RelationSet<string>`")
+                .WithAnnotations("[Check.IsNonZero]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNonZero_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Imam);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Imam` → Ordination")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsNonZero]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNonZero_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Haberdashery);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Haberdashery` → Rating")
+                .WithProblem("the path \"Locale\" does not exist")
                 .WithAnnotations("[Check.IsNonZero]")
                 .EndMessage();
         }

--- a/test/UnitTests/Kvasir/Translation/StringLengthConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/StringLengthConstraints.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using K4os.Hash.xxHash;
 using Kvasir.Schema;
 using Kvasir.Translation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -153,6 +154,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsNonEmpty_LocalizationFieldWithStringKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Frisbee);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "BrandName", ComparisonOperator.GTE, 1).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNonEmpty_LocalizationFieldWithNonStringKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Elegy);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Elegy` → PublishedOn")
+                .WithProblem("the annotation cannot be applied to a Field of non-string type `Guid`")
+                .WithAnnotations("[Check.IsNonEmpty]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsNonEmpty_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -275,6 +308,39 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`RomanBaths` → Rooms")
                 .WithPath("Caldarium")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Bathroom`")
+                .WithAnnotations("[Check.IsNonEmpty]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNonEmpty_NestedLocalizationFieldWithStringKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(FunkoPop);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "Fandom.Name", ComparisonOperator.GTE, 1).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void IsNonEmpty_NestedLocalizationFieldWithNonStringKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(GrandWizard);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`GrandWizard` → Tenure")
+                .WithPath("Start")
+                .WithProblem("the annotation cannot be applied to a Field of non-string type `Guid`")
                 .WithAnnotations("[Check.IsNonEmpty]")
                 .EndMessage();
         }
@@ -531,6 +597,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void IsNonEmpty_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(GarbageCollector);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`GarbageCollector` → Language")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.IsNonEmpty]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void IsNonEmpty_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Eulogy);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Eulogy` → Decedent")
+                .WithProblem("the path \"Value\" does not exist")
+                .WithAnnotations("[Check.IsNonEmpty]")
+                .EndMessage();
+        }
+
         [TestMethod] public void IsNonEmpty_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -707,6 +805,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void LengthIsAtLeast_LocalizationFieldWithStringKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(TermsOfService);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "Company", ComparisonOperator.GTE, 17).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void LengthIsAtLeast_LocalizationFieldWithNonStringKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(ChessGrandmaster);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`ChessGrandmaster` → ELO")
+                .WithProblem("the annotation cannot be applied to a Field of non-string type `ulong`")
+                .WithAnnotations("[Check.LengthIsAtLeast]")
+                .EndMessage();
+        }
+
         [TestMethod] public void LengthIsAtLeast_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -829,6 +959,39 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`Constellation` → MainAsterism")
                 .WithPath("CentralStar")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Star`")
+                .WithAnnotations("[Check.LengthIsAtLeast]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LengthIsAtLeast_NestedLocalizationFieldWithStringKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(UsefulChart);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "Name.Subtitle", ComparisonOperator.GTE, 5).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void LengthIsAtLeast_NestedLocalizationFieldWithNonStringKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Furbie);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Furbie` → CollectorInformation")
+                .WithPath("Rating")
+                .WithProblem("the annotation cannot be applied to a Field of non-string type `short`")
                 .WithAnnotations("[Check.LengthIsAtLeast]")
                 .EndMessage();
         }
@@ -1118,6 +1281,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void LengthIsAtLeast_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(TrailerPark);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`TrailerPark` → Address")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.LengthIsAtLeast]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LengthIsAtLeast_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(BeitDin);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`BeitDin` → Av")
+                .WithProblem("the path \"Key\" does not exist")
+                .WithAnnotations("[Check.LengthIsAtLeast]")
+                .EndMessage();
+        }
+
         [TestMethod] public void LengthIsAtLeast_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -1296,6 +1491,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void LengthIsAtMost_LocalizationFieldWithStringKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(SearsCatalog);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "EditorInChief", ComparisonOperator.LTE, 473).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void LengthIsAtMost_LocalizationFieldWithNonStringKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Crucifixion);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Crucifixion` → NumNailsUsed")
+                .WithProblem("the annotation cannot be applied to a Field of non-string type `ulong`")
+                .WithAnnotations("[Check.LengthIsAtMost]")
+                .EndMessage();
+        }
+
         [TestMethod] public void LengthIsAtMost_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -1418,6 +1645,39 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`Orgasm` → Receiver")
                 .WithPath("Who")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Person`")
+                .WithAnnotations("[Check.LengthIsAtMost]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LengthIsAtMost_NestedLocalizationFieldWithStringKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(WeddingRegistry);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "Location.URL", ComparisonOperator.LTE, 109).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void LengthIsAtMost_NestedLocalizationFieldWithNonStringKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Beautician);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`Beautician` → License")
+                .WithPath("Expiration")
+                .WithProblem("the annotation cannot be applied to a Field of non-string type `Guid`")
                 .WithAnnotations("[Check.LengthIsAtMost]")
                 .EndMessage();
         }
@@ -1705,6 +1965,38 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void LengthIsAtMost_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Swimsuit);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`Swimsuit` → Brand")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.LengthIsAtMost]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LengthIsAtMost_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(GorillaTroop);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`GorillaTroop` → Habitat")
+                .WithProblem("the path \"Key\" does not exist")
+                .WithAnnotations("[Check.LengthIsAtMost]")
+                .EndMessage();
+        }
+
         [TestMethod] public void LengthIsAtMost_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -1883,6 +2175,39 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
+        [TestMethod] public void LengthIsBetween_LocalizationFieldWithStringKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(NonDisclosureAgreement);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "Signatory", ComparisonOperator.GTE, 10).And
+                .HaveConstraint(FieldFunction.LengthOf, "Signatory", ComparisonOperator.LTE, 30).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void LengthIsBetween_LocalizationFieldWithNonStringKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(ObstacleCourse);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`ObstacleCourse` → Rating")
+                .WithProblem("the annotation cannot be applied to a Field of non-string type `short`")
+                .WithAnnotations("[Check.LengthIsBetween]")
+                .EndMessage();
+        }
+
         [TestMethod] public void LengthIsBetween_AggregateNestedApplicableScalar() {
             // Arrange
             var translator = new Translator(NO_ENTITIES);
@@ -1979,6 +2304,40 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`SumoWrestler` → DOB")
                 .WithPath("Month")
                 .WithProblem("the annotation cannot be applied to a property of Reference type `Number`")
+                .WithAnnotations("[Check.LengthIsBetween]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LengthIsBetween_NestedLocalizationFieldWithStringKey() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Visa);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Principal.Table.Should()
+                .HaveConstraint(FieldFunction.LengthOf, "Authority.GrantedBy", ComparisonOperator.GTE, 11).And
+                .HaveConstraint(FieldFunction.LengthOf, "Authority.GrantedBy", ComparisonOperator.LTE, 296).And
+                .HaveNoOtherConstraints();
+            translation.Localizations[0].Table.Should()
+                .HaveNoOtherConstraints();
+        }
+
+        [TestMethod] public void LengthIsBetween_NestedLocalizationFieldWithNonStringKey_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(DDoS);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InapplicableAnnotationException>()
+                .WithLocation("`DDoS` → BotNet")
+                .WithPath("OtherBots")
+                .WithProblem("the annotation cannot be applied to a Field of non-string type `ulong`")
                 .WithAnnotations("[Check.LengthIsBetween]")
                 .EndMessage();
         }
@@ -2327,6 +2686,38 @@ namespace UT.Kvasir.Translation {
             translate.Should().FailWith<InapplicableAnnotationException>()
                 .WithLocation("`HeartAttack` → <synthetic> `Symptoms`")
                 .WithProblem("the annotation cannot be applied to a property of Relation type `RelationSet<string>`")
+                .WithAnnotations("[Check.LengthIsBetween]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LengthIsBetween_NonExistentPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(ThoughtExperiment);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`ThoughtExperiment` → Scientist")
+                .WithProblem("the path \"---\" does not exist")
+                .WithAnnotations("[Check.LengthIsBetween]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LengthIsBetween_NestedPathOnLocalization_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(MusicVideo);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<InvalidPathException>()
+                .WithLocation("`MusicVideo` → SongTitle")
+                .WithProblem("the path \"Value\" does not exist")
                 .WithAnnotations("[Check.LengthIsBetween]")
                 .EndMessage();
         }

--- a/test/UnitTests/Kvasir/Translation/TableNaming.cs
+++ b/test/UnitTests/Kvasir/Translation/TableNaming.cs
@@ -3,7 +3,6 @@ using Kvasir.Translation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
-using static UT.Kvasir.Translation.Nullability;
 using static UT.Kvasir.Translation.TableNaming;
 
 namespace UT.Kvasir.Translation {
@@ -19,6 +18,18 @@ namespace UT.Kvasir.Translation {
 
             // Assert
             translation.Principal.Table.Name.Should().Be("DeckOfCards");
+        }
+
+        [TestMethod] public void LocalizationTableRenamedToBrandNewName() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Vasectomy);
+
+            // Act
+            var translation = translator[source];
+
+            // Assert
+            translation.Localizations[0].Table.Name.Should().Be("AllLocalizedDoctors");
         }
 
         [TestMethod] public void NamespaceExcludedFromDefaultPrimaryTableName() {
@@ -400,6 +411,67 @@ namespace UT.Kvasir.Translation {
                 .WithLocation("`DEFCON` → Four")
                 .WithProblem("the annotation cannot be applied to a pre-defined instance property")
                 .WithAnnotations("[RelationTable]");
+        }
+
+        [TestMethod] public void RelationTable_AppliedToLocalizationField_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Mattress);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NotRelationException>()
+                .WithLocation("`Mattress` → Price")
+                .WithProblem("the property type `LocalizedCurrency` is not a Relation")
+                .WithAnnotations("[RelationTable]")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LocalizationTable_DuplicateNameWithLocalizationTable_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Target);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<DuplicateNameException>()
+                .WithLocation("`Target` → `LocalizedString` (from \"Graffiti\")")
+                .WithProblem("Table name \"GlobalLocalizationTable\" is already in use for the Principal Table of `LocalizedAddress`")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LocalizationTable_DuplicateNameWithPrincipalTable_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(Overlord);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<DuplicateNameException>()
+                .WithLocation("`Overlord` → `LocalizedCount` (from \"SoulsOwned\")")
+                .WithProblem("Table name \"OneTableToRuleThemAll\" is already in use for the Principal Table of `Overlord`")
+                .EndMessage();
+        }
+
+        [TestMethod] public void LocalizationTable_DuplicateNameWithRelationTable_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES);
+            var source = typeof(SportsAgent);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<DuplicateNameException>()
+                .WithLocation("`SportsAgent` → `LocalizedSalary` (from \"LargestNegotiatedSalary\")")
+                .WithProblem("Table name \"TheBestTableEver\" is already in use for the Relation Table of `SportsAgent` → <synthetic> `Clients`")
+                .EndMessage();
         }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/_Localizations.cs
+++ b/test/UnitTests/Kvasir/Translation/_Localizations.cs
@@ -1,0 +1,54 @@
+﻿using Kvasir.Localization;
+using System;
+
+namespace UT.Kvasir.Translation {
+    internal static class TestLocalizations {
+        public enum Language { English, Spanish, French, Hebrew, Hindi, German, Arabic, Japanese, Esperanto, Italian }
+        public enum System { Imperial, Metric, Celsius, Fahrenheit, Kelvin }
+        public enum Calendar { Julian, Gregorian }
+
+        public record struct Measurement(double Value, string Unit);
+
+        public sealed class LocalizedText : Localization<string, Language, string> {
+            public LocalizedText(string key) : base(key) {}
+            public new string this[Language locale] {
+                get { return base[locale]; }
+                set { base[locale] = value; }
+            }
+        }
+        public sealed class LocalizedNullableText : Localization<string, Language, string?> {
+            public LocalizedNullableText(string key) : base(key) {}
+            public new string? this[Language locale] {
+                get { return base[locale]; }
+                set { base[locale] = value; }
+            }
+        }
+        public sealed class LocalizedReadOnlyText : Localization<string, Language, string> {
+            public LocalizedReadOnlyText(string key) : base(key) {}
+        }
+        public sealed class LocalizedMeasure : Localization<ulong, System, Measurement> {
+            public LocalizedMeasure(ulong key) : base(key) {}
+            public new Measurement this[System locale] {
+                get { return base[locale]; }
+                set { base[locale] = value; }
+            }
+        }
+        public sealed class LocalizedDate : Localization<Guid, Calendar, DateOnly> {
+            public LocalizedDate(Guid key) : base(key) {}
+            public new DateOnly this[Calendar locale] {
+                get { return base[locale]; }
+                set { base[locale] = value; }
+            }
+        }
+        public sealed class LocalizedCurrency : Localization<string, string, decimal> {
+            public LocalizedCurrency(string key) : base(key) {}
+            public new decimal this[string locale] {
+                get { return base[locale]; }
+                set { base[locale] = value; }
+            }
+        }
+        public sealed class LocalizedRating : Localization<short, char, double> {
+            public LocalizedRating(short key) : base(key) {}
+        }
+    }
+}

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -2,6 +2,7 @@
 
 401K
 A Capella Group
+Abbey
 Abortion Clinic
 Accountant
 Achaean Naval Contingent
@@ -11,9 +12,12 @@ Actor/Actress
 Actuarial Table
 Ad Blocker
 Address
+Advent Calendar
 Adverb
 Aes Sedai
+Aesop's Fable
 Affidavit
+Agent (athletics)
 AirBNB
 Airline
 Airplane
@@ -32,6 +36,8 @@ Amber Alert
 Ambulance
 American Girl Doll
 American Idol
+American Ninja Warrior
+Amicus Brief
 Amino Acid
 Amusement Park
 Animal
@@ -54,6 +60,8 @@ Arch
 Archaeological Site
 Archangel
 Archbishop
+Arconia Murder
+Argonaut
 Aria
 Armada
 Armory
@@ -84,6 +92,7 @@ Backstreet Boy
 Backyard Baseball Player
 Bacterium
 Bagel
+Bailiff
 Bakery
 Bakugan
 Balk
@@ -96,6 +105,7 @@ Bank Robber
 Bankruptcy
 Banshee
 Baobab Tree
+Baptism
 Bar Graph
 Barbecue Sauce
 Barbie
@@ -111,7 +121,10 @@ Battle
 Battleship
 Bay
 Beach
+Beautician
+Bedouin
 Beekeeper
+Beit Din
 Belt
 Ben 10 Alien
 Benin Bronze
@@ -129,6 +142,7 @@ Bingo Card
 Biography
 Biological Cycle
 Birth Control
+Birthday Party
 Birthstone
 Black Hole
 Black Op
@@ -142,6 +156,8 @@ Blood Drive
 Blood Type
 Boarding School
 Bodhisattva
+Bodybuilder
+Bollywood Film
 Bond
 Bond Girl
 Bone
@@ -161,10 +177,14 @@ Brazilian State
 Bread
 Bridge
 Briefcase
+Brontë Sister
 Brothel
+Buffalo Wild Wings Sauce
 Buffet
 Bug Spray
 Bug Zapper
+Build-a-Bear Workshop
+Bullfight
 Burrito
 Bust
 Butterfly
@@ -174,10 +194,12 @@ C++ Header File
 Cabaret
 Cabinet Department
 Cactus
+Caddie
 Caesarean Section
 Calculator
 Calendar
 Caliphate
+Camel
 Camera
 Camerlengo
 Campfire
@@ -190,15 +212,18 @@ Cannibal
 Cannon
 Canterbury Tale
 Canton of Switzerland
+Cantrip
 Canyon
 Cap'n Crunch
 Capacitor
 Capitol Building
+Capri-Sun
 Car Accident
 Car Dealership
 Carbohydrate
 Cardinal (clergy)
 Care Bear
+Career Fair
 Caricature
 Carnival
 Carousel
@@ -208,6 +233,8 @@ Cash Register
 Casino
 Casserole
 Castle
+Catacombs
+Cathedral
 Cave
 Cave Painting
 Celtic God
@@ -235,6 +262,7 @@ Chewing Gum
 Chinese Character
 Chinese Dynasty
 Chipotle Order
+Chiropractor
 Chocolate
 Choir
 Chopped Basket
@@ -257,7 +285,10 @@ Citrus Fruit
 Civilization VI City State
 Civilization VI District
 Civilization VI Military Unit
+Civilization VI Policy Card
+Civilization VI Technology
 Civilization VI Yield
+Class Action Lawsuit
 Click Consonant
 Cliff
 Climate
@@ -270,9 +301,12 @@ Coal Mine
 Coat of Arms
 Cochlear Implant
 Cockfight
+Cocktail
 Cocoa Farm
+Coconut
 Codex
 Codon
+Coffee
 Coin
 Colonoscopy
 Color
@@ -281,6 +315,7 @@ Comet
 Comic Book
 ComicCon
 Command (terminal)
+Commander (MTG)
 Commercial
 Compiler Warning
 Compression Format
@@ -291,6 +326,7 @@ Concert Tour
 Condiment
 Condom
 Confidence Interval
+Confidential Informant
 Conga Line
 Conlang
 Connecting Wall
@@ -314,9 +350,12 @@ Coupon
 Court Case
 Covalent Bond
 Coven
+Crab Rangoon
 Credit Card
+Credit Report
 Crossbow
 Crossword Clue
+Crucifixion
 Cruise
 Crusade
 Cryochamber
@@ -332,9 +371,11 @@ Cutlery
 Cutthroat Kitchen Sabotage
 CVE
 Cybersite
+Cyclade
 Cyclops
 Cyrillic Letter
 Cytonic
+D-Day Beach
 D&D Character
 D&D Monster
 D&D Spell
@@ -347,7 +388,10 @@ Data Structure
 Database Field
 Date
 Dating App
+DDoS Attack
 Dead Sea Scroll
+Deadly Sin
+Debate
 Debit Card
 Decathlon
 DEFCON
@@ -360,6 +404,8 @@ Deodorant
 Deposition
 Dermatologist
 Desert
+Diacritic
+Diadochos
 Diamond
 Diaper
 Diaspora
@@ -395,6 +441,7 @@ Drum
 Drunk History
 DSM
 Dubbing
+Dueling Pianos
 Duo Push
 Dwarf
 E-Mail
@@ -403,9 +450,11 @@ Earthquake
 Earthworks
 Ecumenical Council
 Edible Arrangement
+Egg Roll
 Egyptian God
 Egyptian Pyramid
 Eigenvector
+Elegy
 Elevator
 Elgin Marble
 Emergency Room
@@ -428,9 +477,11 @@ Escape Room
 Essay
 ETF
 Etiology
+Eulogy
 Eunuch
 Eurovision Song Contest
 Excel Range
+Execution
 Executive Order
 Existentialist
 Exorcism
@@ -444,6 +495,7 @@ Fairy Godparent
 Fairy Tale
 Farmer
 Family Tree
+Famine
 Federal Law
 Federal Reserve District
 Ferris Wheel
@@ -460,11 +512,14 @@ Fishing Rod
 Fitness Center
 Fitted Sheet
 Fjord
+Flamethrower
 Flash Mob
 Flashcard
 Flight
+Flight Attendant
 Flood
 Flower
+Fondue
 Font
 Food Chain
 Food Pantry
@@ -478,12 +533,17 @@ Fraternity
 Fresco
 Fried Chicken
 Friend
+Frisbee
 Fudge
 Function (programming)
 Functional Group
+Funko Pop
+Furbie
 Galaxy
+Game Changer
 Gaming Console
 Garage Sale
+Garbage Collector (programming)
 Garbage Truck
 Garden
 Gargoyle
@@ -508,6 +568,7 @@ GoFundMe Campaign
 Gold Rush
 Golden Raspberry
 Golem
+Golf Cart
 Golf Course
 Golf Hole
 Gondola
@@ -517,10 +578,13 @@ Government Shutdown
 GPU
 Grammatical Case
 Grand Prix
+Grand Wizard of the KKK
+Grandmaster (chess)
 Grasslands
 Great Old One
 Greek God
 Greek Letter
+Gregorian Chant
 Grenade
 Grilled Cheese
 Ground Meat
@@ -531,6 +595,7 @@ Gulag
 Gulf
 Guy's Grocery Game
 Gymnast
+Haberdashery
 Hacker
 Hadith
 Haiku
@@ -538,6 +603,7 @@ Hail Mary
 Hairstyle
 Haitian Loa
 Haka
+Halide
 Hall of Fame
 Hall Pass
 Hamentaschen
@@ -545,6 +611,7 @@ Happy Hour
 Hash Function
 Hash Map
 Hawaiian God
+Headache
 Headphones
 Healing Potion (D&D)
 Heart Attack
@@ -565,12 +632,14 @@ Histogram
 Hoedown (WLIIA)
 Hogwarts House
 Holiday
+Holocaust Museum
 Hologram
 Holy Roman Emperor
 Home Run Derby
 Homeric Hymn
 Hominin
 Honest Trailer
+Hookah Bar
 Horcrux
 Hormone
 Horoscope
@@ -595,6 +664,7 @@ Igloo
 IKEA Furniture
 Illithid Power (BG3)
 Imaginary Friend
+Imam
 Immaculate Grid
 Immortal (Highlander)
 Impeachment
@@ -625,11 +695,14 @@ iPhone
 IPO
 Iron Chef
 ISO Standard
+Isotope
 Isthmus
 Iyalet
 Jack-o-Lantern
 Japanese Emperor
+Japanese Prefecture
 Jedi
+Jester
 Jigsaw Puzzle
 Jötunn
 Joust
@@ -661,13 +734,16 @@ Lake
 Lamp
 Land Card (MTG)
 Land Mine
+Landfill
 Language
 Large Language Model
+Laundromat
 Laundry Detergent
 Law & Order
 Law Firm
 Lawn Gnome
 Lawn Mower
+Lawyer
 Layer of Skin
 Lazarus Pit
 Lease
@@ -679,6 +755,7 @@ LEP Branch
 Leprechaun
 Letter of Recommendation
 Library (books)
+Library Card
 License Plate
 Lifeguard
 Ligament
@@ -693,26 +770,32 @@ Lipstick
 Liquor
 Liquor Store
 Literary Trope
+Lobe of the Brain
 Locale (computing)
 Localization
 Loch
 Lock (computing)
 Log-In Credentials
+Logic Puzzle
 Lollipop
 Longbow
 Lottery Ticket
 Luau
 Lunar Crater
 Lunar Eclipse
+Lunar Phase
 Lycanthrope
 Lyric
 Madden NFL
 Madonna (painting)
 Madrasa
+Madrigal (Encanto)
 Mafia Family
 Magazine
 Magic System
 Magical Preserve (Fablehaven)
+Mahjong Tile
+Make-a-Wish
 Mall Santa
 Manicure
 Mansa of the Mali Empire
@@ -733,17 +816,22 @@ Mass Extinction
 Massacre
 Masseuse
 MasterClass
+Match-Pair (Babel)
 Mathematical Conjecture
 Mathematical Proof
 Matrix
+Mattress
 Mausoleum
 Mayan God
 Mayor
 Medal of Honor
 Medical Specialty
+Megafauna
 Menorah
 Meme
 Memory Buffer
+Memory Leak
+Merger
 Merit Badge
 Mermaid
 Mesopotamian God
@@ -751,6 +839,7 @@ Metra Route
 Metric Prefix
 Mezuzah
 Michelin Guide
+Microscope
 Military Base
 Militia
 Milkshake
@@ -774,14 +863,17 @@ Mountain
 Moustache
 Movie
 Movie Ticket
+Moving Company
 Muffin
 Multiple Choice Question
 Mummy
 Muppet
 Murder
 Muscle
+Muse
 Museum
 Mushroom
+Music Video
 Musical
 Mutiny
 Mutual Fund
@@ -793,7 +885,9 @@ National Anthem
 National Monument
 National Park
 Native American Tribe
+Naval Base
 Nazca Line
+NDA
 Nebula
 Necktie
 Necromancer
@@ -817,6 +911,7 @@ Nymph
 Oasis
 Obelisk
 Obi
+Obstacle Course
 Ocean Current
 Oceanic Trench
 Oceanid
@@ -832,6 +927,7 @@ Olympian Boon (Hades)
 Onomatopoeia
 Opera
 Opioid
+Opium War
 Option (security)
 Orchestra
 Organ Procurement Organization
@@ -841,6 +937,8 @@ Origami
 Orisha
 Orogene
 Orphanage
+Ovarian Cyst
+Overlord
 Overnight Camp
 Overture
 Pacemaker
@@ -854,8 +952,10 @@ Pandava Brother
 Panegyric
 Papal Bull
 Papal Conclave
+Parable
 Parabola
 Parashah
+Parole Hearing
 Parking Garage
 Parking Ticket
 Particle Accelerator
@@ -879,12 +979,13 @@ Perfume
 Person of the Year (Time)
 Personality Test
 Petroglyph
+Petting Zoo
 Pharaoh
 Pharmacy
 Phase Diagram
 Philosopher
 Phobia
-Phone Boook
+Phone Book
 Phone Booth
 Phone Number
 Phonetic Alphabet
@@ -898,18 +999,21 @@ Piñata
 Ping
 Pirate
 Pirate Ship
+Pitmaster
 Pizza
 Pizza Roll
 Plane of Existence (D&D)
 Planeswalker
 Planetarium
+Plastic Surgery
 Platonic Dialogue
 Playing Card
 Playlist
+Plumber
 PO Box
 Poacher
 Podcast
-Poet Laurete
+Poet Laureate
 Pokémon
 Poker Hand
 Polar Vortex
@@ -927,18 +1031,22 @@ Pope
 Porn Star
 Post Office
 Potato
+Power Outage
 Power Ranger
 Pregnancy Test
 Prenuptial Agreement
+Preprocessor Macro
 Prescription
 Presidential Election
 Press Secretary
 Pretzel
 Pride Parade
 Primate
+Prime Minister of Israel
 Printer
 Prison
 Prisoner Exchange
+Prisoner of War
 Process (computing)
 Programming Language
 Promo Code
@@ -959,6 +1067,7 @@ Puppet Show
 Python Interpreter
 QR Code
 Quadratic Equation
+Quark
 Quarterback
 Quasar
 Quatrain
@@ -969,9 +1078,12 @@ Racehorse
 Racetrack (auto racing)
 Radio Station
 Rain Delay
+Rainbow
 Rainforest
+Ramen
 Random Number Generator
 Ransomware
+Rape Kit
 Raptor
 Ravnica Guild
 Readymade
@@ -982,11 +1094,13 @@ Rental Car
 Repository
 Representative
 Requiem
+Reservation (Native Americans)
 Resident Evil
 Resistor
 Rest Stop
 Restaurant
 Retail Product
+Retrovirus
 Rhinoceros
 Ring of Power
 River
@@ -1001,6 +1115,7 @@ Roman Numeral
 Rorschach Ink Blot
 Royal House
 Rube Goldberg Machine
+Rubik's Cube
 Rugrat
 Rune
 Runway
@@ -1027,7 +1142,9 @@ Sea Shanty
 Séance
 Search Engine
 Search Warrant
+Sears Catalog
 Season
+SEC Short
 Secret Hitler Game
 Secret Police
 Secret Society
@@ -1049,14 +1166,17 @@ Shen Gong Wu
 Sheriff
 Sherpa
 Shipwreck
+Shiva
 Shoe
 Shofar
 Shogunate
+Shtetl
 Sign (ASL)
 Sign Language
 Skateboard
 Skee-Ball
 Ski Slope
+Skirt
 Skittles
 Skydiver
 Skyscraper
@@ -1064,19 +1184,23 @@ Slack Channel
 SlamBall Match
 Slap Bet
 Slave Revolt
+Slime Mold
 Slot Machine
 Slumber Party
+Slushy
 Smoke Detector
 Smoothie
 Smurf
 Snake
 SNL Episode
 Snowball Fight
+Snowman
 Soap Opera
 Soccer Team
 Soda Fountain
 Solar Eclipse
 Solicitor General
+Sommelier
 Song
 Sonnet
 Sorority
@@ -1085,13 +1209,16 @@ Soup
 Spa
 Space Shuttle
 Speakeasy
+Special Victim
 Speed Limit
 Speedometer
 Spelling Bee
 Spider
 Spider-Man
+Spoonerism
 Sporcle Quiz
 Sports Bet
+SportsCenter
 Sprachbund
 Spring (mechanics)
 SQL Query
@@ -1110,8 +1237,10 @@ State of the Union
 State Quarter
 Steak
 Step Pyramid
+Stir Fry
 Stock
 Stock Index
+Stock Split
 Stooge
 Stove
 Stratego Piece
@@ -1126,6 +1255,7 @@ Sumo Wrestler
 Sundial
 Sunscreen
 Super Bowl
+Superintendent
 Supermodel
 SuperPAC
 Surah
@@ -1138,6 +1268,7 @@ Sushi Roll
 Sutra
 Swamp
 Swimming Pool
+Swimsuit
 Sword
 Syllabary
 Symbiosis
@@ -1147,6 +1278,7 @@ Talk Show
 Tamagotchi
 Tapestry
 Tar Pits
+Target (store)
 Tariff
 Tarot Card
 Tattoo
@@ -1154,15 +1286,19 @@ Tectonic Plate
 TED Talk
 Telescope
 Teletubby
+Temperature Scale
 Tendon
 Tennis Match
 Teppanyaki
 Tepui
 Terminator
+Terms of Service
 Territory (Pendragon)
+Territory (Risk)
 Terrorist Organization
 Therapist
 Thesis
+Thought Experiment
 Thumb War
 Tic-Tac-Toe Game
 Ticket2Ride Route
@@ -1174,12 +1310,14 @@ Timestamp
 Tirthankara
 "Title of Your Sex Tape" Joke
 Tlatoani
+To-Do List
 Tongue Twister
 Tony Award
 Tooth
 Toothbrush
 Toothpaste
 Top 10 List
+Tortellini
 Tortilla
 Tossup Question
 Totem Pole
@@ -1187,6 +1325,7 @@ Tour de France
 Tournament
 Tractor
 Traffic Stop
+Tailer Park
 Trampoline
 Transformer (robot)
 Transistor
@@ -1200,8 +1339,11 @@ Tribe of Israel
 Trilogy
 Triplets
 Triptych
+Triumvirate
 Trivial Pursuit
 Trolley Problem
+Troop (primates)
+Tropism
 Tsunami
 Tumbleweed
 Tuxedo
@@ -1218,18 +1360,23 @@ Union
 University
 Upanishad
 URL
+Useful Chart
 UUID
 Vaccine
 Vacuum Cleaner
 Valet
+Valkyrie
 Vampire Slayer
+Vasectomy
 Vault (bank)
 Venmo Request
+Venus Fly Trap
 Verb
 Vertebra
 Vestige of Divergence
 Vigenère Cipher
 Vineyard
+Visa
 Vitamin
 Voicemail
 Voir Dire
@@ -1251,10 +1398,13 @@ Waterbending Discipline
 Waterfall
 Web Browser
 Wedding
+Wedding Registry
 Weekend Update
 Weird Al Parody
+Well
 Welsh God
 Werewolf
+Whale
 Wheelchair
 Where's Waldo?
 White Walker
@@ -1271,6 +1421,7 @@ Wizard
 Woodshop
 Word Search
 Wordle
+World Baseball Classic
 World Cup
 World Heritage Site
 World Wonder
@@ -1288,6 +1439,7 @@ Yoga Position
 Yogurt
 YouTube Video
 Yu-Gi-Oh Monster
+Zeppelin
 Ziggurat
 Zipline
 Zodiac Sign


### PR DESCRIPTION
This commit introduces Localizations, a new first-class property type that Kvasir can handle. A Localization is any type derived from the Localization<K, L, V> generic, which in turn implements the brand new ILocalization interface. Localizations are designed to support different values under different circumstances for a single semantic, such as different languages' translations of text or different systems' units of measurement.

The "key" of a Localization shows up in the Principal or Relation Table that "owns" the Localization, while the locale-value pairs are aggregated into a Localization Table. All instances of a Localization Type share a single Localization Table, so the keys must be unique-per-type, while the locales are necessarily unique per-key. Derived Localization types cannot have their own properties included in the data model.

Annotations may be applied to a Localization's key in the Principal or Relation Table, but those constraints do not propagate to the Localization Table. Data Converters are not supported, however. Localizations may appear nested in Relations, but not in other Localizations; Relations cannot be nested in Localizations.

At this time, only the Schema-layer translation of Localizations is supported. Extraction and Reconstitution will be implemented in future commits.