### PR TITLE
Add Basic Logging

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -7546,7 +7546,7 @@
               entities and a particular back-end provider/system.
             </summary>
         </member>
-        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},System.Data.IDbConnection,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object})">
+        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},System.Data.IDbConnection,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Microsoft.Extensions.Logging.ILogger)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.Translator"/> that uses default <see cref="T:Kvasir.Core.Settings"/>.
             </summary>
@@ -7568,8 +7568,11 @@
             <param name="entityStorage">
               The functor through which reconstituted Entities will be stored for later look-up.
             </param>
+            <param name="logger">
+              The <see cref="T:Microsoft.Extensions.Logging.ILogger">logger</see> with which to issue diagnostics.
+            </param>
         </member>
-        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},System.Data.IDbConnection,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Kvasir.Core.Settings)">
+        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},System.Data.IDbConnection,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Kvasir.Core.Settings,Microsoft.Extensions.Logging.ILogger)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.Translator"/> that uses custom <see cref="T:Kvasir.Core.Settings"/>.
             </summary>
@@ -7593,6 +7596,9 @@
             </param>
             <param name="settings">
               The <see cref="T:Kvasir.Core.Settings"/> according to which to perform the transaction activity.
+            </param>
+            <param name="logger">
+              The <see cref="T:Microsoft.Extensions.Logging.ILogger">logger</see> with which to issue diagnostics.
             </param>
             <remarks>
               Note that the settings are not currently used for anything; in fact, there are no traits available in the
@@ -8652,15 +8658,18 @@
               <see langword="false"/>.
             </returns>
         </member>
-        <member name="M:Kvasir.Translation.Translator.#ctor(System.Func{System.Type,System.Collections.Generic.IEnumerable{System.Object}})">
+        <member name="M:Kvasir.Translation.Translator.#ctor(System.Func{System.Type,System.Collections.Generic.IEnumerable{System.Object}},Microsoft.Extensions.Logging.ILogger)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.Translator"/> that uses default <see cref="T:Kvasir.Core.Settings"/>.
             </summary>
             <param name="entityLookup">
               The function used to look up the collection of existing Entities for a given <see cref="T:System.Type"/>.
             </param>
+            <param name="logger">
+              The<see cref="T:Microsoft.Extensions.Logging.ILogger">logger</see> with which to issue diagnostics.
+            </param>
         </member>
-        <member name="M:Kvasir.Translation.Translator.#ctor(System.Func{System.Type,System.Collections.Generic.IEnumerable{System.Object}},Kvasir.Core.Settings)">
+        <member name="M:Kvasir.Translation.Translator.#ctor(System.Func{System.Type,System.Collections.Generic.IEnumerable{System.Object}},Kvasir.Core.Settings,Microsoft.Extensions.Logging.ILogger)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.Translator"/> that uses custom <see cref="T:Kvasir.Core.Settings"/>.
             </summary>
@@ -8669,6 +8678,9 @@
             </param>
             <param name="settings">
               The <see cref="T:Kvasir.Core.Settings"/> according to which to perform the translation.
+            </param>
+            <param name="logger">
+              The <see cref="T:Microsoft.Extensions.Logging.ILogger">logger</see> with which to issue diagnostics.
             </param>
             <remarks>
               Note that the settings are not currently used for anything; in fact, there are no traits available in the

--- a/src/Kvasir/Kvasir.csproj
+++ b/src/Kvasir/Kvasir.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
     <PackageReference Include="Combinatorics" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageReference Include="MySql.Data" Version="9.3.0" />
     <PackageReference Include="Optional" Version="4.0.0" />
   </ItemGroup>

--- a/src/Kvasir/Transaction/Transactor.cs
+++ b/src/Kvasir/Transaction/Transactor.cs
@@ -3,6 +3,7 @@ using Kvasir.Core;
 using Kvasir.Reconstitution;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -36,14 +37,18 @@ namespace Kvasir.Transaction {
         /// <param name="entityStorage">
         ///   The functor through which reconstituted Entities will be stored for later look-up.
         /// </param>
+        /// <param name="logger">
+        ///   The <see cref="ILogger">logger</see> with which to issue diagnostics.
+        /// </param>
         public Transactor(
             IEnumerable<EntityTranslation> entityTranslations,
             IEnumerable<LocalizationTranslation> localizationTranslations,
             IDbConnection connection,
             ICommandsFactory commandsFactory,
-            Action<object> entityStorage
+            Action<object> entityStorage,
+            ILogger logger
         )
-            : this(entityTranslations, localizationTranslations, connection, commandsFactory, entityStorage, Settings.Default) {}
+            : this(entityTranslations, localizationTranslations, connection, commandsFactory, entityStorage, Settings.Default, logger) {}
 
         /// <summary>
         ///   Constructs a new <see cref="Translator"/> that uses custom <see cref="Settings"/>.
@@ -69,6 +74,9 @@ namespace Kvasir.Transaction {
         /// <param name="settings">
         ///   The <see cref="Settings"/> according to which to perform the transaction activity.
         /// </param>
+        /// <param name="logger">
+        ///   The <see cref="ILogger">logger</see> with which to issue diagnostics.
+        /// </param>
         /// <remarks>
         ///   Note that the settings are not currently used for anything; in fact, there are no traits available in the
         ///   <see cref="Settings"/> class. Instead, the settings serve as a forward compatibility mechanism that allows
@@ -80,7 +88,8 @@ namespace Kvasir.Transaction {
             IDbConnection connection,
             ICommandsFactory commandsFactory,
             Action<object> entityStorage,
-            Settings settings
+            Settings settings,
+            ILogger logger
         ) {
             Debug.Assert(entityTranslations is not null);
             Debug.Assert(localizationTranslations is not null);
@@ -89,6 +98,7 @@ namespace Kvasir.Transaction {
             Debug.Assert(commandsFactory is not null);
             Debug.Assert(entityStorage is not null);
             Debug.Assert(settings is not null);
+            Debug.Assert(logger is not null);
 
             settings_ = settings;
             entityTranslations_ = entityTranslations.ToDictionary(t => t.CLRSource, t => t);
@@ -96,6 +106,9 @@ namespace Kvasir.Transaction {
             connection_ = connection;
             commandsFactory_ = commandsFactory;
             entityStorage_ = entityStorage;
+            logger_ = logger;
+
+            logger_.LogDebug("Transactor created for {} regular Entities and {} Localizations", entityTranslations_.Count, localizationTranslations_.Count);
 
             var principalCommands = new List<ICommands>();
             var relationCommands = new List<ICommands>();
@@ -104,16 +117,19 @@ namespace Kvasir.Transaction {
             foreach (var principal in Topology.OrderEntities(entityTranslations.ToList())) {
                 tables[principal.Table] = principalCommands.Count;
                 principalCommands.Add(commandsFactory_.CreateCommands(principal.Table, isPrincipalTable: true));
+                logger_.LogDebug("Entity #{} is `{}`", principalCommands.Count, principal.Extractor.SourceType.Name);
 
                 // using `Extractor.SourceType` is a little awkward here, but it's the best we have
                 foreach (var relation in entityTranslations_[principal.Extractor.SourceType].Relations) {
                     tables[relation.Table] = entityTranslations_.Count + relationCommands.Count;
                     relationCommands.Add(commandsFactory_.CreateCommands(relation.Table, isPrincipalTable: false));
+                    logger_.LogDebug("Relation #{} is for table {}", relationCommands.Count, relation.Table.Name);
                 }
             }
             foreach (var principal in localizationTranslations.Select(x => x.Principal)) {
                 tables[principal.Table] = principalCommands.Count + relationCommands.Count + localizationCommands.Count;
                 localizationCommands.Add(commandsFactory_.CreateCommands(principal.Table, isPrincipalTable: true));
+                logger_.LogDebug("Entity #{} is `{}`", principalCommands.Count + localizationCommands.Count, principal.Extractor.SourceType.Name);
             }
 
             // The order here is Regular Entities -> Relations -> Localizations, with the former in topological order.
@@ -142,6 +158,7 @@ namespace Kvasir.Transaction {
             foreach (var command in commands_.Select(c => c.CreateTableCommand)) {
                 command.Connection = connection_;
                 command.Transaction = transaction;
+                logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
             }
             TryCommitTransaction(transaction);
@@ -170,6 +187,7 @@ namespace Kvasir.Transaction {
             var locInstByKey = new List<Dictionary<DBValue, object>>();
             for (int idx = 0; idx < numLocalizationTypes; ++idx) {
                 var query = commands_[idx + localizationStartIdx_].SelectAllQuery;
+                logger_.LogDebug("Executing SQL: {}", query.CommandText);
                 query.Connection = connection_;
                 var reader = query.ExecuteReader();
 
@@ -189,6 +207,7 @@ namespace Kvasir.Transaction {
 
                 locRowsByKey.Add(rows);
                 locInstByKey.Add(instances);
+                logger_.LogDebug("{} instances of {} loaded", instances.Count, localizationTranslations[idx].Principal.Reconstitutor.ResultType.Name);
             }
             foreach (var dict in locInstByKey) {
                 foreach (var (_, instance) in dict.OrderBy(kvp => kvp.Key.Datum)) {
@@ -199,6 +218,7 @@ namespace Kvasir.Transaction {
             // Load all the data from Principal Tables and create the Entity instances second
             for (int idx = 0; idx < numEntityTypes; ++idx) {
                 var query = commands_[idx].SelectAllQuery;
+                logger_.LogDebug("Executing SQL: {}", query.CommandText);
                 query.Connection = connection_;
                 var reader = query.ExecuteReader();
 
@@ -209,7 +229,9 @@ namespace Kvasir.Transaction {
                     entityStorage_(entity);
                     creations.Add(entity);
                 }
+                
                 allEntities[idx] = creations;
+                logger_.LogDebug("{} instances of {} loaded", creations.Count, entityTranslations[idx].Principal.Reconstitutor.ResultType.Name);
             }
 
             // Load all the data from Relation Tables and repopulate the Relations third
@@ -220,6 +242,7 @@ namespace Kvasir.Transaction {
 
                 foreach (var relation in translation.Relations) {
                     var query = commands_[tables_[relation.Table]].SelectAllQuery;
+                    logger_.LogDebug("Executing SQL: {}", query.CommandText);
                     query.Connection = connection_;
                     var reader = query.ExecuteReader();
 
@@ -280,6 +303,7 @@ namespace Kvasir.Transaction {
                 var command = commands_[tables_[translation.Principal.Table]].InsertCommand(rows);
                 command.Connection = connection_;
                 command.Transaction = transaction;
+                logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
             }
 
@@ -303,6 +327,7 @@ namespace Kvasir.Transaction {
                     var command = commands_[tables_[relation.Table]].InsertCommand(rows);
                     command.Connection = connection_;
                     command.Transaction = transaction;
+                    logger_.LogDebug("Executing SQL: {}", command.CommandText);
                     command.ExecuteNonQuery();
                 }
             }
@@ -324,6 +349,7 @@ namespace Kvasir.Transaction {
                 var command = commands_[tables_[translation.Principal.Table]].InsertCommand(rows);
                 command.Connection = connection_;
                 command.Transaction = transaction;
+                logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
             }
 
@@ -369,6 +395,7 @@ namespace Kvasir.Transaction {
                 var command = commands_[tables_[translation.Principal.Table]].UpdateCommand(rows);
                 command.Connection = connection_;
                 command.Transaction = transaction;
+                logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
             }
 
@@ -398,6 +425,7 @@ namespace Kvasir.Transaction {
                         if (!isEmpty) {
                             command.Connection = connection_;
                             command.Transaction = transaction;
+                            logger_.LogDebug("Executing SQL: {}", command.CommandText);
                             command.ExecuteNonQuery();
                         }
                     }
@@ -428,6 +456,7 @@ namespace Kvasir.Transaction {
                     if (!isEmpty) {
                         command.Connection = connection_;
                         command.Transaction = transaction;
+                        logger_.LogDebug("Executing SQL: {}", command.CommandText);
                         command.ExecuteNonQuery();
                     }
                 }
@@ -479,6 +508,7 @@ namespace Kvasir.Transaction {
                 var command = commands_[tables_[translation.Principal.Table]].DeleteCommand(rows);
                 command.Connection = connection_;
                 command.Transaction = transaction;
+                logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
             }
 
@@ -499,6 +529,7 @@ namespace Kvasir.Transaction {
                     var command = commands_[tables_[relation.Table]].DeleteCommand(rows);
                     command.Connection = connection_;
                     command.Transaction = transaction;
+                    logger_.LogDebug("Executing SQL: {}", command.CommandText);
                     command.ExecuteNonQuery();
                 }
             }
@@ -513,6 +544,7 @@ namespace Kvasir.Transaction {
                 var command = commands_[tables_[translation.Principal.Table]].DeleteCommand(rows);
                 command.Connection = connection_;
                 command.Transaction = transaction;
+                logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
             }
 
@@ -534,15 +566,18 @@ namespace Kvasir.Transaction {
         /// <exception cref="AggregateException">
         ///   if the attempt to commit <paramref name="transaction"/> fails, and the attempt to roll it back also fails.
         /// </exception>
-        private static void TryCommitTransaction(IDbTransaction transaction) {
+        private void TryCommitTransaction(IDbTransaction transaction) {
             try {
+                logger_.LogDebug("Committing Transaction");
                 transaction.Commit();
             }
             catch (InvalidOperationException commitEx) {
                 try {
+                    logger_.LogError("Rolling Back Transaction (cause: {})", commitEx.Message);
                     transaction.Rollback();
                 }
                 catch (InvalidOperationException rollbackEx) {
+                    logger_.LogError("Roll Back Failed (cause: {})", rollbackEx.Message);
                     throw new AggregateException(commitEx, rollbackEx);
                 }
 
@@ -561,5 +596,6 @@ namespace Kvasir.Transaction {
         private readonly IDbConnection connection_;
         private readonly ICommandsFactory commandsFactory_;
         private readonly Action<object> entityStorage_;
+        private readonly ILogger logger_;
     }
 }

--- a/src/Kvasir/Translation/TranslateEntity.cs
+++ b/src/Kvasir/Translation/TranslateEntity.cs
@@ -5,6 +5,7 @@ using Kvasir.Core;
 using Kvasir.Extraction;
 using Kvasir.Reconstitution;
 using Kvasir.Schema;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -61,9 +62,11 @@ namespace Kvasir.Translation {
             // Memoization
             if (principalTableCache_.TryGetValue(source, out PrincipalTableDef? principal)) {
                 Debug.Assert(pkCache_.ContainsKey(source));
+                logger_.LogDebug("{} already translated; returning memoization from `TranslatePrincipalTable`", source.Name);
                 return principal;
             }
             Debug.Assert(!pkCache_.ContainsKey(source));
+            logger_.LogDebug("Translating Principal Table for {} . . .", source.Name);
 
             // The error checking for invalid Entity types has to be here rather than in operator[], because the latter
             // is invoked only from the top-level API whereas the former is invoked from both the top-level API (via the
@@ -138,6 +141,7 @@ namespace Kvasir.Translation {
             principalTableCache_.Add(source, principal);
             tableNameCache_.Add(tableName, source);
             keyMatchers_.Add(source, new KeyMatcher(() => entityLookup_(source), pkExtractor));
+            logger_.LogDebug("Translation of Principal Table for {} complete!", source.Name);
             return principal;
         }
 
@@ -169,6 +173,8 @@ namespace Kvasir.Translation {
             Debug.Assert(pkCache_.ContainsKey(source));
             Debug.Assert(relationTrackersCache_.ContainsKey(source));
 
+            logger_.LogDebug("Translating Relation Tables of {} . . .", source.Name);
+
             // Because a Relation Table is translated from the combination of a particular Entity Type and a particular
             // nested property, there's no need for memoization: each combination will only ever be translated once.
             // However, the owning Entity will have been memoized when initially translated, and the element type will
@@ -180,6 +186,7 @@ namespace Kvasir.Translation {
                 var property = tracker.Property;
                 var syntheticType = SyntheticType.MakeSyntheticType(source, tracker);
                 var context = new Context(syntheticType);
+                logger_.LogDebug("Translating Relation Table for {} . . .", syntheticType.Name);
 
                 // A Relation-type property cannot be natively nullable unless it has a [NonNullable] annotation
                 // attached
@@ -260,9 +267,11 @@ namespace Kvasir.Translation {
                 relationTables.Add(def);
 
                 relationTypes.Add(syntheticType);
+                logger_.LogDebug("Translation of Relation Table for {} complete!", syntheticType.Name);
             }
 
             relationTypesFromEntity_[source] = relationTypes;
+            logger_.LogDebug("Translation of Relation Tables of {} complete!", source.Name);
             return relationTables;
         }
 
@@ -298,9 +307,11 @@ namespace Kvasir.Translation {
             // Memoization
             if (localizationTableCache_.TryGetValue(source, out LocalizationTableDef? principal)) {
                 Debug.Assert(pkCache_.ContainsKey(source));
+                logger_.LogDebug("{} already translated; returning memoization from `TranslateLocalizationTable`", source.Name);
                 return principal;
             }
             Debug.Assert(!pkCache_.ContainsKey(source));
+            logger_.LogDebug("Translating Principal Table for {} . . .", source.Name);
 
             // Localizations cannot induce a reference cycle on their own. The Key Type is required to be a primitive,
             // which cannot be an Entity. The Locale Type and Value Types are allowed to be the same as the Entity on
@@ -392,6 +403,7 @@ namespace Kvasir.Translation {
                 keyMatchers_.Add(source, keyMatcher);
             }
 
+            logger_.LogDebug("Translation of Principal Table for {} . . .", source.Name);
             return principal;
         }
 

--- a/src/Kvasir/Translation/Translator.cs
+++ b/src/Kvasir/Translation/Translator.cs
@@ -2,6 +2,7 @@
 using Kvasir.Localization;
 using Kvasir.Reconstitution;
 using Kvasir.Schema;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -38,6 +39,7 @@ namespace Kvasir.Translation {
                 Debug.Assert(!IsLocalizationType(source));
 
                 if (translationCache_.TryGetValue(source, out var translation)) {
+                    logger_.LogDebug("{} already translated; returning memoization from `operator[]`", source.Name);
                     return translation;
                 }
 
@@ -83,6 +85,7 @@ namespace Kvasir.Translation {
                 Debug.Assert(IsLocalizationType(source));
 
                 if (localizationCache_.TryGetValue(source, out var translation)) {
+                    logger_.LogDebug("{} already translated; returning memoization from `operator[]`", source.Name);
                     return translation;
                 }
 
@@ -123,8 +126,11 @@ namespace Kvasir.Translation {
         /// <param name="entityLookup">
         ///   The function used to look up the collection of existing Entities for a given <see cref="Type"/>.
         /// </param>
-        public Translator(Func<Type, IEnumerable<object>> entityLookup)
-            : this(entityLookup, Settings.Default) {
+        /// <param name="logger">
+        ///   The<see cref="ILogger">logger</see> with which to issue diagnostics.
+        /// </param>
+        public Translator(Func<Type, IEnumerable<object>> entityLookup, ILogger logger)
+            : this(entityLookup, Settings.Default, logger) {
 
             // Need to reset this because the constructor delegation causes the "calling assembly" to actually be the
             // one of the Translator itself, but we need it to be the assembly that initially called into the Translator
@@ -140,14 +146,18 @@ namespace Kvasir.Translation {
         /// <param name="settings">
         ///   The <see cref="Settings"/> according to which to perform the translation.
         /// </param>
+        /// <param name="logger">
+        ///   The <see cref="ILogger">logger</see> with which to issue diagnostics.
+        /// </param>
         /// <remarks>
         ///   Note that the settings are not currently used for anything; in fact, there are no traits available in the
         ///   <see cref="Settings"/> class. Instead, the settings serve as a forward compatibility mechanism that allows
         ///   us to provide customization of behaviors in the future without necessitating a significant redesign.
         /// </remarks>
-        public Translator(Func<Type, IEnumerable<object>> entityLookup, Settings settings) {
+        public Translator(Func<Type, IEnumerable<object>> entityLookup, Settings settings, ILogger logger) {
             Debug.Assert(entityLookup is not null);
             Debug.Assert(settings is not null);
+            Debug.Assert(logger is not null);
 
             settings_ = settings;
             callingAssembly_ = Assembly.GetCallingAssembly();
@@ -163,6 +173,7 @@ namespace Kvasir.Translation {
             localizationTrackersCache_ = new Dictionary<Type, IReadOnlyList<LocalizationTracker>>();
             keyMatchers_ = new Dictionary<Type, KeyMatcher>();
             relationTypesFromEntity_ = new Dictionary<Type, IReadOnlyList<Type>>();
+            logger_ = logger;
         }
 
 
@@ -180,6 +191,7 @@ namespace Kvasir.Translation {
         private readonly Dictionary<Type, IReadOnlyList<LocalizationTracker>> localizationTrackersCache_;
         private readonly Dictionary<Type, KeyMatcher> keyMatchers_;
         private readonly Dictionary<Type, IReadOnlyList<Type>> relationTypesFromEntity_;
+        private readonly ILogger logger_;
     }
 
 

--- a/test/UnitTests/Kvasir/Providers/MySQL.cs
+++ b/test/UnitTests/Kvasir/Providers/MySQL.cs
@@ -4,6 +4,7 @@ using Kvasir.Exceptions;
 using Kvasir.Providers.MySQL;
 using Kvasir.Schema;
 using Kvasir.Transcription;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System;
@@ -2496,7 +2497,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void CreateTable_Principal() {
             // Arrange
             var source = typeof(Mutiny);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
 
             // Act
@@ -2520,7 +2521,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void CreateTable_Relation() {
             // Arrange
             var source = typeof(CyrillicLetter);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var principalTable = translator[source].Principal.Table;
             var relationTable = translator[source].Relations[0].Table;
 
@@ -2544,7 +2545,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void CreateTable_PreDefinedEntity() {
             // Arrange
             var source = typeof(BackstreetBoy);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
 
             // Act
@@ -2566,7 +2567,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void CreateTable_Localization() {
             // Arrange
             var source = typeof(MusicalNote);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source, Translator.AsLocalzation].Principal.Table;
 
             // Act
@@ -2588,7 +2589,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void SelectAll_Principal() {
             // Arrange
             var source = typeof(CarDealership);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
 
             // Act
@@ -2604,7 +2605,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void SelectAll_Relation() {
             // Arrange
             var source = typeof(Hadith);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
 
             // Act
@@ -2620,7 +2621,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void SelectAll_WithCalculatedField() {
             // Arrange
             var source = typeof(Grenade);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
 
             // Act
@@ -2636,7 +2637,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Insert_TextEnumerations() {
             // Arrange
             var source = typeof(ChipotleOrder);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -2682,7 +2683,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Insert_IntegersBooleans() {
             // Arrange
             var source = typeof(RegularExpression);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -2718,7 +2719,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Insert_FloatingPoint() {
             // Arrange
             var source = typeof(Tariff);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -2758,7 +2759,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Insert_DateGuid() {
             // Arrange
             var source = typeof(ExecutiveOrder);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -2796,7 +2797,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Insert_Null() {
             // Arrange
             var source = typeof(Codex);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -2830,7 +2831,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Insert_TwoRows() {
             // Arrange
             var source = typeof(Choreographer);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -2875,7 +2876,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Insert_ThreePlusRows() {
             // Arrange
             var source = typeof(Nachos);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -2961,7 +2962,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Insert_Relation() {
             // Arrange
             var source = typeof(Manicure);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -2999,7 +3000,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Update_SingleFieldPrimaryKey() {
             // Arrange
             var source = typeof(SignLanguage);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3034,7 +3035,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Update_MultiFieldPrimaryKey() {
             // Arrange
             var source = typeof(Diaspora);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3069,7 +3070,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Update_AllFieldsPrimaryKey() {
             // Arrange
             var source = typeof(Click);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3093,7 +3094,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Update_TwoRows() {
             // Arrange
             var source = typeof(CutthroatKitchenSabotage);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3148,7 +3149,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Update_ThreePlusRows() {
             // Arrange
             var source = typeof(WelshGod);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3223,7 +3224,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Update_NullValue() {
             // Arrange
             var source = typeof(Curry);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3260,7 +3261,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Update_NonAssociativeRelation() {
             // Arrange
             var source = typeof(Overture);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3285,7 +3286,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Update_SingleKeyAssociativeRelation() {
             // Arrange
             var source = typeof(Supermodel);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3316,7 +3317,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Update_MultiKeyAssociativeRelation() {
             // Arrange
             var source = typeof(StockIndex);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3349,7 +3350,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_SingleFieldPrimaryKey() {
             // Arrange
             var source = typeof(Mansa);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3375,7 +3376,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_MultiFieldPrimaryKey() {
             // Arrange
             var source = typeof(Hamentaschen);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3407,7 +3408,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_AllFieldsPrimaryKey() {
             // Arrange
             var source = typeof(Tirthankara);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3437,7 +3438,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_TwoRows() {
             // Arrange
             var source = typeof(FoodTruck);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3472,7 +3473,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_ThreePlusRows() {
             // Arrange
             var source = typeof(Iyalet);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Principal.Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3513,7 +3514,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_NonAssociativeRelation() {
             // Arrange
             var source = typeof(BuzzerSystem);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3541,7 +3542,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_SingleKeyAssociativeRelation() {
             // Arrange
             var source = typeof(LineDance);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3571,7 +3572,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_MultiKeyAssociativeRelation() {
             // Arrange
             var source = typeof(CochlearImplant);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3605,7 +3606,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_OwningEntity_NonAssociativeRelation() {
             // Arrange
             var source = typeof(CongaLine);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3631,7 +3632,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_OwningEntity_SingleKeyAssociativeRelation() {
             // Arrange
             var source = typeof(Rodeo);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3662,7 +3663,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_OwningEntity_MultiKeyAssociativeRelation() {
             // Arrange
             var source = typeof(Surrogate);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {
@@ -3704,7 +3705,7 @@ namespace UT.Kvasir.Providers {
         [TestMethod] public void Delete_MixedStyleFromRelation() {
             // Arrange
             var source = typeof(AbortionClinic);
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var table = translator[source].Relations[0].Table;
             var rows = new List<List<DBValue>>() {
                 new() {

--- a/test/UnitTests/Kvasir/Transaction/_Fixture.cs
+++ b/test/UnitTests/Kvasir/Transaction/_Fixture.cs
@@ -4,6 +4,7 @@ using FluentAssertions.Execution;
 using Kvasir.Schema;
 using Kvasir.Transaction;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.Core;
 using System;
@@ -30,7 +31,7 @@ namespace UT.Kvasir.Transaction {
             Connection = Substitute.For<IDbConnection>();
             Transaction = Connection.BeginTransaction();
             Depot = types.ToDictionary(t => t, _ => new List<object>());
-            translator_ = new Translator(t => Depot[t]);
+            translator_ = new Translator(t => Depot[t], NullLogger.Instance);
             ordering_ = new Dictionary<IDbCommand, int>();
             invocationArgs_ = new Dictionary<IDbCommand, IReadOnlyList<IReadOnlyList<DBValue>>>();
 
@@ -85,7 +86,7 @@ namespace UT.Kvasir.Transaction {
                 dbRows_[table] = new List<IReadOnlyList<object>>().GetEnumerator();
             }
 
-            Transactor = new Transactor(entityTranslations, localizationTranslations, Connection, commandsFactory_, e => Depot[e.GetType()].Add(e));
+            Transactor = new Transactor(entityTranslations, localizationTranslations, Connection, commandsFactory_, e => Depot[e.GetType()].Add(e), NullLogger.Instance);
         }
         public TestFixture WithCommitError() {
             Transaction.When(x => x.Commit()).Throw<InvalidOperationException>();

--- a/test/UnitTests/Kvasir/Translation/CandidateKeys.cs
+++ b/test/UnitTests/Kvasir/Translation/CandidateKeys.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -10,7 +11,7 @@ namespace UT.Kvasir.Translation {
     public class CandidateKeyTests {
         [TestMethod] public void MultipleUnnamedCandidateKeys() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Inmate);
 
             // Act
@@ -25,7 +26,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NamedCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BowlGame);
 
             // Act
@@ -42,7 +43,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SingleFieldInMultipleCandidateKeys() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(KingOfEngland);
 
             // Act
@@ -67,7 +68,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleDirectIdenticalUnnamedCandidateKeys() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pigment);
 
             // Act
@@ -81,7 +82,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleIndirectIdenticalUnnamedCandidateKeys() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Octopus);
 
             // Act
@@ -95,7 +96,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleIdenticalNamedCandidateKeys() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BankCheck);
 
             // Act
@@ -109,7 +110,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void FieldInSameCandidateKeyMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Desert);
 
             // Act
@@ -126,7 +127,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateInCandidateKeyAlone() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ointment);
 
             // Act
@@ -143,7 +144,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateInCandidateKeyWithOtherFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Shipwreck);
 
             // Act
@@ -165,7 +166,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateNestedScalarsInCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SpiderMan);
 
             // Act
@@ -187,7 +188,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedAggregatesInCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Neurotransmitter);
 
             // Act
@@ -204,7 +205,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateFieldsNativelyInCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ZoomMeeting);
 
             // Act
@@ -222,7 +223,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferenceInCandidateKeyAlone() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Luau);
 
             // Act
@@ -239,7 +240,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferenceInCandidateKeyWithOtherFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GreatOldOne);
 
             // Act
@@ -256,7 +257,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferenceNestedScalarsInCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(JapaneseEmperor);
 
             // Act
@@ -273,7 +274,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedReferencesInCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Kibbutz);
 
             // Act
@@ -290,7 +291,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PrimaryKeyReferenceFieldsNativelyInCandidateKeyNotPropagated() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DiscworldGuild);
 
             // Act
@@ -303,7 +304,7 @@ namespace UT.Kvasir.Translation {
         
         [TestMethod] public void NonPrimaryKeyReferenceFieldsNativelyInCandidateKeyNotPropagated() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HonestTrailer);
 
             // Act
@@ -316,7 +317,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedScalarsInCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BigBlockOfCheeseDay);
 
             // Act
@@ -333,7 +334,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedRelationsInCandidateKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RentalCar);
 
             // Act
@@ -350,7 +351,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationFieldsNativelyInCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Intifada);
 
             // Act
@@ -369,7 +370,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AnchorPlusMapKeyIsCandidateKey_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(VoodooDoll);
 
             // Act
@@ -386,7 +387,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AnchorPlusOrderedListIndexIsCandidateKey_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(OPO);
 
             // Act
@@ -403,7 +404,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationInCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ToDoList);
 
             // Act
@@ -419,7 +420,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedLocalizationInCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hexagon);
 
             // Act
@@ -436,7 +437,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ScalarAndNestedFieldsInSameCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sabermetric);
 
             // Act
@@ -453,7 +454,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CandidateKeyNameIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PlatonicDialogue);
 
             // Act
@@ -469,7 +470,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CandidateKeyNameIsEmptyString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Allomancy);
 
             // Act
@@ -485,7 +486,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CandidateKeyNameIsReserved_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lens);
 
             // Act
@@ -501,7 +502,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CandidateKeyIsEquivalentToPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AchaeanNavalContingent);
 
             // Act
@@ -513,7 +514,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CandidateKeyIsSupersetOfPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WorldHeritageSite);
 
             // Act
@@ -525,7 +526,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PreDefinedInstanceInCandidateKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cheesecake);
 
             // Act
@@ -541,7 +542,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tendon);
 
             // Act
@@ -557,7 +558,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sonnet);
 
             // Act
@@ -573,7 +574,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(EgyptianGod);
 
             // Act
@@ -589,7 +590,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bachelorette);
 
             // Act
@@ -605,7 +606,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sherpa);
 
             // Act
@@ -621,7 +622,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathOnReferenceRefersToPartiallyExposedAggregate() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LawFirm);
 
             // Act
@@ -638,7 +639,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Antihistamine);
 
             // Act
@@ -654,7 +655,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Oasis);
 
             // Act
@@ -670,7 +671,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LimboCompetition);
 
             // Act
@@ -686,7 +687,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GameChanger);
 
             // Act
@@ -702,7 +703,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ramen);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/ColumnOrdering.cs
+++ b/test/UnitTests/Kvasir/Translation/ColumnOrdering.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -10,7 +11,7 @@ namespace UT.Kvasir.Translation {
     public class ColumnOrderingTests {
         [TestMethod] public void AllFieldsOrdered() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Fraction);
 
             // Act
@@ -26,7 +27,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SomeScalarFieldsOrdered() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Parashah);
 
             // Act
@@ -44,7 +45,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateFieldsOrdered() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Armada);
 
             // Act
@@ -70,7 +71,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferenceFieldsOrdered() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(EdibleArrangement);
 
             // Act
@@ -93,7 +94,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTableOrdering() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DebitCard);
 
             // Act
@@ -117,7 +118,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationTableOrdering() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RoyalTitle);
 
             // Act
@@ -133,7 +134,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationFieldsOrdered() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Merger);
 
             // Act
@@ -152,7 +153,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationFieldsOrdered_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tapestry);
 
             // Act
@@ -168,7 +169,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PreDefinedInstanceOrdered_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Birthstone);
 
             // Act
@@ -184,7 +185,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferencePrimaryKeysAreNonSequential() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MassExtinction);
 
             // Act
@@ -203,7 +204,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationAnchorPrimaryKeysAreNonSequential() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DuoPush);
 
             // Act
@@ -219,7 +220,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void TwoScalarFieldsOrderedToSameIndexInEntity_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pizza);
 
             // Act
@@ -234,7 +235,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void TwoScalarFieldsOrderedToSameIndexInAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BiblicalPlague);
 
             // Act
@@ -249,7 +250,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void TwoNestedFieldsOrderedToSameIndex_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Coup);
 
             // Act
@@ -265,7 +266,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ScalarAndNestedFieldOrderedToSameIndex_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bread);
 
             // Act
@@ -280,7 +281,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ColumnOrderingOfScalarsLeavesGaps_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PhoneNumber);
 
             // Act
@@ -295,7 +296,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ColumnOrderingOfAggregatesLeavesGaps_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Verb);
 
             // Act
@@ -310,7 +311,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ColumnOrderingOfReferencesLeavesGaps_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Origami);
 
             // Act
@@ -325,7 +326,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NegativeColumnIndex_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NationalPark);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
@@ -16,7 +17,7 @@ namespace UT.Kvasir.Translation {
     public class IsGreaterThanTests {
         [TestMethod] public void IsGreaterThan_NumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DNDSpell);
 
             // Act
@@ -32,7 +33,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_TextualFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MultipleChoiceQuestion);
 
             // Act
@@ -50,7 +51,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Font);
 
             // Act
@@ -66,7 +67,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_DecimalField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AuctionLot);
 
             // Act
@@ -80,7 +81,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_DateishField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GoldRush);
 
             // Act
@@ -95,7 +96,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Skyscraper);
 
             // Act
@@ -111,7 +112,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Orisha);
 
             // Act
@@ -127,7 +128,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_LocalizationFieldWithApplicableKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(IsraeliPrimeMinister);
 
             // Act
@@ -141,7 +142,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_LocalizationFieldWithInapplicableKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ArconiaMurder);
 
             // Act
@@ -157,7 +158,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Opioid);
 
             // Act
@@ -172,7 +173,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Wordle);
 
             // Act
@@ -189,7 +190,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FlashMob);
 
             // Act
@@ -206,7 +207,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Apostle);
 
             // Act
@@ -220,7 +221,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Influenza);
 
             // Act
@@ -237,7 +238,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Gorgon);
 
             // Act
@@ -253,7 +254,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PapalBull);
 
             // Act
@@ -266,7 +267,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BloodDrive);
 
             // Act
@@ -283,7 +284,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NestedLocalizationWithApplicableKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Valkyrie);
 
             // Act
@@ -297,7 +298,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NestedLocalizationWithInapplicableKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LibraryCard);
 
             // Act
@@ -314,7 +315,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(KidNextDoor);
 
             // Act
@@ -329,7 +330,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Antari);
 
             // Act
@@ -346,7 +347,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Clown);
 
             // Act
@@ -363,7 +364,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NullableTotallyOrderedFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Baryon);
 
             // Act
@@ -379,7 +380,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_InconvertibleAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Racehorse);
 
             // Act
@@ -395,7 +396,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_ConvertibleAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChineseCharacter);
 
             // Act
@@ -411,7 +412,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_ArrayAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Query);
 
             // Act
@@ -427,7 +428,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NullAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(UNResolution);
 
             // Act
@@ -443,7 +444,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_AnchorIsMaximum_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Upanishad);
 
             // Act
@@ -459,7 +460,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_DecimalAnchorIsNotDouble_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GarageSale);
 
             // Act
@@ -475,7 +476,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_DecimalAnchorIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TalkShow);
 
             // Act
@@ -491,7 +492,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_DateTimeAnchorIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Meme);
 
             // Act
@@ -507,7 +508,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_DateTimeAnchorIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChristianDenomination);
 
             // Act
@@ -523,7 +524,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_DateTimeAnchorIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GraduateThesis);
 
             // Act
@@ -539,7 +540,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_AnchorMatchesDataConversionSourceType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Azeotrope);
 
             // Act
@@ -555,7 +556,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_AnchorMatchesDataConversionTargetType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BingoCard);
 
             // Act
@@ -569,7 +570,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_ScalarConstrainedMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NuclearPowerPlant);
 
             // Act
@@ -583,7 +584,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Domino);
 
             // Act
@@ -599,7 +600,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Canyon);
 
             // Act
@@ -615,7 +616,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Conlang);
 
             // Act
@@ -631,7 +632,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LaborStrike);
 
             // Act
@@ -647,7 +648,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(InstallationWizard);
 
             // Act
@@ -663,7 +664,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BugSpray);
 
             // Act
@@ -679,7 +680,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Intern);
 
             // Act
@@ -695,7 +696,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Delicatessen);
 
             // Act
@@ -711,7 +712,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BlackjackHand);
 
             // Act
@@ -727,7 +728,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Inquisition);
 
             // Act
@@ -743,7 +744,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AmericanNinjaWarrior);
 
             // Act
@@ -759,7 +760,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Camel);
 
             // Act
@@ -775,7 +776,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DraftPick);
 
             // Act
@@ -791,7 +792,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterThan_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Madrasa);
 
             // Act
@@ -811,7 +812,7 @@ namespace UT.Kvasir.Translation {
     public class IsLessThanTests {
         [TestMethod] public void IsLessThan_NumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Resistor);
 
             // Act
@@ -827,7 +828,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_TextualFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Senator);
 
             // Act
@@ -842,7 +843,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Milkshake);
 
             // Act
@@ -858,7 +859,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_DecimalField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TreasuryBond);
 
             // Act
@@ -872,7 +873,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_DateishField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Commercial);
 
             // Act
@@ -887,7 +888,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DLL);
 
             // Act
@@ -903,7 +904,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SolicitorGeneral);
 
             // Act
@@ -919,7 +920,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_LocalizationFieldWithApplicableKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BuildABearWorkshop);
 
             // Act
@@ -933,7 +934,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_LocalizationFieldWithInapplicableKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HookahBar);
 
             // Act
@@ -949,7 +950,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Raptor);
 
             // Act
@@ -966,7 +967,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Feruchemy);
 
             // Act
@@ -983,7 +984,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Firefighter);
 
             // Act
@@ -1000,7 +1001,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Butterfly);
 
             // Act
@@ -1014,7 +1015,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cartel);
 
             // Act
@@ -1031,7 +1032,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CharacterEncoding);
 
             // Act
@@ -1047,7 +1048,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CVE);
 
             // Act
@@ -1060,7 +1061,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hallucination);
 
             // Act
@@ -1077,7 +1078,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NestedLocalizationWithApplicableKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CivVITechnology);
 
             // Act
@@ -1091,7 +1092,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NestedLocalizationWithInapplicableKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MakeAWish);
 
             // Act
@@ -1108,7 +1109,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FairyGodparent);
 
             // Act
@@ -1124,7 +1125,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NavalBlockade);
 
             // Act
@@ -1141,7 +1142,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Blacksmith);
 
             // Act
@@ -1158,7 +1159,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NullableTotallyOrderedFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AutoRacetrack);
 
             // Act
@@ -1174,7 +1175,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_InconvertibleAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Distribution);
 
             // Act
@@ -1190,7 +1191,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_ConvertibleAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WebBrowser);
 
             // Act
@@ -1206,7 +1207,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_ArrayAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GrammaticalCase);
 
             // Act
@@ -1222,7 +1223,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NullAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PowerPointAnimation);
 
             // Act
@@ -1238,7 +1239,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_AnchorIsMinimum_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StrategoPiece);
 
             // Act
@@ -1254,7 +1255,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_DecimalAnchorIsNotDouble_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Toothpaste);
 
             // Act
@@ -1270,7 +1271,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_DecimalAnchorIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Census);
 
             // Act
@@ -1286,7 +1287,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_DateTimeAnchorIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NobelPrize);
 
             // Act
@@ -1302,7 +1303,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_DateTimeAnchorIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Shogunate);
 
             // Act
@@ -1318,7 +1319,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_DateTimeAnchorIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ISOStandard);
 
             // Act
@@ -1334,7 +1335,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_AnchorMatchesDataConversionSourceType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Artiodactyl);
 
             // Act
@@ -1350,7 +1351,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_AnchorMatchesDataConversionTargetType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Phobia);
 
             // Act
@@ -1364,7 +1365,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_ScalarConstrainedMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CinemaSins);
 
             // Act
@@ -1378,7 +1379,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BaseballBat);
 
             // Act
@@ -1394,7 +1395,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Potato);
 
             // Act
@@ -1410,7 +1411,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SurgicalMask);
 
             // Act
@@ -1426,7 +1427,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SecretSociety);
 
             // Act
@@ -1442,7 +1443,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NationalMonument);
 
             // Act
@@ -1458,7 +1459,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(YogaPosition);
 
             // Act
@@ -1474,7 +1475,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PubCrawl);
 
             // Act
@@ -1490,7 +1491,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mime);
 
             // Act
@@ -1506,7 +1507,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CatholicCardinal);
 
             // Act
@@ -1522,7 +1523,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hemalurgy);
 
             // Act
@@ -1538,7 +1539,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Isotope);
 
             // Act
@@ -1554,7 +1555,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLesThan_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WorldBaseballClassic);
 
             // Act
@@ -1570,7 +1571,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ParkingGarage);
 
             // Act
@@ -1586,7 +1587,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThan_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ContactLens);
 
             // Act
@@ -1606,7 +1607,7 @@ namespace UT.Kvasir.Translation {
     public class IsGreaterOrEqualToTests {
         [TestMethod] public void IsGreaterOrEqualTo_NumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Geyser);
 
             // Act
@@ -1622,7 +1623,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_TextualFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hotel);
 
             // Act
@@ -1637,7 +1638,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Steak);
 
             // Act
@@ -1653,7 +1654,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_DecimalField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ETF);
 
             // Act
@@ -1667,7 +1668,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_DateishField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PEP);
 
             // Act
@@ -1682,7 +1683,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CoatOfArms);
 
             // Act
@@ -1698,7 +1699,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CivCityState);
 
             // Act
@@ -1714,7 +1715,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_LocalizationFieldWithApplicableKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PrisonerOfWar);
 
             // Act
@@ -1728,7 +1729,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_LocalizationFieldWithInapplicableKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Diadochos);
 
             // Act
@@ -1744,7 +1745,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FamilyTree);
 
             // Act
@@ -1759,7 +1760,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Readymade);
 
             // Act
@@ -1776,7 +1777,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FitnessCenter);
 
             // Act
@@ -1793,7 +1794,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CandyBar);
 
             // Act
@@ -1807,7 +1808,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SlumberParty);
 
             // Act
@@ -1824,7 +1825,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Squash);
 
             // Act
@@ -1840,7 +1841,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Spa);
 
             // Act
@@ -1853,7 +1854,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Barbie);
 
             // Act
@@ -1870,7 +1871,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NestedLocalizationWithApplicableKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Commander);
 
             // Act
@@ -1884,7 +1885,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NestedLocalizationWithInapplicableKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BuffaloWildWingsSauce);
 
             // Act
@@ -1901,7 +1902,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PuppetShow);
 
             // Act
@@ -1916,7 +1917,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Horcrux);
 
             // Act
@@ -1933,7 +1934,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WheresWaldo);
 
             // Act
@@ -1950,7 +1951,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NullableTotallyOrderedFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Muscle);
 
             // Act
@@ -1966,7 +1967,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_InconvertibleAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LandCard);
 
             // Act
@@ -1982,7 +1983,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_ConvertibleAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Keystroke);
 
             // Act
@@ -1998,7 +1999,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_ArrayAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Zoo);
 
             // Act
@@ -2014,7 +2015,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NullAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Neurotoxin);
 
             // Act
@@ -2030,7 +2031,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_AnchorIsMinimum_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bacterium);
 
             // Act
@@ -2044,7 +2045,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_DecimalAnchorIsNotDouble_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GitHook);
 
             // Act
@@ -2060,7 +2061,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_DecimalAnchorIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RubeGoldbergMachine);
 
             // Act
@@ -2076,7 +2077,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_DateTimeAnchorIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Smurf);
 
             // Act
@@ -2092,7 +2093,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_DateTimeAnchorIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WorldCup);
 
             // Act
@@ -2108,7 +2109,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_DateTimeAnchorIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SharkTankPitch);
 
             // Act
@@ -2124,7 +2125,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_AnchorMatchesDataConversionSourceType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mushroom);
 
             // Act
@@ -2140,7 +2141,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_AnchorMatchesDataConversionTargetType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(EMail);
 
             // Act
@@ -2154,7 +2155,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_ScalarConstrainedMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SolarEclipse);
 
             // Act
@@ -2168,7 +2169,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(YuGiOhMonster);
 
             // Act
@@ -2184,7 +2185,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hieroglyph);
 
             // Act
@@ -2200,7 +2201,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pagoda);
 
             // Act
@@ -2216,7 +2217,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Motorcycle);
 
             // Act
@@ -2232,7 +2233,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Druid);
 
             // Act
@@ -2248,7 +2249,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mirror);
 
             // Act
@@ -2264,7 +2265,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Chromosome);
 
             // Act
@@ -2280,7 +2281,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HighlanderImmortal);
 
             // Act
@@ -2296,7 +2297,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Synagogue);
 
             // Act
@@ -2312,7 +2313,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Panegyric);
 
             // Act
@@ -2328,7 +2329,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PlasticSurgery);
 
             // Act
@@ -2344,7 +2345,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Landfill);
 
             // Act
@@ -2360,7 +2361,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Camera);
 
             // Act
@@ -2376,7 +2377,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsGreaterOrEqualTo_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SlapBet);
 
             // Act
@@ -2396,7 +2397,7 @@ namespace UT.Kvasir.Translation {
     public class IsLessOrEqualToTests {
         [TestMethod] public void IsLessOrEqualTo_NumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Fjord);
 
             // Act
@@ -2413,7 +2414,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_TextualFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ExcelRange);
 
             // Act
@@ -2428,7 +2429,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TectonicPlate);
 
             // Act
@@ -2444,7 +2445,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_DecimalField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Caliphate);
 
             // Act
@@ -2458,7 +2459,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_DateishField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Representative);
 
             // Act
@@ -2473,7 +2474,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sunscreen);
 
             // Act
@@ -2489,7 +2490,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ConcertTour);
 
             // Act
@@ -2505,7 +2506,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_LocalizationFieldWithApplicableKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CrabRangoon);
 
             // Act
@@ -2519,7 +2520,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_LocalizationFieldWithInapplicableKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Flamethrower);
 
             // Act
@@ -2535,7 +2536,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hominin);
 
             // Act
@@ -2549,7 +2550,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AmazonService);
 
             // Act
@@ -2566,7 +2567,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Shampoo);
 
             // Act
@@ -2583,7 +2584,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Gatorade);
 
             // Act
@@ -2597,7 +2598,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Knife);
 
             // Act
@@ -2614,7 +2615,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChannelIsland);
 
             // Act
@@ -2630,7 +2631,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WhiteWalker);
 
             // Act
@@ -2643,7 +2644,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ransomware);
 
             // Act
@@ -2660,7 +2661,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NestedLocalizationWithApplicableKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Coconut);
 
             // Act
@@ -2674,7 +2675,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NestedLocalizationWithInapplicableKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SpecialVictim);
 
             // Act
@@ -2691,7 +2692,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Syllabary);
 
             // Act
@@ -2705,7 +2706,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TreehouseOfHorror);
 
             // Act
@@ -2722,7 +2723,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CocoaFarm);
 
             // Act
@@ -2739,7 +2740,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NullableTotallyOrderedFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Subreddit);
 
             // Act
@@ -2755,7 +2756,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_InconvertibleAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Dreidel);
 
             // Act
@@ -2771,7 +2772,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_ConvertibleAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ArthurianKnight);
 
             // Act
@@ -2787,7 +2788,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_ArrayAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mint);
 
             // Act
@@ -2803,7 +2804,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NullAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(VoirDire);
 
             // Act
@@ -2819,7 +2820,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_AnchorIsMaximum_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ShellCommand);
 
             // Act
@@ -2833,7 +2834,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_DecimalAnchorIsNotDouble_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChewingGum);
 
             // Act
@@ -2849,7 +2850,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_DecimalAnchorIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Headphones);
 
             // Act
@@ -2865,7 +2866,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_DateTimeAnchorIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ClockTower);
 
             // Act
@@ -2881,7 +2882,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_DateTimeAnchorIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(KentuckyDerby);
 
             // Act
@@ -2897,7 +2898,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_DateTimeAnchorIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Firearm);
 
             // Act
@@ -2913,7 +2914,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_AnchorMatchesDataConversionSourceType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ShardOfAdonalsium);
 
             // Act
@@ -2929,7 +2930,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_AnchorMatchesDataConversionTargetType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HTMLElement);
 
             // Act
@@ -2943,7 +2944,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_ScalarConstrainedMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Archbishop);
 
             // Act
@@ -2957,7 +2958,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GameOfClue);
 
             // Act
@@ -2973,7 +2974,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PlaneOfExistence);
 
             // Act
@@ -2989,7 +2990,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mausoleum);
 
             // Act
@@ -3005,7 +3006,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pseudonym);
 
             // Act
@@ -3021,7 +3022,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FoodPantry);
 
             // Act
@@ -3037,7 +3038,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FittedSheet);
 
             // Act
@@ -3053,7 +3054,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Playlist);
 
             // Act
@@ -3069,7 +3070,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ThumbWar);
 
             // Act
@@ -3085,7 +3086,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(EngagementRing);
 
             // Act
@@ -3101,7 +3102,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ImpracticalJoke);
 
             // Act
@@ -3117,7 +3118,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThanOrEqualTo_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GolfCart);
 
             // Act
@@ -3133,7 +3134,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessThanOrEqualTo_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DDayBeach);
 
             // Act
@@ -3149,7 +3150,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BowlingFrame);
 
             // Act
@@ -3165,7 +3166,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsLessOrEqualTo_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Defenestration);
 
             // Act
@@ -3185,7 +3186,7 @@ namespace UT.Kvasir.Translation {
     public class IsNotTests {
         [TestMethod] public void IsNot_NumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bridge);
 
             // Act
@@ -3201,7 +3202,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_TextualFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Quatrain);
 
             // Act
@@ -3219,7 +3220,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_BooleanField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PoliceOfficer);
 
             // Act
@@ -3233,7 +3234,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_DecimalField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Therapist);
 
             // Act
@@ -3247,7 +3248,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_DateishField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SlotMachine);
 
             // Act
@@ -3262,7 +3263,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_GuidField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Church);
 
             // Act
@@ -3276,7 +3277,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_EnumerationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MarianApparition);
 
             // Act
@@ -3301,7 +3302,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_LocalizationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Catacombs);
 
             // Act
@@ -3316,7 +3317,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_AggregateNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SeventhInningStretch);
 
             // Act
@@ -3331,7 +3332,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SportsBet);
 
             // Act
@@ -3348,7 +3349,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_ReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StanleyCup);
 
             // Act
@@ -3366,7 +3367,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sexuality);
 
             // Act
@@ -3382,7 +3383,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Diet);
 
             // Act
@@ -3395,7 +3396,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FishingRod);
 
             // Act
@@ -3412,7 +3413,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NestedLocalization() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Shtetl);
 
             // Act
@@ -3426,7 +3427,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_RelationNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StandUpComedian);
 
             // Act
@@ -3447,7 +3448,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Interview);
 
             // Act
@@ -3464,7 +3465,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NullableFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Fountain);
 
             // Act
@@ -3482,7 +3483,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_InconvertibleAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Candle);
 
             // Act
@@ -3498,7 +3499,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_ConvertibleAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CompilerWarning);
 
             // Act
@@ -3514,7 +3515,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_ArrayAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Alarm);
 
             // Act
@@ -3530,7 +3531,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NullAnchor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HallOfFame);
 
             // Act
@@ -3546,7 +3547,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_DecimalAnchorIsNotDouble_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DistrictAttorney);
 
             // Act
@@ -3562,7 +3563,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_DecimalAnchorIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ping);
 
             // Act
@@ -3578,7 +3579,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_DateTimeAnchorIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(InsurancePolicy);
 
             // Act
@@ -3594,7 +3595,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_DateTimeAnchorIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mosque);
 
             // Act
@@ -3610,7 +3611,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_DateTimeAnchorIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lease);
 
             // Act
@@ -3626,7 +3627,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_GuidValueIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RainDelay);
 
             // Act
@@ -3642,7 +3643,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_GuidValueIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Wiretap);
 
             // Act
@@ -3658,7 +3659,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_AnchorMatchesDataConversionSourceType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FairyTale);
 
             // Act
@@ -3674,7 +3675,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_AnchorMatchesDataConversionTargetType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RingOfPower);
 
             // Act
@@ -3688,7 +3689,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_ScalarConstrainedMultipleTimesSameAnchor() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NazcaLine);
 
             // Act
@@ -3702,7 +3703,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_ScalarConstrainedMultipleTimesDifferentAnchors() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pterosaur);
 
             // Act
@@ -3718,7 +3719,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LotteryTicket);
 
             // Act
@@ -3734,7 +3735,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Prison);
 
             // Act
@@ -3750,7 +3751,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Restaurant);
 
             // Act
@@ -3766,7 +3767,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Balk);
 
             // Act
@@ -3782,7 +3783,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Planetarium);
 
             // Act
@@ -3798,7 +3799,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LiquorStore);
 
             // Act
@@ -3814,7 +3815,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Waterbending);
 
             // Act
@@ -3830,7 +3831,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AutoDaFe);
 
             // Act
@@ -3846,7 +3847,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Dream);
 
             // Act
@@ -3862,7 +3863,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BachelorParty);
 
             // Act
@@ -3878,7 +3879,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pitmaster);
 
             // Act
@@ -3894,7 +3895,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Skirt);
 
             // Act
@@ -3910,7 +3911,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RestStop);
 
             // Act
@@ -3926,7 +3927,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNot_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HearthstoneMinion);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/CustomConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/CustomConstraints.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Kvasir.Core;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System.Collections.Generic;
@@ -21,7 +22,7 @@ namespace UT.Kvasir.Translation {
     public class CustomConstraintTests {
         [TestMethod] public void Check_DefaultConstructed() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(VampireSlayer);
 
             // Act
@@ -46,7 +47,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_ConstructedFromArguments() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lyric);
 
             // Act
@@ -71,7 +72,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_AppliedToAggregateNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Asteroid);
 
             // Act
@@ -107,7 +108,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_AppliedToNestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Vineyard);
 
             // Act
@@ -124,7 +125,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_AppliedToReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Stock);
 
             // Act
@@ -149,7 +150,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_AppliedToNestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Werewolf);
 
             // Act
@@ -166,7 +167,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_AppliedToPreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ubuntu);
 
             // Act
@@ -182,7 +183,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_AppliedToRelationNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CareBear);
 
             // Act
@@ -207,7 +208,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_AppliedToNestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RiverWalk);
 
             // Act
@@ -224,7 +225,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_ScalarConstrainedMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TarotCard);
 
             // Act
@@ -250,7 +251,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_DataConvertedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DataStructure);
 
             // Act
@@ -273,7 +274,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_NameChangedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AronKodesh);
 
             // Act
@@ -296,7 +297,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_ConstraintGeneratorNoViableDefaultConstructor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Seizure);
 
             // Act
@@ -312,7 +313,7 @@ namespace UT.Kvasir.Translation {
         
         [TestMethod] public void Check_ConstraintGeneratorNoViableArgumentsConstructor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Transistor);
 
             // Act
@@ -328,7 +329,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_ConstraintGeneratorDefaultConstructorThrows_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Buffet);
 
             // Act
@@ -344,7 +345,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_ConstraintGeneratorArgumentsConstructorThrows_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BasketballPlayer);
 
             // Act
@@ -360,7 +361,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_ConstraintGeneratorGenerationThrows_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Aquarium);
 
             // Act
@@ -376,7 +377,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Trilogy);
 
             // Act
@@ -392,7 +393,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TarPits);
 
             // Act
@@ -408,7 +409,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StarCrossedLovers);
 
             // Act
@@ -424,7 +425,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Zombie);
 
             // Act
@@ -440,7 +441,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Piano);
 
             // Act
@@ -456,7 +457,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_NonPrimaryKeyFieldPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Exorcism);
 
             // Act
@@ -472,7 +473,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pond);
 
             // Act
@@ -488,7 +489,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CanadianProvince);
 
             // Act
@@ -504,7 +505,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Skydiver);
 
             // Act
@@ -520,7 +521,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Check_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Spring);
 
             // Act
@@ -539,7 +540,7 @@ namespace UT.Kvasir.Translation {
     public class ComplexConstraintTests {
         [TestMethod] public void ComplexCheck_DefaultConstructed() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CanterburyTale);
 
             // Act
@@ -564,7 +565,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_ConstructedFromArguments() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pope);
 
             // Act
@@ -590,7 +591,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_NoFields_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Terminator);
 
             // Act
@@ -606,7 +607,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_MultipleFieldsInOneConstraint() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LinuxDistribution);
 
             // Act
@@ -632,7 +633,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_SingleFieldMultipleTimesInOneConstraint() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Muppet);
 
             // Act
@@ -659,7 +660,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_NameSwappedFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PastaSauce);
 
             // Act
@@ -684,7 +685,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_OriginalNameOfSwappedField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Dam);
 
             // Act
@@ -700,7 +701,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_UnrecognizedField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PeaceTreaty);
 
             // Act
@@ -716,7 +717,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_DataConvertedFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Massacre);
 
             // Act
@@ -742,7 +743,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_RepeatedConstraint() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Musical);
 
             // Act
@@ -779,7 +780,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_ConstraintGeneratorNoViableArgumentsConstructor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CookingOil);
 
             // Act
@@ -795,7 +796,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_ConstraintGeneratorArgumentsConstructorThrows_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pirate);
 
             // Act
@@ -811,7 +812,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_ConstraintGeneratorGenerationThrows_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ComplexCheckConstraints.Attribute);
 
             // Act
@@ -827,7 +828,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexCheck_OnLocalization() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MahjongTile);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/DataConverters.cs
+++ b/test/UnitTests/Kvasir/Translation/DataConverters.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
@@ -13,7 +14,7 @@ namespace UT.Kvasir.Translation {
     public class DataConverterTests {
         [TestMethod] public void NoChangeToFieldsType_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cenote);
 
             // Act
@@ -31,7 +32,7 @@ namespace UT.Kvasir.Translation {
         
         [TestMethod] public void ChangFieldsTypeToScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Comet);
 
             // Act
@@ -51,7 +52,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ChangeFieldsTypeToEnumeration() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TitleOfYourSexTape);
 
             // Act
@@ -79,7 +80,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ChangeFieldsTypeToDifferentEnumeration() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(VestigeOfDivergence);
 
             // Act
@@ -107,7 +108,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EnumerationToUnrelatedType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HomeRunDerby);
 
             // Act
@@ -133,7 +134,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void BooleanToUnrelatedType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MathematicalConjecture);
 
             // Act
@@ -153,7 +154,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EnumerationToNumericBackingType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Quarterback);
 
             // Act
@@ -201,7 +202,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EnumerationToString() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(EcumenicalCouncil);
 
             // Act
@@ -223,7 +224,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ConverterOnAggregateField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Joust);
 
             // Act
@@ -239,7 +240,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ConverterOnReferenceField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Decathlon);
 
             // Act
@@ -255,7 +256,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ConverterOnRelationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bank);
 
             // Act
@@ -271,7 +272,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ConverterOnLocalizationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RiskTerritory);
 
             // Act
@@ -287,7 +288,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ConverterOnPreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PowerRanger);
 
             // Act
@@ -303,7 +304,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ConverterOnNullablePropertyHasNonNullableTargetType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RoyalHouse);
 
             // Act
@@ -320,7 +321,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ConverterOnNonNullablePropertyHasNullableTargetType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Planeswalker);
 
             // Act
@@ -341,7 +342,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsInconvertibleToSourceType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Jedi);
 
             // Act
@@ -357,7 +358,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsConvertibleToSourceType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ConstitutionalAmendment);
 
             // Act
@@ -373,7 +374,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void TargetTypeIsNotSupported_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SNLEpisode);
 
             // Act
@@ -389,7 +390,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DataConverterTypeThrowsOnConstruction_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sword);
 
             // Act
@@ -405,7 +406,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DataConverterTypeThrowsOnConversion_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ligament);
 
             // Act
@@ -420,7 +421,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnBooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pillow);
 
             // Act
@@ -436,7 +437,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnTextualField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(VigenereCipher);
 
             // Act
@@ -452,7 +453,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnNumericField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Satellite);
 
             // Act
@@ -468,7 +469,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnDateOnlyField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PonziScheme);
 
             // Act
@@ -484,7 +485,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnDateTimeField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Symphony);
 
             // Act
@@ -500,7 +501,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnGuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WordSearch);
 
             // Act
@@ -516,7 +517,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnAggregateField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GolfCourse);
 
             // Act
@@ -532,7 +533,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnReferenceField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SlamBallMatch);
 
             // Act
@@ -548,7 +549,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnRelationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Wadi);
 
             // Act
@@ -564,7 +565,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnLocalizationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(JapanesePrefecture);
 
             // Act
@@ -580,7 +581,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConverterOnPreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Friend);
 
             // Act
@@ -596,7 +597,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnBooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BondGirl);
 
             // Act
@@ -612,7 +613,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnTextualField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BatmanVillain);
 
             // Act
@@ -628,7 +629,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnNumericField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cemetery);
 
             // Act
@@ -644,7 +645,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnDateOnlyField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Vaccine);
 
             // Act
@@ -660,7 +661,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnDateTimeField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ImmaculateGrid);
 
             // Act
@@ -676,7 +677,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnGuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Eyeglasses);
 
             // Act
@@ -692,7 +693,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnAggregateField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Windmill);
 
             // Act
@@ -708,7 +709,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnReferenceField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Chakra);
 
             // Act
@@ -724,7 +725,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnRelationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cryptogram);
 
             // Act
@@ -740,7 +741,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnLocalizationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PettingZoo);
 
             // Act
@@ -756,7 +757,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConverterOnPreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Teletubby);
 
             // Act
@@ -772,7 +773,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DataConverterAndNumeric_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SecretHitlerGame);
 
             // Act
@@ -788,7 +789,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DataConverterAndAsString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mezuzah);
 
             // Act
@@ -804,7 +805,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericAndAsString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Atoll);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/DefaultValues.cs
+++ b/test/UnitTests/Kvasir/Translation/DefaultValues.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
@@ -11,7 +12,7 @@ namespace UT.Kvasir.Translation {
     public class DefaultValueTests {
         [TestMethod] public void NonNullBasicScalarDefaults() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BloodType);
 
             // Act
@@ -29,7 +30,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullDecimalDefault() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bestiary);
 
             // Act
@@ -49,7 +50,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullDateishDefault() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Umpire);
 
             // Act
@@ -68,7 +69,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullGuidDefault() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Saint);
 
             // Act
@@ -86,7 +87,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullValidEnumerationDefault() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Oceanid);
 
             // Act
@@ -103,7 +104,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullDefaultsOnNullableScalars() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pepper);
 
             // Act
@@ -121,7 +122,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullDefaultOnNullableEnumeration() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cryptid);
 
             // Act
@@ -139,7 +140,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultOnAggregateNestedFieldPropagated() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sermon);
 
             // Act
@@ -160,7 +161,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void FirstDefaultOnAggregateNestedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Salsa);
 
             // Act
@@ -178,7 +179,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SubsequentDefaultOnAggregateNestedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bicycle);
 
             // Act
@@ -206,7 +207,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultOnReferenceNestedFieldNotPropagated() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Arch);
 
             // Act
@@ -226,7 +227,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void FirstDefaultOnReferenceNestedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Kite);
 
             // Act
@@ -246,7 +247,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SubsequentDefaultOnReferenceNestedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(EscapeRoom);
 
             // Act
@@ -266,7 +267,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultOnRelationNestedFieldPropagated() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DockerContainer);
 
             // Act
@@ -287,7 +288,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void FirstDefaultOnRelationNestedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Kami);
 
             // Act
@@ -307,7 +308,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SubsequentDefaultOnRelationNestedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tamagotchi);
 
             // Act
@@ -324,7 +325,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultOnLocalizationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ConfidentialInformant);
 
             // Act
@@ -342,7 +343,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullDefaultOnNonNullableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RadioStation);
 
             // Act
@@ -358,7 +359,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void InconvertibleNonNullDefaultValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Battleship);
 
             // Act
@@ -374,7 +375,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ConvertibleNonNullDefaultValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(County);
 
             // Act
@@ -390,7 +391,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EnumerationDefaultOnNumericChangedField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MasterClass);
 
             // Act
@@ -406,7 +407,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EnumerationDefaultOnStringChangedField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Orphanage);
 
             // Act
@@ -422,7 +423,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultOnNestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StuffedAnimal);
 
             // Act
@@ -439,7 +440,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultOnNestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PoetLaureate);
 
             // Act
@@ -456,7 +457,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultOnNestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TimeTraveler);
 
             // Act
@@ -473,7 +474,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultOnNestedLocalizationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cantrip);
 
             // Act
@@ -493,7 +494,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ArrayDefaultValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BilliardBall);
 
             // Act
@@ -509,7 +510,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DecimalDefaultIsNotDouble_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Geocache);
 
             // Act
@@ -525,7 +526,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DecimalDefaultIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Screwdriver);
 
             // Act
@@ -541,7 +542,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DateDefaultIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Doula);
 
             // Act
@@ -557,7 +558,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DateDefaultIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Unicorn);
 
             // Act
@@ -573,7 +574,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DateDefaultIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LargeLanguageModel);
 
             // Act
@@ -589,7 +590,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DateTimeDefaultIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RomanEmperor);
 
             // Act
@@ -605,7 +606,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DateTimeDefaultIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tournament);
 
             // Act
@@ -621,7 +622,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DateTimeDefaultIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sculpture);
 
             // Act
@@ -637,7 +638,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void GuidDefaultIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HogwartsHouse);
 
             // Act
@@ -653,7 +654,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void GuidDefaultIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Gene);
 
             // Act
@@ -669,7 +670,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EnumerationDefaultIsInvalidEnumerator_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MoonOfJupiter);
 
             // Act
@@ -685,7 +686,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EnumerationDefaultIsInvalidCombination_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Newspaper);
 
             // Act
@@ -701,7 +702,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultMatchesDataConversionSourceType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CrosswordClue);
 
             // Act
@@ -717,7 +718,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultMatchesDataConversionTargetType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Coupon);
 
             // Act
@@ -736,7 +737,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleDefaultsOnScalarProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SkeeBall);
 
             // Act
@@ -752,7 +753,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultOnPreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(InspectorClouseau);
 
             // Act
@@ -768,7 +769,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Waterfall);
 
             // Act
@@ -784,7 +785,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NativeAmericanTribe);
 
             // Act
@@ -800,7 +801,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TourDeFrance);
 
             // Act
@@ -816,7 +817,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(InfinityStone);
 
             // Act
@@ -832,7 +833,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hepatitis);
 
             // Act
@@ -848,7 +849,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Calculator);
 
             // Act
@@ -864,7 +865,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PopTart);
 
             // Act
@@ -880,7 +881,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ArcadeGame);
 
             // Act
@@ -896,7 +897,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Monad);
 
             // Act
@@ -912,7 +913,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LaundryDetergent);
 
             // Act
@@ -928,7 +929,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SportsCenter);
 
             // Act
@@ -944,7 +945,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Caddie);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/DiscretenessConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/DiscretenessConstraints.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
@@ -13,7 +14,7 @@ namespace UT.Kvasir.Translation {
     public class IsOneOfTests {
         [TestMethod] public void IsOneOf_NumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CoralReef);
 
             // Act
@@ -35,7 +36,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_TextualFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Encyclopedia);
 
             // Act
@@ -54,7 +55,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_BooleanField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Astronaut);
 
             // Act
@@ -70,7 +71,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_DecimalField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CiderMill);
 
             // Act
@@ -86,7 +87,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_DateishField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hospital);
 
             // Act
@@ -105,7 +106,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_GuidField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tsunami);
 
             // Act
@@ -119,7 +120,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_EnumerationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tooth);
 
             // Act
@@ -144,7 +145,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_LocalizationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Zeppelin);
 
             // Act
@@ -160,7 +161,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_AggregateNestedScalarField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Earring);
 
             // Act
@@ -176,7 +177,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NestedAggregateProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PhoneticAlphabet);
 
             // Act
@@ -193,7 +194,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_ReferenceNestedScalarField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FerrisWheel);
 
             // Act
@@ -209,7 +210,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NestedReferenceProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pulsar);
 
             // Act
@@ -226,7 +227,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NestedLocalizationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TemperatureScale);
 
             // Act
@@ -242,7 +243,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_RelationNestedScalarField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Dinosaur);
 
             // Act
@@ -259,7 +260,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WorldWonder);
 
             // Act
@@ -275,7 +276,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PullRequest);
 
             // Act
@@ -288,7 +289,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NestedRelationProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cheerleader);
 
             // Act
@@ -305,7 +306,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NullableFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Wildfire);
 
             // Act
@@ -324,7 +325,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_DuplicatedValues() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HealingPotion);
 
             // Act
@@ -340,7 +341,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_InconvertibleValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Battery);
 
             // Act
@@ -356,7 +357,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_ConvertibleValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TennisMatch);
 
             // Act
@@ -372,7 +373,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_InvalidEnumerator_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SpeedLimit);
 
             // Act
@@ -388,7 +389,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_ArrayValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Flashcard);
 
             // Act
@@ -404,7 +405,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NullValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Prophet);
 
             // Act
@@ -420,7 +421,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_DecimalValueIsNotDouble_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Carousel);
 
             // Act
@@ -436,7 +437,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_DecimalValueIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Borate);
 
             // Act
@@ -452,7 +453,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_DateTimeValueIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DalaiLama);
 
             // Act
@@ -468,7 +469,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_DateTimeValueIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Voicemail);
 
             // Act
@@ -484,7 +485,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_DateTimeValueIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FinalJeopardy);
 
             // Act
@@ -500,7 +501,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_GuidValueIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BiologicalCycle);
 
             // Act
@@ -516,7 +517,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_GuidValueIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WaterBottle);
 
             // Act
@@ -532,7 +533,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_ValueMatchesDataConversionSourceType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Burrito);
 
             // Act
@@ -548,7 +549,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_ValueMatchesDataConversionTargetType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WaterSlide);
 
             // Act
@@ -564,7 +565,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_ScalarConstrainedMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cannon);
 
             // Act
@@ -580,7 +581,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_SingleEnumeratorAllowed() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Treehouse);
 
             // Act
@@ -603,7 +604,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Dragon);
 
             // Act
@@ -619,7 +620,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HomericHymn);
 
             // Act
@@ -635,7 +636,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MarbleLeague);
 
             // Act
@@ -651,7 +652,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Artery);
 
             // Act
@@ -667,7 +668,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Safari);
 
             // Act
@@ -683,7 +684,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Adverb);
 
             // Act
@@ -699,7 +700,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Swamp);
 
             // Act
@@ -715,7 +716,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PawnShop);
 
             // Act
@@ -731,7 +732,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DrinkingFountain);
 
             // Act
@@ -747,7 +748,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hairstyle);
 
             // Act
@@ -763,7 +764,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bailiff);
 
             // Act
@@ -779,7 +780,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NavalBase);
 
             // Act
@@ -795,7 +796,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Guillotine);
 
             // Act
@@ -811,7 +812,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOf_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(IKEAFurniture);
 
             // Act
@@ -831,7 +832,7 @@ namespace UT.Kvasir.Translation {
     public class IsNotOneOfTests {
         [TestMethod] public void IsNotOneOf_NumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NationalAnthem);
 
             // Act
@@ -853,7 +854,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_TextualFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Taxi);
 
             // Act
@@ -872,7 +873,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_BooleanField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BirthControl);
 
             // Act
@@ -886,7 +887,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_DecimalField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HouseCommittee);
 
             // Act
@@ -902,7 +903,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_DateishField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GamingConsole);
 
             // Act
@@ -921,7 +922,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_GuidField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Podcast);
 
             // Act
@@ -937,7 +938,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_EnumerationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RorschachInkBlot);
 
             // Act
@@ -960,7 +961,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_LocalizationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SECShort);
 
             // Act
@@ -976,7 +977,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_AggregateNestedScalarField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Condiment);
 
             // Act
@@ -992,7 +993,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NestedAggregateProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tattoo);
 
             // Act
@@ -1009,7 +1010,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_ReferenceNestedScalarField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lifeguard);
 
             // Act
@@ -1025,7 +1026,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_PreDefinedInstance() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pentomino);
 
             // Act
@@ -1041,7 +1042,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SearchWarrant);
 
             // Act
@@ -1054,7 +1055,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NestedReferenceProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NurseryRhyme);
 
             // Act
@@ -1071,7 +1072,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NestedLocalizationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GregorianChant);
 
             // Act
@@ -1085,7 +1086,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_RelationNestedScalarField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Infomercial);
 
             // Act
@@ -1101,7 +1102,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NestedRelationProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PersonOfTheYear);
 
             // Act
@@ -1118,7 +1119,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NullableFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PIERoot);
 
             // Act
@@ -1137,7 +1138,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_DuplicatedValues() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tweet);
 
             // Act
@@ -1153,7 +1154,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_InconvertibleValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cancer);
 
             // Act
@@ -1169,7 +1170,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_ConvertibleValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Avatar);
 
             // Act
@@ -1185,7 +1186,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_InvalidEnumerator_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Emotion);
 
             // Act
@@ -1201,7 +1202,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_ArrayValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Wristwatch);
 
             // Act
@@ -1217,7 +1218,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NullValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ballet);
 
             // Act
@@ -1233,7 +1234,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_DecimalValueIsNotDouble_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AmericanIdol);
 
             // Act
@@ -1249,7 +1250,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_DecimalValueIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RussianTsar);
 
             // Act
@@ -1265,7 +1266,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_DateTimeValueIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mayor);
 
             // Act
@@ -1281,7 +1282,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_DateTimeValueIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Inator);
 
             // Act
@@ -1297,7 +1298,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_DateTimeValueIsOutOfRange_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Museum);
 
             // Act
@@ -1313,7 +1314,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_GuidValueIsNotString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cruise);
 
             // Act
@@ -1329,7 +1330,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_GuidValueIsMalformatted_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Union);
 
             // Act
@@ -1345,7 +1346,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_ValueMatchesDataConversionSourceType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Guitar);
 
             // Act
@@ -1361,7 +1362,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_ValueMatchesDataConversionTargetType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SoccerTeam);
 
             // Act
@@ -1377,7 +1378,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_BothBooleansDisallowed_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Transformer);
 
             // Act
@@ -1392,7 +1393,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_AllEnumeratorsDisallowed_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ProgrammingLanguage);
 
             // Act
@@ -1407,7 +1408,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_ScalarConstrainedMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Eurovision);
 
             // Act
@@ -1423,7 +1424,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tuxedo);
 
             // Act
@@ -1439,7 +1440,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Donut);
 
             // Act
@@ -1455,7 +1456,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Necktie);
 
             // Act
@@ -1471,7 +1472,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Scattergories);
 
             // Act
@@ -1487,7 +1488,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pencil);
 
             // Act
@@ -1503,7 +1504,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mitzvah);
 
             // Act
@@ -1519,7 +1520,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Eunuch);
 
             // Act
@@ -1535,7 +1536,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PhoneBook);
 
             // Act
@@ -1551,7 +1552,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bakugan);
 
             // Act
@@ -1567,7 +1568,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(QRCode);
 
             // Act
@@ -1583,7 +1584,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bedouin);
 
             // Act
@@ -1599,7 +1600,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RubiksCube);
 
             // Act
@@ -1615,7 +1616,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pie);
 
             // Act
@@ -1631,7 +1632,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOf_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GirlScoutCookie);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/EntityShapes.cs
+++ b/test/UnitTests/Kvasir/Translation/EntityShapes.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Reflection;
 
@@ -12,7 +13,7 @@ namespace UT.Kvasir.Translation {
     public class EntityShapeTests {
         [TestMethod] public void EntityTypeIsRecordClass() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Color);
 
             // Act
@@ -31,7 +32,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsPartialClass() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PresidentialElection);
 
             // Act
@@ -54,7 +55,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsStaticClass_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HighHell);
 
             // Act
@@ -69,7 +70,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsPrivate() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(EntityShapes).GetNestedType("GitCommit", BindingFlags.NonPublic)!;
 
             // Act
@@ -89,7 +90,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsInternal() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Belt);
 
             // Act
@@ -109,7 +110,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsLocalization() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MatchPair);
 
             // Act
@@ -139,7 +140,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsStruct_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Carbohydrate);
 
             // Act
@@ -154,7 +155,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsRecordStruct_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AminoAcid);
 
             // Act
@@ -169,7 +170,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsAbstractClass_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SuperBowl);
 
             // Act
@@ -184,7 +185,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsAbstractLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Trademark);
 
             // Act
@@ -199,7 +200,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsOpenGeneric_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Speedometer<>);
 
             // Act
@@ -214,7 +215,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsOpenGenericLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Emoticon<>);
 
             // Act
@@ -229,7 +230,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsClosedGeneric_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Speedometer<double>);
 
             // Act
@@ -244,7 +245,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsInterface_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ILiquor);
 
             // Act
@@ -259,7 +260,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsEnumeration_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Season);
 
             // Act
@@ -274,7 +275,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityTypeIsDelegate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SurfingManeuver);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/Extraction.cs
+++ b/test/UnitTests/Kvasir/Translation/Extraction.cs
@@ -2,6 +2,7 @@
 using Kvasir.Core;
 using Kvasir.Relations;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
@@ -26,7 +27,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Morgue)];
             var data = translation.Principal.Extractor.ExtractFrom(morgue);
             var pk = translation.Principal.KeyExtractor.ExtractFrom(morgue);
@@ -56,7 +57,7 @@ namespace UT.Kvasir.Translation {
             PythonInterpreter.BackEndLanguage = PythonInterpreter.Language.CPP;
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(PythonInterpreter)];
             var data = translation.Principal.Extractor.ExtractFrom(interpreter);
             var pk = translation.Principal.KeyExtractor.ExtractFrom(interpreter);
@@ -86,7 +87,7 @@ namespace UT.Kvasir.Translation {
             ship.SetNumCannons(30);
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(PirateShip)];
             var data = translation.Principal.Extractor.ExtractFrom(ship);
             var pk = translation.Principal.KeyExtractor.ExtractFrom(ship);
@@ -116,7 +117,7 @@ namespace UT.Kvasir.Translation {
             Enzyme.FirstDiscovered = new DateTime(1906, 7, 22);
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Enzyme)];
             var data = translation.Principal.Extractor.ExtractFrom(enzyme);
             var pk = translation.Principal.KeyExtractor.ExtractFrom(enzyme);
@@ -146,7 +147,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Ode)];
             var data = translation.Principal.Extractor.ExtractFrom(ode);
             var pk = translation.Principal.KeyExtractor.ExtractFrom(ode);
@@ -176,7 +177,7 @@ namespace UT.Kvasir.Translation {
             (tlatoani as IWorldLeader).Name = "Montezuma II";
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Tlatoani)];
             var data = translation.Principal.Extractor.ExtractFrom(tlatoani);
 
@@ -201,7 +202,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(StateQuarter)];
             var data = translation.Principal.Extractor.ExtractFrom(quarter);
 
@@ -224,7 +225,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Aurora)];
             var data = translation.Principal.Extractor.ExtractFrom(aurora);
 
@@ -241,7 +242,7 @@ namespace UT.Kvasir.Translation {
             var numeral = RomanNumeral.D;
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(RomanNumeral)];
             var data = translation.Principal.Extractor.ExtractFrom(numeral);
 
@@ -262,7 +263,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Underworld)];
             var data = translation.Principal.Extractor.ExtractFrom(underworld);
 
@@ -287,7 +288,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(CornMaze)];
             var data = translation.Principal.Extractor.ExtractFrom(maze);
 
@@ -313,7 +314,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(MarioKartRacetrack)];
             var data = translation.Principal.Extractor.ExtractFrom(racetrack);
 
@@ -336,7 +337,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Lighthouse)];
             var data = translation.Principal.Extractor.ExtractFrom(lighthouse);
 
@@ -358,7 +359,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Nucleobase)];
             var data = translation.Principal.Extractor.ExtractFrom(nucleobase);
 
@@ -386,7 +387,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(LegoSet)];
             var data = translation.Principal.Extractor.ExtractFrom(legos);
 
@@ -418,7 +419,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(SnowballFight)];
             var data = translation.Principal.Extractor.ExtractFrom(fight);
 
@@ -443,7 +444,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Knot)];
             var data = translation.Principal.Extractor.ExtractFrom(knot);
 
@@ -466,7 +467,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES); ;
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance); ;
             var translation = translator[typeof(Armory)];
             var data = translation.Principal.Extractor.ExtractFrom(armory);
 
@@ -515,7 +516,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(MillionaireQuestion)];
             var data = translation.Principal.Extractor.ExtractFrom(question);
 
@@ -558,7 +559,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(GroceryGame)];
             var data = translation.Principal.Extractor.ExtractFrom(game);
 
@@ -593,7 +594,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(PapalConclave)];
             var data = translation.Principal.Extractor.ExtractFrom(conclave);
 
@@ -622,7 +623,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Cytonic)];
             var data = translation.Principal.Extractor.ExtractFrom(cytonic);
 
@@ -650,7 +651,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(SoapOpera)];
             var data = translation.Principal.Extractor.ExtractFrom(soapOpera);
 
@@ -677,7 +678,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Library)];
             var data = translation.Principal.Extractor.ExtractFrom(library);
 
@@ -713,7 +714,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(CurlingMatch)];
             var data = translation.Principal.Extractor.ExtractFrom(match);
 
@@ -740,7 +741,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Pretzel)];
             var data = translation.Relations[0].Extractor.ExtractFrom(pretzel);
 
@@ -775,7 +776,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Teppanyaki)];
             var setData = translation.Relations[0].Extractor.ExtractFrom(teppanyaki);
             var listData = translation.Relations[1].Extractor.ExtractFrom(teppanyaki);
@@ -814,7 +815,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(SpellingBee)];
             var data = translation.Relations[0].Extractor.ExtractFrom(spellingBee);
 
@@ -846,7 +847,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(ImprovTroupe)];
             var data = translation.Relations[0].Extractor.ExtractFrom(troupe);
 
@@ -877,7 +878,7 @@ namespace UT.Kvasir.Translation {
             (tip.For as IRelation).Canonicalize();
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(NedsDeclassifiedTip)];
             var data = translation.Relations[0].Extractor.ExtractFrom(tip);
 
@@ -903,7 +904,7 @@ namespace UT.Kvasir.Translation {
             territory.Travellers[1] = "Osa";
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(PendragonTerritory)];
             var data = translation.Relations[0].Extractor.ExtractFrom(territory);
 
@@ -935,7 +936,7 @@ namespace UT.Kvasir.Translation {
             caucus.DelegatesEarned.Remove("uncommitted");
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(IowaCaucus)];
             var data = translation.Relations[0].Extractor.ExtractFrom(caucus);
 
@@ -957,7 +958,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Existentialist)];
             var data = translation.Relations[0].Extractor.ExtractFrom(existentialist);
 
@@ -983,7 +984,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(OlympianBoon)];
             var data = translation.Relations[0].Extractor.ExtractFrom(boon);
 
@@ -1032,7 +1033,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Impeachment)];
             var data = translation.Relations[0].Extractor.ExtractFrom(impeachment);
 
@@ -1057,7 +1058,7 @@ namespace UT.Kvasir.Translation {
             god.Family[god] = MaoriGod.Relation.Self;
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(MaoriGod)];
             var data = translation.Relations[0].Extractor.ExtractFrom(god);
 
@@ -1095,7 +1096,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(DataCenter)];
             var data0 = translation.Relations[0].Extractor.ExtractFrom(center);
             var data1 = translation.Relations[1].Extractor.ExtractFrom(center);
@@ -1126,7 +1127,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Chameleon)];
             var data = translation.Relations[0].Extractor.ExtractFrom(chameleon);
 
@@ -1159,7 +1160,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Horoscope)];
             var data = translation.Relations[0].Extractor.ExtractFrom(horoscope);
 
@@ -1183,7 +1184,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Orogene)];
             var data = translation.Principal.Extractor.ExtractFrom(orogene);
 
@@ -1209,7 +1210,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(DWTSCouple)];
             var data = translation.Principal.Extractor.ExtractFrom(couple);
 
@@ -1234,7 +1235,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Arcanum)];
             var data = translation.Principal.Extractor.ExtractFrom(arcanum);
 
@@ -1259,7 +1260,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(CombatantCommand)];
             var data = translation.Principal.Extractor.ExtractFrom(command);
 
@@ -1285,7 +1286,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(SapaInca)];
             var data = translation.Principal.Extractor.ExtractFrom(sapa);
 
@@ -1316,7 +1317,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Dragonlord)];
             var data = translation.Relations[0].Extractor.ExtractFrom(dragonlord);
 
@@ -1347,7 +1348,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Showstopper)];
             var data = translation.Relations[0].Extractor.ExtractFrom(showstopper);
 
@@ -1379,7 +1380,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(AntarcticExpedition)];
             var data = translation.Relations[0].Extractor.ExtractFrom(expedition);
 
@@ -1434,7 +1435,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Iditarod)];
             var data = translation.Relations[0].Extractor.ExtractFrom(iditarod);
 
@@ -1496,7 +1497,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Festigal)];
             var data = translation.Relations[0].Extractor.ExtractFrom(festigal);
 
@@ -1521,7 +1522,7 @@ namespace UT.Kvasir.Translation {
             var mural = new Mural(Guid.NewGuid());
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Mural), Translator.AsLocalzation];
             var data = translation.Principal.Extractor.ExtractFrom(mural);
 
@@ -1539,7 +1540,7 @@ namespace UT.Kvasir.Translation {
             carpeting[15516026] = "Polyestered Carpet";
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Carpeting), Translator.AsLocalzation];
             var data = translation.Principal.Extractor.ExtractFrom(carpeting);
 
@@ -1560,7 +1561,7 @@ namespace UT.Kvasir.Translation {
             (taste.Relation as IRelation).Canonicalize();
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Taste), Translator.AsLocalzation];
             var data = translation.Principal.Extractor.ExtractFrom(taste);
 
@@ -1583,7 +1584,7 @@ namespace UT.Kvasir.Translation {
             trait.Delocalize(Language.Japanese);
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(HumanTrait), Translator.AsLocalzation];
             var data = translation.Principal.Extractor.ExtractFrom(trait);
 
@@ -1605,7 +1606,7 @@ namespace UT.Kvasir.Translation {
             position["HI"] = new Position("CEO", 148241M);
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(CSuitePosition), Translator.AsLocalzation];
             var data = translation.Principal.Extractor.ExtractFrom(position);
 
@@ -1631,7 +1632,7 @@ namespace UT.Kvasir.Translation {
             schedule[DayOfWeek.Wednesday] = cookie;
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(CookieSchedule), Translator.AsLocalzation];
             var data = translation.Principal.Extractor.ExtractFrom(schedule);
 
@@ -1647,7 +1648,7 @@ namespace UT.Kvasir.Translation {
             var era = TaylorSwiftEra.Folklore;
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(TaylorSwiftEra), Translator.AsLocalzation];
             var data = translation.Principal.Extractor.ExtractFrom(era);
 

--- a/test/UnitTests/Kvasir/Translation/FieldClusivity.cs
+++ b/test/UnitTests/Kvasir/Translation/FieldClusivity.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -10,7 +11,7 @@ namespace UT.Kvasir.Translation {
     public class FieldClusivityTests {
         [TestMethod] public void EntityHasZeroFields_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Nothing);
 
             // Act
@@ -25,7 +26,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityHasOneField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Integer);
 
             // Act
@@ -40,7 +41,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateHasZeroFields_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TotemPole);
 
             // Act
@@ -55,7 +56,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonPublicPropertiesAreExcluded() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Animal);
 
             // Act
@@ -70,7 +71,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PublicWriteOnlyPropertiesAreExcluded() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ScrabbleTile);
 
             // Act
@@ -85,7 +86,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PublicPropertiesWithNonPublicAccessorsAreExcluded() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChemicalElement);
 
             // Act
@@ -100,7 +101,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PublicStaticPropertiesAreExcluded() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Circle);
 
             // Act
@@ -116,7 +117,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PublicIndexerPropertiesAreExcluded() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BattingOrder);
 
             // Act
@@ -131,7 +132,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CodeOnly_PublicReadableInstanceProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(QuadraticEquation);
 
             // Act
@@ -147,7 +148,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CodeOnly_RelationProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LazarusPit);
 
             // Act
@@ -159,7 +160,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void FirstDefinedVirtualPropertyIsIncluded() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GreekGod);
 
             // Act
@@ -175,7 +176,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void InterfacePropertiesAreExcluded() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Movie);
 
             // Act
@@ -192,7 +193,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void InheritedClassPropertiesAreExcluded() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Holiday);
 
             // Act
@@ -207,7 +208,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void VirtualPropertyOverrideIsExcluded() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(POBox);
 
             // Act
@@ -222,7 +223,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void HidingPropertiesAreIncluded() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FighterJet);
 
             // Act
@@ -239,7 +240,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_PublicIndexer_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Language);
 
             // Act
@@ -254,7 +255,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_PublicWriteOnlyProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HebrewPrayer);
 
             // Act
@@ -269,7 +270,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_PublicStaticProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChessPiece);
 
             // Act
@@ -286,7 +287,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_NonPublicProperties() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Song);
 
             // Act
@@ -306,7 +307,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_PublicPropertiesWithNonPublicAccessors() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Country);
 
             // Act
@@ -325,7 +326,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_InterfaceProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Book);
 
             // Act
@@ -340,7 +341,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_VirtualPropertyOverride() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Drum);
 
             // Act
@@ -356,7 +357,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_ExplicitInterfaceImplementationScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BasicDiceRoll);
 
             // Act
@@ -375,7 +376,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_ExplicitInterfaceImplementationAggregate() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Wrestler);
 
             // Act
@@ -395,7 +396,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CodeOnly_InterfaceProperty_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(IPAddress);
 
             // Act
@@ -410,7 +411,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CodeOnly_VirtualPropertyOverride_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Submarine);
 
             // Act
@@ -429,7 +430,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CodeOnly_PublicWriteOnlyProperty_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CourtCase);
 
             // Act
@@ -446,7 +447,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CodeOnly_NonPublicProperties_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lake);
 
             // Act
@@ -462,7 +463,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CodeOnly_PublicPropertiesWithNonPublicAccessors_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mountain);
 
             // Act
@@ -479,7 +480,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CodeOnly_PublicStaticProperty_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tossup);
 
             // Act
@@ -497,7 +498,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CodeOnly_PublicIndexer_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(University);
 
             // Act
@@ -515,7 +516,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_PublicReadableInstanceProperty_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Haiku);
 
             // Act
@@ -533,7 +534,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_NonPublicPreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SortingAlgorithm);
 
             // Act
@@ -549,7 +550,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IncludeInModel_WriteOnlyPreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AnimalPhylum);
 
             // Act
@@ -565,7 +566,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CombinedAnnotation_CodeOnlyAndIncludeInModel_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CreditCard);
 
             // Act
@@ -581,7 +582,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithPublicInstanceDerivedProperties_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Motto);
 
             // Act
@@ -596,7 +597,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithDerivedPropeties_CodeOnly() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Vase);
 
             // Act
@@ -613,7 +614,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithNonPublicStaticDerivedProperties() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Biome);
 
             // Act
@@ -630,7 +631,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithNonPublicDerivedProperties_IncludeInModel_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tropism);
 
             // Act
@@ -645,7 +646,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithStaticDerivedProperties_IncludedInModel_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Dermatitis);
 
             // Act
@@ -660,7 +661,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithHidingKeyProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TierList);
 
             // Act
@@ -675,7 +676,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithIntermediateInheritedProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PowerOutage.SuperDuperLocalizedText);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/FieldNaming.cs
+++ b/test/UnitTests/Kvasir/Translation/FieldNaming.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -11,7 +12,7 @@ namespace UT.Kvasir.Translation {
     public class FieldNamingTests {
         [TestMethod] public void NonPascalCasedNames() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Surah);
 
             // Act
@@ -28,7 +29,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ScalarFieldNameChangedToBrandNewIdentifier() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(River);
 
             // Act
@@ -46,7 +47,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateFieldNameChanged() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BorderCrossing);
 
             // Act
@@ -67,7 +68,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateNestedFieldNameChangedToBrandNewIdentifier() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ziggurat);
 
             // Act
@@ -86,7 +87,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ChangeNameOfNestedAggregate() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DogShow);
 
             // Act
@@ -106,7 +107,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComplexNameChangesWithAggregates() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cliff);
 
             // Act
@@ -134,7 +135,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferenceFieldNameChanged() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ballerina);
 
             // Act
@@ -153,7 +154,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferenceNestedFieldNameChangedToBrandNewIdentifier() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DMZ);
 
             // Act
@@ -181,7 +182,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ChangeNameOfNestedReference() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Carnival);
 
             // Act
@@ -208,7 +209,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ChangeRelatonFieldName_AffectsRelationTable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(KidneyStone);
 
             // Act
@@ -230,7 +231,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedFieldNameChangedToBrandNewIdentifier() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SwissCanton);
 
             // Act
@@ -274,7 +275,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ChangeNameOfNestedRelation_AffectsRelationTable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Gulag);
 
             // Act
@@ -296,7 +297,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void FieldsSwapNames() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Episode);
 
             // Act
@@ -314,7 +315,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NameConflictWithExplicitInterfaceImplementation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GroundMeat);
 
             // Act
@@ -330,7 +331,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ChangeToNameOfExistingField_PrincipalTable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ComputerLock);
 
             // Act
@@ -346,7 +347,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void TwoFieldsNamesChangedToSameName_PrincipalTable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ticket2RideRoute);
 
             // Act
@@ -361,7 +362,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ChangeToNameOfExistingField_RelationTable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cookbook);
 
             // Act
@@ -377,7 +378,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void TwoFieldsNamesChangedToSameName_RelationTable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HostageSituation);
 
             // Act
@@ -392,7 +393,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleIdenticalNameChangesOnScalarProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Antiparticle);
 
             // Act
@@ -411,7 +412,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleDifferentNameChangesOnScalarProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BankAccount);
 
             // Act
@@ -427,7 +428,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RedundantAndImpactfulNameChangesOnScalarProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Billionaire);
 
             // Act
@@ -443,7 +444,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleIdenticalNameChangesOnAggregateProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Militia);
 
             // Act
@@ -466,7 +467,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleDifferentNameChangesOnAggregateProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Walkabout);
 
             // Act
@@ -482,7 +483,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RedundantAndImpactfulNameChangesOnAggregateProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Treadmill);
 
             // Act
@@ -498,7 +499,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleIdenticalNameChangesOnReferenceProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MongolKhan);
 
             // Act
@@ -517,7 +518,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleDifferentNameChangesOnReferenceProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(QuizBowlProtest);
 
             // Act
@@ -534,7 +535,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RedundantAndImpactfulNameChangesOnReferenceProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Grassland);
 
             // Act
@@ -550,7 +551,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleIdenticalNameChangesOnRelationProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Necromancer);
 
             // Act
@@ -576,7 +577,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleDifferentNameChangesOnRelationProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Genocide);
 
             // Act
@@ -592,7 +593,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RedundantAndImpactfulNameChangesOnRelationProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PrideParade);
 
             // Act
@@ -608,7 +609,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ChangeNameOfLocalizationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Shiva);
 
             // Act
@@ -633,7 +634,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ChangeNameOfNestedLocalizationField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BollywoodMovie);
 
             // Act
@@ -656,7 +657,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleIdenticalNameChangesOnLocalizationProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FlightAttendant);
 
             // Act
@@ -686,7 +687,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleDifferentNameChangesOnLocalizationProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bullfight);
 
             // Act
@@ -702,7 +703,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RedundantAndImpactfulNameChangesOnLocalizationProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Baptism);
 
             // Act
@@ -718,7 +719,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NameChangeOnAggregateNestedFieldOverridesOriginalNameChange() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HashMap);
 
             // Act
@@ -742,7 +743,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NameChangeOnRelationNestedFieldOverridesOriginalNameChange() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ArchaeologicalSite);
 
             // Act
@@ -767,7 +768,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NameChangeOnNestedAggregateOverridesOriginalNameChange() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sarcophagus);
 
             // Act
@@ -788,7 +789,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NameChangeOnNestedReferenceOverridesOriginalNameChange() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MariachiBand);
 
             // Act
@@ -809,7 +810,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NameChangeOnNestedRelationOverridesOriginalNameChange() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PolarVortex);
 
             // Act
@@ -843,7 +844,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NameChangeOnNestedLocalizationOverridesOriginalNameChange() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MovingCompany);
 
             // Act
@@ -863,7 +864,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleNameChangesOnNestedProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Helicopter);
 
             // Act
@@ -880,7 +881,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void FieldNameIsUnchangedByAnnotation_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Opera);
 
             // Act
@@ -897,7 +898,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NewNameIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Longbow);
 
             // Act
@@ -913,7 +914,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NewNameIsEmptyString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Volcano);
 
             // Act
@@ -929,7 +930,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AppliedToPreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Murder);
 
             // Act
@@ -945,7 +946,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MedalOfHonor);
 
             // Act
@@ -961,7 +962,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Legume);
 
             // Act
@@ -977,7 +978,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Madonna);
 
             // Act
@@ -993,7 +994,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CapitolBuilding);
 
             // Act
@@ -1009,7 +1010,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Rabbi);
 
             // Act
@@ -1025,7 +1026,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathOnReferenceRefersToPartiallyExposedAggregate() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CarAccident);
 
             // Act
@@ -1042,7 +1043,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ProcessRegister);
 
             // Act
@@ -1058,7 +1059,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Yeshiva);
 
             // Act
@@ -1074,7 +1075,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Slushy);
 
             // Act
@@ -1090,7 +1091,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Spoonerism);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/MixedConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/MixedConstraints.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
@@ -12,7 +13,7 @@ namespace UT.Kvasir.Translation {
     public class MixedConstraintTests {
         [TestMethod] public void IsPositiveIsNonZero_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Peninsula);
 
             // Act
@@ -26,7 +27,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegativeIsNonZero_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HTTPError);
 
             // Act
@@ -40,7 +41,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositiveIsNegative_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Directory);
 
             // Act
@@ -56,7 +57,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void GreaterThanConstraints() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ACT);
 
             // Act
@@ -73,7 +74,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LessThanConstraints() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Concert);
 
             // Act
@@ -90,7 +91,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComparisonLowerLessThanComparisonUpper() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SlaveRevolt);
 
             // Act
@@ -111,7 +112,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComparisonInclusiveLowerEqualsComparisonInclusiveUpper() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Prescription);
 
             // Act
@@ -126,7 +127,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComparisonInclusiveLowerEqualsComparisonExclusiveUpper_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Genie);
 
             // Act
@@ -142,7 +143,7 @@ namespace UT.Kvasir.Translation {
         
         [TestMethod] public void ComparisonExclusiveLowerEqualsComparisonInclusiveUpper_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ComicCon);
 
             // Act
@@ -158,7 +159,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComparisonExclusiveLowerEqualsComparisonExclusiveUpper_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CabinetDepartment);
 
             // Act
@@ -174,7 +175,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ComparisonLowerGreaterThanComparisonUpper_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Locale);
 
             // Act
@@ -190,7 +191,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotValueOutsideComparisonRange_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Calendar);
 
             // Act
@@ -204,7 +205,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeastIsNonEmpty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StepPyramid);
 
             // Act
@@ -219,7 +220,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMostIsNonEmpty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(UIButton);
 
             // Act
@@ -234,7 +235,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetweenIsNonEmpty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cave);
 
             // Act
@@ -251,7 +252,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeastBoundNoLargerThanLengthIsAtMostBound() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Vulgarity);
 
             // Act
@@ -267,7 +268,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeastBoundGreaterThanLengthIsAtMostBound_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Generation);
 
             // Act
@@ -283,7 +284,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeastLengthIsBetween() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WitchHunt);
 
             // Act
@@ -303,7 +304,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeastBoundGreaterThanLengthIsBetweenUpperBound_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Integral);
 
             // Act
@@ -319,7 +320,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMostLengthIsBetween() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Isthmus);
 
             // Act
@@ -339,7 +340,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMostBoundLessThanLengthIsBetweenLowerBound_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NuGetPackage);
 
             // Act
@@ -355,7 +356,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotValueHasInvalidLength_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LicensePlate);
 
             // Act
@@ -370,7 +371,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOfIsNotOneOfDisjoint() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SkiSlope);
 
             // Act
@@ -386,7 +387,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOfIsNotOneOfOverlapping() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AmusementPark);
 
             // Act
@@ -402,7 +403,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOfIsNotOneOfEquivalent_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MarkUpSymbol);
 
             // Act
@@ -417,7 +418,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOfWithComparisons() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TicTacToeGame);
 
             // Act
@@ -448,7 +449,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOfWithLengths() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Printer);
 
             // Act
@@ -465,7 +466,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOfAllFailComparisonChecks_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Aqueduct);
 
             // Act
@@ -480,7 +481,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOfAllFailLengthChecks_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SurvivorSeason);
 
             // Act
@@ -495,7 +496,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsOneOfAllFailEitherComparisonOrLengthChecks_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NorseGod);
 
             // Act
@@ -510,7 +511,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOfWithComparisons() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PostageStamp);
 
             // Act
@@ -536,7 +537,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOfWithLengths() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Obelisk);
 
             // Act
@@ -553,7 +554,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNotOneOfDisallowsSingleComparisonValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Beach);
 
             // Act
@@ -568,7 +569,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConversionWithSignedness() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Soup);
 
             // Act
@@ -590,7 +591,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConversionWithComparisons() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CavePainting);
 
             // Act
@@ -606,7 +607,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConversionWithDiscreteness() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Triangle);
 
             // Act
@@ -622,7 +623,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NumericConversionWithIsOneOfNoOverlap_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DSM);
 
             // Act
@@ -637,7 +638,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConversionWithComparisons() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Casino);
 
             // Act
@@ -653,7 +654,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConversionWithLengths() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FacebookPost);
 
             // Act
@@ -669,7 +670,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConversionWithDiscreteness() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ZodiacSign);
 
             // Act
@@ -685,7 +686,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AsStringConversionWithIsOneOfNoOverlap_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ParkingTicket);
 
             // Act
@@ -700,7 +701,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AlteredComparisonsOnNestedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TribeOfIsrael);
 
             // Act
@@ -719,7 +720,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AlteredSignednessOnNestedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SecretPolice);
 
             // Act
@@ -742,7 +743,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AlteredLengthsOnNestedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SearchEngine);
 
             // Act
@@ -758,7 +759,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AlteredDiscretenessOnNestedField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BeninBronze);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/Nullability.cs
+++ b/test/UnitTests/Kvasir/Translation/Nullability.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -11,7 +12,7 @@ namespace UT.Kvasir.Translation {
     public class NullabilityTests {
         [TestMethod] public void NonNullableScalarsMarkedNullable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Timestamp);
 
             // Act
@@ -31,7 +32,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableAggregateMarkedNullable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bankruptcy);
 
             // Act
@@ -51,7 +52,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableReferenceMarkedNullable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Jukebox);
 
             // Act
@@ -75,7 +76,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableScalarsMarkedNonNullable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bone);
 
             // Act
@@ -92,7 +93,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableAggregateMarkedNonNullable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Orchestra);
 
             // Act
@@ -120,7 +121,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableReferenceMarkedNonNullable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bodhisattva);
 
             // Act
@@ -147,7 +148,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableScalarsMarkedAsNullable_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CivMilitaryUnit);
 
             // Act
@@ -165,7 +166,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableScalarsMarkedAsNonNullable_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Patent);
 
             // Act
@@ -182,7 +183,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CombinedAnnotation_NullableAndNonNullable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RetailProduct);
 
             // Act
@@ -198,7 +199,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NativelyNullableAggregateContainsOnlyNullableFields_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Waffle);
 
             // Act
@@ -213,7 +214,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AnnotatedNullableAggregateContainsOnlyNullableFields_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(iPhone);
 
             // Act
@@ -229,7 +230,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Forecast);
 
             // Act
@@ -243,7 +244,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationWithNullableElements() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PostOffice);
 
             // Act
@@ -285,7 +286,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationListWithNullableElement_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hibakusha);
 
             // Act
@@ -299,7 +300,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationSetWithNullableElement_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Earthworks);
 
             // Act
@@ -313,7 +314,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationMapWithNullableKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Naiad);
 
             // Act
@@ -327,7 +328,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationElementNullableAggregateContainsOnlyNullableFields_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Parabola);
 
             // Act
@@ -343,7 +344,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationMarkedNonNullable_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Squintern);
 
             // Act
@@ -367,7 +368,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationMarkedNullable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Axiom);
 
             // Act
@@ -382,7 +383,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PreDefinedInstanceMarkedNonNullable_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Rugrat);
 
             // Act
@@ -399,7 +400,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PreDefinedInstanceMarkedNullable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cutlery);
 
             // Act
@@ -415,7 +416,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableLocalization() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Madrigal);
 
             // Act
@@ -433,7 +434,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithNullableKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Alignment);
 
             // Act
@@ -447,7 +448,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithNullableLocale_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Halide);
 
             // Act
@@ -461,7 +462,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithNullableValue() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Rhyme);
 
             // Act
@@ -478,7 +479,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationMarkedNonNullable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CivVIPolicy);
 
             // Act
@@ -510,7 +511,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationMarkedNullable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Superintendent);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/PreDefinedEntities.cs
+++ b/test/UnitTests/Kvasir/Translation/PreDefinedEntities.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -11,7 +12,7 @@ namespace UT.Kvasir.Translation {
     public class PreDefinedEntityTests {
         [TestMethod] public void ZeroInstances_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StainedGlassWindow);
 
             // Act
@@ -26,7 +27,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void OneInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Gulf);
 
             // Act
@@ -41,7 +42,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void TwoPlusInstances() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Disciple);
 
             // Act
@@ -75,7 +76,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Localization() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FishFin);
 
             // Act
@@ -102,7 +103,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationProperties() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BrainLobe);
 
             // Act
@@ -129,7 +130,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PubliclyWriteableFieldProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Olive);
 
             // Act
@@ -144,7 +145,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonPubliclyWriteableFieldProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cloud);
 
             // Act
@@ -159,7 +160,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PubliclyWriteableInstanceProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LayerOfSkin);
 
             // Act
@@ -174,7 +175,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonPubliclyWriteableInstanceProperty() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PunctuationMark);
 
             // Act
@@ -205,7 +206,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PublicConstructor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FederalReserveDistrict);
 
             // Act
@@ -220,7 +221,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferenceToPreDefinedEntity() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RavnicaGuild);
 
             // Act
@@ -262,7 +263,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateNestedReferenceToPreDefinedEntity() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MarxBrother);
 
             // Act
@@ -295,7 +296,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationToPreDefinedEntity() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ResidentEvil);
 
             // Act
@@ -321,7 +322,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateNestedRelationToPreDefinedEntity() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CitrusFruit);
 
             // Act
@@ -348,7 +349,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationToPreDefinedEntity() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DeadlySin);
 
             // Act
@@ -377,7 +378,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateLocalizationToPreDefinedEntity() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LunarPhase);
 
             // Act
@@ -408,7 +409,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedLocalizationToPreDefinedEntity() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cyclade);
 
             // Act
@@ -430,7 +431,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferenceToNonPreDefinedEntity_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CapnCrunch);
 
             // Act
@@ -445,7 +446,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateNestedReferenceToNonPreDefinedEntity_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StageOfGrief);
 
             // Act
@@ -460,7 +461,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateNestedReferenceToNonPreDefinedEntity_PostMemoization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Stooge);
 
             // Act
@@ -476,7 +477,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationToNonPreDefinedEntity_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CivVIYield);
 
             // Act
@@ -491,7 +492,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateNestedRelationToNonPreDefinedEntity_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StateOfMatter);
 
             // Act
@@ -506,7 +507,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateNestedRelationToNonPreDefinedEntity_PostMemoization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Primate);
 
             // Act
@@ -522,7 +523,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationToNonPreDefinedEntity_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(OpiumWar);
 
             // Act
@@ -537,7 +538,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregatedNestedLocalizationToNonPreDefinedEntity_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BronteSister);
 
             // Act
@@ -552,7 +553,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateNestedLocalizationToNonPreDefinedEntity_PostMemoization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CapriSun);
 
             // Act
@@ -568,7 +569,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedLocalizationToNonPreDefinedEntity_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Muse);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/PrimaryKeys.cs
+++ b/test/UnitTests/Kvasir/Translation/PrimaryKeys.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -11,7 +12,7 @@ namespace UT.Kvasir.Translation {
     public class PrimaryKeyIdentificationTests {
         [TestMethod] public void SingleScalarMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(XKCDComic);
 
             // Act
@@ -24,7 +25,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleScalarsMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Month);
 
             // Act
@@ -40,7 +41,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SpaceShuttle);
 
             // Act
@@ -58,7 +59,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateNestedScalarMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tepui);
 
             // Act
@@ -74,7 +75,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedAggregateMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChoppedBasket);
 
             // Act
@@ -98,7 +99,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferenceMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Etiology);
 
             // Act
@@ -114,7 +115,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferenceNestedScalarMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PoirotMystery);
 
             // Act
@@ -127,7 +128,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedReferenceMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Prophecy);
 
             // Act
@@ -145,7 +146,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedScalarMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GrandPrix);
 
             // Act
@@ -162,7 +163,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedRelationMarkedPrimaryKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Psalm);
 
             // Act
@@ -179,7 +180,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Headache);
 
             // Act
@@ -192,7 +193,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedLocalizationMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Abbey);
 
             // Act
@@ -208,7 +209,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AllScalarsMarkedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Character);
 
             // Act
@@ -225,7 +226,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableScalarFieldNativelyNamedID() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Actor);
 
             // Act
@@ -238,7 +239,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableScalarFieldRenamedToID() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PokerHand);
 
             // Act
@@ -251,7 +252,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableScalarFieldNativelyNamedEntityID() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(IntegerSequence);
 
             // Act
@@ -264,7 +265,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableScalarFieldRenamedToEntityID() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Stadium);
 
             // Act
@@ -277,7 +278,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableScalarFieldsNamedTableIDAndEntityID() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Function);
 
             // Act
@@ -290,7 +291,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SingleCandidateKeyWithSingleNonNullableField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Star);
 
             // Act
@@ -304,7 +305,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SingleCandidateKeyWithMultipleNonNullableFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Expiration);
 
             // Act
@@ -320,7 +321,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleCandidateKeysOnlyOneAllNonNullable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Vitamin);
 
             // Act
@@ -345,7 +346,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleCandidateKeysOneSubsetOfAllOthers() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Escalator);
 
             // Act
@@ -359,7 +360,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SingleCandidateKeyDeducedForOtherReasons() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Repository);
 
             // Act
@@ -373,7 +374,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SingleNativelyNonNullableField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Earthquake);
 
             // Act
@@ -386,7 +387,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SingleAnnotatedNonNullableField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GeologicEpoch);
 
             // Act
@@ -399,7 +400,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AllNonNullableFieldsDefaultDeduction() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HotAirBalloon);
 
             // Act
@@ -418,7 +419,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultPrimaryKeyForListSetRelations() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Brothel);
 
             // Act
@@ -440,7 +441,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultPrimaryKeyForMapRelation() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cult);
 
             // Act
@@ -456,7 +457,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultPrimaryKeyForOrderedListRelation() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PianoSonata);
 
             // Act
@@ -473,7 +474,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationWithSingleViableCandidateKeyIncludingAnchor() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChromeExtension);
 
             // Act
@@ -490,7 +491,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationWithSingleViableCandidateKeyExcludingAnchor() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Zipline);
 
             // Act
@@ -506,7 +507,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void DefaultPrimaryKeyForLocalization() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pronoun);
 
             // Act
@@ -522,7 +523,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableFieldNamedIDSkipped() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Rollercoaster);
 
             // Act
@@ -535,7 +536,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableFieldNamedEntityIDSkipped() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Doctor);
 
             // Act
@@ -552,7 +553,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CandidateKeysWithNullableFieldsSkipped() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Polyhedron);
 
             // Act
@@ -565,7 +566,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ScalarMarkedPrimaryKeyMultipleTimesDirectly_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Airport);
 
             // Act
@@ -578,7 +579,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ScalarMarkedPrimaryKeyMultipleTimesIndirectly_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CompressionFormat);
 
             // Act
@@ -596,7 +597,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableScalarMarkedPrimaryKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NorseWorld);
 
             // Act
@@ -612,7 +613,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableAggregateMarkedPrimaryKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MedievalCastle);
 
             // Act
@@ -629,7 +630,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateWithNullablePropertyMarkedPrimaryKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Wizard);
 
             // Act
@@ -646,7 +647,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableReferenceMarkedPrimaryKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Avocado);
 
             // Act
@@ -663,7 +664,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyInAggregateMarkedPrimaryKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LunarCrater);
 
             // Act
@@ -679,7 +680,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CannotDeducePrincipalPrimaryKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FederalLaw);
 
             // Act
@@ -694,7 +695,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CannotDeduceRelationPrimaryKeyWithoutCandidateKeys_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lagerstatte);
 
             // Act
@@ -709,7 +710,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CannotDeduceRelationPrimaryKeyWithCandidateKeys_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Blockbuster);
 
             // Act
@@ -724,7 +725,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PreDefinedInstanceMarkedPrimaryKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FunctionalGroup);
 
             // Act
@@ -740,7 +741,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Alphabet);
 
             // Act
@@ -756,7 +757,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Highway);
 
             // Act
@@ -772,7 +773,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ConfidenceInterval);
 
             // Act
@@ -788,7 +789,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PhoneBooth);
 
             // Act
@@ -804,7 +805,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ScientificExperiment);
 
             // Act
@@ -820,7 +821,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PathOnReferenceRefersToPartiallyExposedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cryochamber);
 
             // Act
@@ -836,7 +837,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Missile);
 
             // Act
@@ -852,7 +853,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TreasureMap);
 
             // Act
@@ -868,7 +869,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hologram);
 
             // Act
@@ -884,7 +885,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AesopsFable);
 
             // Act
@@ -900,7 +901,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CreditReport);
 
             // Act
@@ -919,7 +920,7 @@ namespace UT.Kvasir.Translation {
     public class PrimaryKeyNamingTests {
         [TestMethod] public void NamedPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HebrewLetter);
 
             // Act
@@ -932,7 +933,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NamedPriaryKeyOfLocalizationTable() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Dial);
 
             // Act
@@ -945,7 +946,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NamedPrimaryKeyForUnnamedDeducedCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DatabaseField);
 
             // Act
@@ -959,7 +960,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NamedPrimaryKeyMatchesNamedDeducedCandidateKey_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TimeZone);
 
             // Act
@@ -973,7 +974,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NamedPrimaryKeyOverridesNamedDeducedCandidateKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(JigsawPuzzle);
 
             // Act
@@ -986,7 +987,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NamedPrimaryKeySameAsNonDeducedCandidateKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Currency);
 
             // Act
@@ -1002,7 +1003,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NamedPrimaryKeyIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HinduGod);
 
             // Act
@@ -1018,7 +1019,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NamedPrimaryKeyIsEmptyString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bay);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
+++ b/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
@@ -2,6 +2,7 @@
 using FluentAssertions.Execution;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections;
@@ -14,7 +15,7 @@ namespace UT.Kvasir.Translation {
     public class PropertyTypeTests {
         [TestMethod] public void NonNullableScalars() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Smorgasbord);
 
             // Act
@@ -45,7 +46,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableScalars() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Plethora);
 
             // Act
@@ -77,7 +78,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsDelegate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hurricane);
 
             // Act
@@ -92,7 +93,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsDynamic_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MonopolyProperty);
 
             // Act
@@ -107,7 +108,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsObject_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(URL);
 
             // Act
@@ -122,7 +123,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsSystemEnum_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Enumeration);
 
             // Act
@@ -137,7 +138,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsSystemValueType_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(YouTubeVideo);
 
             // Act
@@ -152,7 +153,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsNonCollectionClassFromStandardLibrary_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Coin);
 
             // Act
@@ -170,7 +171,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsCollectionFromStandardLibrary_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Eigenvector);
 
             // Act
@@ -188,7 +189,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsStructFromStandardLibrary_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Emoji);
 
             // Act
@@ -206,7 +207,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsClassFromNugetPackage_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(UUID);
 
             // Act
@@ -224,7 +225,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsInterface_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Painting);
 
             // Act
@@ -239,7 +240,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsClosedGenericClass_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SlackChannel);
 
             // Act
@@ -254,7 +255,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsAbstractClass_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BotanicalGarden);
 
             // Act
@@ -269,7 +270,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsArray_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MeritBadge);
 
             // Act
@@ -284,7 +285,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsPointer_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Assassination);
 
             // Act
@@ -299,7 +300,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsByRef_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Spider);
 
             // Act
@@ -314,7 +315,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CodeOnly_PropertyOfUnsupportedType() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DNDCharacter);
 
             // Act
@@ -335,7 +336,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void Enumerations() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DNDWeapon);
 
             // Act
@@ -384,7 +385,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableAggregates() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChineseDynasty);
 
             // Act
@@ -409,7 +410,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableAggregates() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BarbecueSauce);
 
             // Act
@@ -437,7 +438,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NestedAggregates() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DNDMonster);
 
             // Act
@@ -481,7 +482,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableReferences() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Scorpion);
 
             // Act
@@ -506,7 +507,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NullableReferences() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ferry);
 
             // Act
@@ -544,7 +545,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferencesNestedWithinAggregates() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WeekendUpdate);
 
             // Act
@@ -601,7 +602,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferencesNestedWithinReferencesNonPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DannyPhantomGhost);
 
             // Act
@@ -630,7 +631,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReferencesNestedWithinReferencesPrimaryKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Arson);
 
             // Act
@@ -659,7 +660,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableRelationsOfNonNullableElements() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CMakeTarget);
 
             // Act
@@ -720,7 +721,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReadOnlyRelations() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CivVIDistrict);
 
             // Act
@@ -792,7 +793,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationsNestedWithinAggregates() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Gelateria);
 
             // Act
@@ -814,7 +815,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedWithinRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BlackHole);
 
             // Act
@@ -829,7 +830,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationAsLocaliationLocale_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(OvarianCyst);
 
             // Act
@@ -844,7 +845,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationAsLocalizationValue_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Fondue);
 
             // Act
@@ -859,7 +860,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedWithinRelationNestedWithinAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(IntelligenceAgency);
 
             // Act
@@ -874,7 +875,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedWithinLocalizationNestedWithinAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AmicusBrief);
 
             // Act
@@ -889,7 +890,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedWithinAggregateNestedWithinRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Poll);
 
             // Act
@@ -904,7 +905,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedWithinAggregateNestedWithinLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PreprocessorMacro);
 
             // Act
@@ -919,7 +920,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedWithinAggregateNestedWithinRelation_PostMemoization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Quinceanera);
 
             // Act
@@ -934,7 +935,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationNestedWithinAggregateNestedWithinLocalization_PostMemoization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Parable);
 
             // Act
@@ -949,7 +950,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsListSetOfKeyValuePair_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Caricature);
 
             // Act
@@ -964,7 +965,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsIRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Perfume);
 
             // Act
@@ -979,7 +980,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PropertyTypeIsWriteableRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BugZapper);
 
             // Act
@@ -994,7 +995,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void AggregateConsistingOnlyOfRelations() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Loch);
 
             // Act
@@ -1035,7 +1036,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NonNullableLocalizationsOfNonNullableElements() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Retrovirus);
 
             // Act
@@ -1059,7 +1060,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReadOnlyLocalizations() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Debate);
 
             // Act
@@ -1081,7 +1082,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationsNestedWithinAggregates() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bodybuilder);
 
             // Act
@@ -1102,7 +1103,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationsNestedWithinRelations() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AdventCalendar);
 
             // Act
@@ -1125,7 +1126,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationAsLocalizationLocale() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Execution);
 
             // Act
@@ -1140,7 +1141,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationAsLocalizationValue() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SlimeMold);
 
             // Act
@@ -1155,7 +1156,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationsNestedWithinRelationNestedWithinAggregate() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Chiropractor);
 
             // Act
@@ -1185,7 +1186,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationNestedWithinLocalizationNestedWithinAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Coffee);
 
             // Act
@@ -1200,7 +1201,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationsNestedWithinAggregateNestedWithinRelation() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Triumvirate);
 
             // Act
@@ -1223,7 +1224,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationNestedWithinAggregateNestedWithinLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Laundromat);
 
             // Act
@@ -1238,7 +1239,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationNestedWithinAggregateNestedWithinLocalization_PostMemoization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sommelier);
 
             // Act
@@ -1253,7 +1254,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithAggregateKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ParoleHearing);
 
             // Act
@@ -1268,7 +1269,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationWithReferenceKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cocktail);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/Reconstitution.cs
+++ b/test/UnitTests/Kvasir/Translation/Reconstitution.cs
@@ -2,6 +2,7 @@
 using Kvasir.Core;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -28,7 +29,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Garden)];
             var garden = (Garden)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -53,7 +54,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Dormitory)];
             var dormitory = (Dormitory)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -78,7 +79,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(KingOfFrance)];
             var king = (KingOfFrance)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -103,7 +104,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(MathematicalProof)];
             var proof = (MathematicalProof)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -128,7 +129,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Banshee)];
             var banshee = (Banshee)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -154,7 +155,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Neighborhood)];
             var neighborhood = (Neighborhood)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -180,7 +181,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Patreon)];
             var patreon = (Patreon)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -206,7 +207,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(EmergencyRoom)];
             var room = (EmergencyRoom)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -231,7 +232,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Accountant)];
             var accountant = (Accountant)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -255,7 +256,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Prenup)];
             var prenup = (Prenup)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -283,7 +284,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Penguin)];
             var penguin = (Penguin)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -307,7 +308,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Trampoline)];
             var trampoline = (Trampoline)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -329,7 +330,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Quilt)];
             var quilt = (Quilt)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -353,7 +354,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(MetraRoute)];
             var route = (MetraRoute)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -377,7 +378,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Loa)];
             var loa = (Loa)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -398,7 +399,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(LED)];
             var led = (LED)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -420,7 +421,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(ConspiracyTheory)];
             var theory = (ConspiracyTheory)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -451,7 +452,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Mermaid)];
             var mermaid = (Mermaid)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -484,7 +485,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Cheese)];
             var cheese = (Cheese)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -509,7 +510,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(EpiPen)];
             var epipen = (EpiPen)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -536,7 +537,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Hacker)];
             var hacker = (Hacker)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -564,7 +565,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Iconoclast)];
             var iconoclast = (Iconoclast)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -591,7 +592,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(AlphaMonster)];
             var alpha = (AlphaMonster)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -618,7 +619,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Empanada)];
             var empanada = (Empanada)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -659,7 +660,7 @@ namespace UT.Kvasir.Translation {
             var depot = new EntityDepot();
             depot.StoreEntity(rooster1);
             depot.StoreEntity(rooster2);
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(Cockfight)];
             var cockfight = (Cockfight)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -693,7 +694,7 @@ namespace UT.Kvasir.Translation {
             // Act
             var depot = new EntityDepot();
             depot.StoreEntity(range);
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(Glacier)];
             var glacier = (Glacier)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -716,7 +717,7 @@ namespace UT.Kvasir.Translation {
 
             // Act
             var depot = new EntityDepot();
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(Allegory)];
             var allegory = (Allegory)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -752,7 +753,7 @@ namespace UT.Kvasir.Translation {
             // Act
             var depot = new EntityDepot();
             depot.StoreEntity(person);
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(StripClub)];
             var stripClub = (StripClub)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -787,7 +788,7 @@ namespace UT.Kvasir.Translation {
             // Act
             var depot = new EntityDepot();
             depot.StoreEntity(painter);
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(Fresco)];
             var fresco = (Fresco)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -820,7 +821,7 @@ namespace UT.Kvasir.Translation {
             // Act
             var depot = new EntityDepot();
             depot.StoreEntity(company);
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(GoKart)];
             var gokart = (GoKart)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -846,7 +847,7 @@ namespace UT.Kvasir.Translation {
             var usageRows = new List<List<DBValue>>();
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(CharcuterieBoard)];
             var board = (CharcuterieBoard)translation.Principal.Reconstitutor.ReconstituteFrom(boardRow);
             translation.Relations[0].Repopulator!.Repopulate(board, cheeseRows);
@@ -892,7 +893,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Mutant)];
             var mutant = (Mutant)translation.Principal.Reconstitutor.ReconstituteFrom(mutantRow);
             translation.Relations[0].Repopulator!.Repopulate(mutant, appearanceRows);
@@ -943,7 +944,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(WaterPark)];
             var park = (WaterPark)translation.Principal.Reconstitutor.ReconstituteFrom(parkRow);
             translation.Relations[0].Repopulator!.Repopulate(park, admissionRows);
@@ -976,7 +977,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Seance)];
             var seance = (Seance)translation.Principal.Reconstitutor.ReconstituteFrom(seanceRow);
             translation.Relations[0].Repopulator!.Repopulate(seance, spiritRows);
@@ -1021,7 +1022,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Dermatologist)];
             var dermatologist = (Dermatologist)translation.Principal.Reconstitutor.ReconstituteFrom(dermatologistRow);
             translation.Relations[0].Repopulator!.Repopulate(dermatologist, almaMatersRow);
@@ -1065,7 +1066,7 @@ namespace UT.Kvasir.Translation {
             var sauceRows = new List<List<DBValue>>() {};
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(FriedChicken)];
             var chicken = (FriedChicken)translation.Principal.Reconstitutor.ReconstituteFrom(chickenRow);
             translation.Relations[0].Repopulator!.Repopulate(chicken, sauceRows);
@@ -1095,7 +1096,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Limousine)];
             var limousine = (Limousine)translation.Principal.Reconstitutor.ReconstituteFrom(limousineRow);
             translation.Relations[0].Repopulator!.Repopulate(limousine, driverRows);
@@ -1121,7 +1122,7 @@ namespace UT.Kvasir.Translation {
             var impregnationRows = new List<List<DBValue>>() {};
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Xenomorph)];
             var xenomorph = (Xenomorph)translation.Principal.Reconstitutor.ReconstituteFrom(xenomorphRow);
             translation.Relations[0].Repopulator!.Repopulate(xenomorph, impregnationRows);
@@ -1153,7 +1154,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(EpicPoem)];
             var poem = (EpicPoem)translation.Principal.Reconstitutor.ReconstituteFrom(poemRow);
             translation.Relations[0].Repopulator!.Repopulate(poem, sectionRows);
@@ -1222,7 +1223,7 @@ namespace UT.Kvasir.Translation {
 
             // Act
             var depot = new EntityDepot();
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var officerTranslation = translator[typeof(TrafficStop.PoliceOfficer)];
             var officer1 = (TrafficStop.PoliceOfficer)officerTranslation.Principal.Reconstitutor.ReconstituteFrom(officerRow1);
             var officer2 = (TrafficStop.PoliceOfficer)officerTranslation.Principal.Reconstitutor.ReconstituteFrom(officerRow2);
@@ -1264,7 +1265,7 @@ namespace UT.Kvasir.Translation {
 
             // Act
             var depot = new EntityDepot();
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(Poacher)];
             var poacher1 = (Poacher)translation.Principal.Reconstitutor.ReconstituteFrom(poacherRow1);
             var poacher2 = (Poacher)translation.Principal.Reconstitutor.ReconstituteFrom(poacherRow2);
@@ -1294,7 +1295,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(MichelinGuide)];
             var guide = (MichelinGuide)translation.Principal.Reconstitutor.ReconstituteFrom(guideRow);
             translation.Relations[0].Repopulator!.Repopulate(guide, restaurantRows);
@@ -1323,7 +1324,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Stove)];
             var stove = (Stove)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1348,7 +1349,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Cannibal)];
             var cannibal = (Cannibal)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1372,7 +1373,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Menorah)];
             var menorah = (Menorah)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1397,7 +1398,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Wedding)];
             var wedding = (Wedding)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1422,7 +1423,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(GoFundMe)];
             var goFundMe = (GoFundMe)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1437,7 +1438,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoViableConstructor_AllWriteableProperties_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tractor);
 
             // Act
@@ -1452,7 +1453,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoViableConstructor_NoneWithReadOnlyProperties_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Deposition);
 
             // Act
@@ -1467,7 +1468,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoViableConstructor_MultipleWithReadOnlyProperties_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hypnotist);
 
             // Act
@@ -1482,7 +1483,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoViableConstructor_ConvertibleArgument_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Paycheck);
 
             // Act
@@ -1497,7 +1498,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoViableConstructor_InconvertibleArgument_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Disneyland);
 
             // Act
@@ -1512,7 +1513,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoViableConstructor_NonNullableArgumentForNullableField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bakery);
 
             // Act
@@ -1527,7 +1528,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoViableConstructor_MultipleArgumentsMatchSameField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ParticleAccelerator);
 
             // Act
@@ -1550,7 +1551,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(CovalentBond)];
             var bond = (CovalentBond)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1573,7 +1574,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(AmericanGirlDoll)];
             var doll = (AmericanGirlDoll)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1588,7 +1589,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleViableConstructors_SameAritySameFields_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ambulance);
 
             // Act
@@ -1603,7 +1604,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void MultipleViableConstructors_SameArityDifferentFields_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CustomerServiceLine);
 
             // Act
@@ -1629,7 +1630,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Winery)];
             var winery = (Winery)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1655,7 +1656,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Constructor)];
             var constructor = (Constructor)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1680,7 +1681,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Petroglyph)];
             var petroglyph = (Petroglyph)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1704,7 +1705,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(PaintballGun)];
             var gun = (PaintballGun)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1729,7 +1730,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(BaobabTree)];
             var baobab = (BaobabTree)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1757,7 +1758,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(GPU)];
             var gpu = (GPU)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1774,7 +1775,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoViableConstructor_AggregateWithAllWriteableProperties_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Gargoyle);
 
             // Act
@@ -1789,7 +1790,7 @@ namespace UT.Kvasir.Translation {
         
         [TestMethod] public void NoViableConstructor_AggregateWithReadOnlyProperties_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SecurityClearance);
 
             // Act
@@ -1815,7 +1816,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(IllithidPower)];
             var power = (IllithidPower)translation.Principal.Reconstitutor.ReconstituteFrom(powerRow);
             translation.Relations[0].Repopulator!.Repopulate(power, featureRows);
@@ -1842,7 +1843,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Requiem)];
             var requiem = (Requiem)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1867,7 +1868,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Beekeeper)];
             var beekeeper = (Beekeeper)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1892,7 +1893,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Nightclub)];
             var nightclub = (Nightclub)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1907,7 +1908,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReconstituteThrough_NonViableConstructor_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Condom);
 
             // Act
@@ -1923,7 +1924,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReconstituteThrough_MultipleConstructors_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AntColony);
 
             // Act
@@ -1948,7 +1949,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Aphrodisiac)];
             var aphrodisiac = (Aphrodisiac)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -1962,7 +1963,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void ReconstituteThrough_PreDefinedEntity_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Vertebra);
 
             // Act
@@ -2000,7 +2001,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Tortilla)];
             var flourTortilla = (Tortilla)translation.Principal.Reconstitutor.ReconstituteFrom(flourRow);
             var cornTortilla = (Tortilla)translation.Principal.Reconstitutor.ReconstituteFrom(cornRow);
@@ -2024,7 +2025,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Symbiosis)];
             var symbiosis = (Symbiosis)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2042,7 +2043,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(MetricPrefix)];
             var reconstitute = () => translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2060,7 +2061,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Organelle)];
             var reconstitute = () => translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2079,7 +2080,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(LawAndOrder)];
             var reconstitute = () => translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2096,7 +2097,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(BrazilianState)];
             var reconstitute = () => translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2116,7 +2117,7 @@ namespace UT.Kvasir.Translation {
             );
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(PizzaRoll)];
             var pizzaRoll = (PizzaRoll)translation.Principal.Reconstitutor.ReconstituteFrom(pizzaRollRow);
             translation.Relations[0].Repopulator!.Repopulate(pizzaRoll, ingredientsRow);
@@ -2140,7 +2141,7 @@ namespace UT.Kvasir.Translation {
             // Act
             var depot = new EntityDepot();
             depot.StoreEntity(establishmentDate);
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(HolocaustMuseum)];
             var museum = (HolocaustMuseum)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2161,7 +2162,7 @@ namespace UT.Kvasir.Translation {
 
             // Act
             var depot = new EntityDepot();
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(Ultrasound)];
             var ultrasound = (Ultrasound)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2184,7 +2185,7 @@ namespace UT.Kvasir.Translation {
             // Arrange
             var depot = new EntityDepot();
             depot.StoreEntity(height);
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(DragQueen)];
             var queen = (DragQueen)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2199,7 +2200,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoViableConstructor_KeyTypeArgumentForLocalizationProperty_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Chinatown);
 
             // Act
@@ -2233,7 +2234,7 @@ namespace UT.Kvasir.Translation {
             depot.StoreEntity(city);
             depot.StoreEntity(country);
             depot.StoreEntity(diocese);
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(Cathedral)];
             var cathedral = (Cathedral)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2257,7 +2258,7 @@ namespace UT.Kvasir.Translation {
 
             // Act
             var depot = new EntityDepot();
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(Thunderstorm)];
             var thunderstorm = (Thunderstorm)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2289,7 +2290,7 @@ namespace UT.Kvasir.Translation {
             depot.StoreEntity(criminal0);
             depot.StoreEntity(criminal1);
             depot.StoreEntity(criminal2);
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(WarCrime)];
             var warCrime = (WarCrime)translation.Principal.Reconstitutor.ReconstituteFrom(crimeRow);
             translation.Relations[0].Repopulator.Repopulate(warCrime, perpetratorRows);
@@ -2306,7 +2307,7 @@ namespace UT.Kvasir.Translation {
             var row = new List<DBValue>() { DBValue.Create(-71336) };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Conjunction), Translator.AsLocalzation];
             var conjunction = (Conjunction)translation.Principal.Reconstitutor.ReconstituteFrom(row);
 
@@ -2316,7 +2317,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NoViableConstructor_Localization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Diminutive);
 
             // Act
@@ -2338,7 +2339,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(SwearWord), Translator.AsLocalzation];
             var swear = (SwearWord)translation.Principal.Reconstitutor.ReconstituteFrom(rows[0]);
             translation.Principal.Repopulator.Repopulate(swear, rows);
@@ -2361,7 +2362,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Wallpaper), Translator.AsLocalzation];
             var wallpaper = (Wallpaper)translation.Principal.Reconstitutor.ReconstituteFrom(rows[0]);
             translation.Principal.Repopulator.Repopulate(wallpaper, rows);
@@ -2386,7 +2387,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(Handshake), Translator.AsLocalzation];
             var handshake = (Handshake)translation.Principal.Reconstitutor.ReconstituteFrom(rows[0]);
             translation.Principal.Repopulator.Repopulate(handshake, rows);
@@ -2427,7 +2428,7 @@ namespace UT.Kvasir.Translation {
             var depot = new EntityDepot();
             depot.StoreEntity(spelling0);
             depot.StoreEntity(spelling1);
-            var translator = new Translator(t => depot[t]);
+            var translator = new Translator(t => depot[t], NullLogger.Instance);
             var translation = translator[typeof(Honorific), Translator.AsLocalzation];
             var honorific = (Honorific)translation.Principal.Reconstitutor.ReconstituteFrom(rows[0]);
             translation.Principal.Repopulator.Repopulate(honorific, rows);
@@ -2458,7 +2459,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(LiteraryGenre), Translator.AsLocalzation];
             var mysteryGenre = (LiteraryGenre)translation.Principal.Reconstitutor.ReconstituteFrom(mysteryRow);
             var folkloreGenre = (LiteraryGenre)translation.Principal.Reconstitutor.ReconstituteFrom(folkloreRow);
@@ -2479,7 +2480,7 @@ namespace UT.Kvasir.Translation {
             };
 
             // Act
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var translation = translator[typeof(PillarOfIslam), Translator.AsLocalzation];
             var reconstitute = () => translation.Principal.Reconstitutor.ReconstituteFrom(row);
 

--- a/test/UnitTests/Kvasir/Translation/ReferenceCycles.cs
+++ b/test/UnitTests/Kvasir/Translation/ReferenceCycles.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -11,7 +12,7 @@ namespace UT.Kvasir.Translation {
     public class ReferenceCycleTests {
         [TestMethod] public void SelfReferentialEntity_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Constitution);
 
             // Act
@@ -26,7 +27,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityReferenceChainLength2_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Niqqud);
 
             // Act
@@ -41,7 +42,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityReferenceCycleLength3OrMore_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RefugeeCamp);
 
             // Act
@@ -56,7 +57,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationReferenceCycle_DirectElement() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SoftwarePackage);
 
             // Act
@@ -112,7 +113,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationReferenceCycle_AggregateElement() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Indictment);
 
             // Act
@@ -147,7 +148,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationReferenceCycle_ReferenceElement() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StackFrame);
 
             // Act
@@ -174,7 +175,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void SystemReferenceCycle_ReferenceRelation() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Filibuster);
 
             // Act
@@ -202,7 +203,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityReferenceCycle_LocalizationLocale() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DuelingPianos);
 
             // Act
@@ -221,7 +222,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void EntityReferenceCycle_LocalizationValue() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CareerFair);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/SignednessConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/SignednessConstraints.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -13,7 +14,7 @@ namespace UT.Kvasir.Translation {
     public class IsPositiveTests {
         [TestMethod] public void IsPositive_NonNullableNumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GreekLetter);
 
             // Act
@@ -29,7 +30,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NullableNumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MedicalSpecialty);
 
             // Act
@@ -45,7 +46,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_TextualField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FieldGoal);
 
             // Act
@@ -61,7 +62,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GolfHole);
 
             // Act
@@ -77,7 +78,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_DateOnlyField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Jotunn);
 
             // Act
@@ -93,7 +94,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_DateTimeField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Gymnast);
 
             // Act
@@ -109,7 +110,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Documentary);
 
             // Act
@@ -125,7 +126,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mythbusting);
 
             // Act
@@ -141,7 +142,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_LocalizationWithNumericKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Argonaut);
 
             // Act
@@ -155,7 +156,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_LocalizationWithNonNumericKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Microscope);
 
             // Act
@@ -171,7 +172,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(IceAge);
 
             // Act
@@ -186,7 +187,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GoldenRaspberry);
 
             // Act
@@ -203,7 +204,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SudokuPuzzle);
 
             // Act
@@ -220,7 +221,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Runway);
 
             // Act
@@ -234,7 +235,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CaesareanSection);
 
             // Act
@@ -251,7 +252,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lamp);
 
             // Act
@@ -268,7 +269,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NestedLocalizationWithNumericKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StockSplit);
 
             // Act
@@ -282,7 +283,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NestedLocalizationWithNonNumericKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Famine);
 
             // Act
@@ -299,7 +300,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Russo);
 
             // Act
@@ -315,7 +316,7 @@ namespace UT.Kvasir.Translation {
         
         [TestMethod] public void IsPositive_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lycanthrope);
 
             // Act
@@ -328,7 +329,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ArtificialIntelligence);
 
             // Act
@@ -344,7 +345,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Margarita);
 
             // Act
@@ -361,7 +362,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PulitzerPrize);
 
             // Act
@@ -378,7 +379,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_FieldWithNumericDataConversionTarget() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SwimmingPool);
 
             // Act
@@ -392,7 +393,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_FieldWithNumericDataConversionSource_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WikipediaPage);
 
             // Act
@@ -408,7 +409,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_ScalarConstrainedMultipleTimes_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BaseballCard);
 
             // Act
@@ -422,7 +423,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HotSpring);
 
             // Act
@@ -438,7 +439,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Canal);
 
             // Act
@@ -454,7 +455,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SharkWeek);
 
             // Act
@@ -470,7 +471,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Philosopher);
 
             // Act
@@ -486,7 +487,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HappyHour);
 
             // Act
@@ -502,7 +503,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Aquifer);
 
             // Act
@@ -518,7 +519,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FactCheck);
 
             // Act
@@ -534,7 +535,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sukkah);
 
             // Act
@@ -550,7 +551,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Screenwriter);
 
             // Act
@@ -566,7 +567,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Typewriter);
 
             // Act
@@ -582,7 +583,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Well);
 
             // Act
@@ -598,7 +599,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Diacritic);
 
             // Act
@@ -614,7 +615,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ScoobyDooFilm);
 
             // Act
@@ -630,7 +631,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsPositive_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cyclops);
 
             // Act
@@ -650,7 +651,7 @@ namespace UT.Kvasir.Translation {
     public class IsNegativeTests {
         [TestMethod] public void IsNegative_SignedNonNullableNumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Acid);
 
             // Act
@@ -665,7 +666,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_UnsignedNumericFields_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cereal);
 
             // Act
@@ -681,7 +682,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_SignedNullableNumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ConcentrationCamp);
 
             // Act
@@ -697,7 +698,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_TextualField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(KeySignature);
 
             // Act
@@ -713,7 +714,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SporcleQuiz);
 
             // Act
@@ -729,7 +730,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_DateOnlyField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(VenmoRequest);
 
             // Act
@@ -745,7 +746,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_DateTimeField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Olympiad);
 
             // Act
@@ -761,7 +762,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(W2);
 
             // Act
@@ -777,7 +778,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SerialKiller);
 
             // Act
@@ -793,7 +794,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_LocalizationWithSignedNumericKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Snowman);
 
             // Act
@@ -807,7 +808,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_LocalizationWithUnsignedNumericKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tortellini);
 
             // Act
@@ -823,7 +824,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_LocalizationWithNonNumericKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Quark);
 
             // Act
@@ -839,7 +840,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Flood);
 
             // Act
@@ -853,7 +854,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TrolleyProblem);
 
             // Act
@@ -870,7 +871,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pharaoh);
 
             // Act
@@ -887,7 +888,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HawaiianGod);
 
             // Act
@@ -901,7 +902,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(OceanCurrent);
 
             // Act
@@ -918,7 +919,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AirBNB);
 
             // Act
@@ -935,7 +936,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NestedLocalizationWithSignedNumericKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RapeKit);
 
             // Act
@@ -949,7 +950,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NestedLocalizationWithUnsignedNumericKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LogicPuzzle);
 
             // Act
@@ -966,7 +967,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NestedLocalizationWithNonNumericKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Rainbow);
 
             // Act
@@ -983,7 +984,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MBTI);
 
             // Act
@@ -999,7 +1000,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DragonRider);
 
             // Act
@@ -1012,7 +1013,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Almanac);
 
             // Act
@@ -1026,7 +1027,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LandMine);
 
             // Act
@@ -1043,7 +1044,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(YahtzeeGame);
 
             // Act
@@ -1060,7 +1061,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_FieldWithNumericDataConversionTarget() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Boxer);
 
             // Act
@@ -1074,7 +1075,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_FieldWithNumericDataConversionSource_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Archangel);
 
             // Act
@@ -1090,7 +1091,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_ScalarConstrainedMultipleTimes_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Alkene);
 
             // Act
@@ -1104,7 +1105,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Climate);
 
             // Act
@@ -1120,7 +1121,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CircleOfHell);
 
             // Act
@@ -1136,7 +1137,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(VolleyballMatch);
 
             // Act
@@ -1152,7 +1153,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Yacht);
 
             // Act
@@ -1168,7 +1169,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pharmacy);
 
             // Act
@@ -1184,7 +1185,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Popcorn);
 
             // Act
@@ -1200,7 +1201,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WinForm);
 
             // Act
@@ -1216,7 +1217,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RomanFestival);
 
             // Act
@@ -1232,7 +1233,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AmberAlert);
 
             // Act
@@ -1248,7 +1249,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BoyBand);
 
             // Act
@@ -1264,7 +1265,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Jester);
 
             // Act
@@ -1280,7 +1281,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Reservation);
 
             // Act
@@ -1296,7 +1297,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SuperPAC);
 
             // Act
@@ -1312,7 +1313,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNegative_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PressSecretary);
 
             // Act
@@ -1332,7 +1333,7 @@ namespace UT.Kvasir.Translation {
     public class IsNonZeroTests {
         [TestMethod] public void IsNonZero_NonNullableNumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RegularPolygon);
 
             // Act
@@ -1349,7 +1350,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NullableNumericFields() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Skittles);
 
             // Act
@@ -1365,7 +1366,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_TextualField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Brassiere);
 
             // Act
@@ -1381,7 +1382,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FutharkRune);
 
             // Act
@@ -1397,7 +1398,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_DateOnlyField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TieDye);
 
             // Act
@@ -1413,7 +1414,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_DateTimeField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FinalFour);
 
             // Act
@@ -1429,7 +1430,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Fractal);
 
             // Act
@@ -1445,7 +1446,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(IPO);
 
             // Act
@@ -1461,7 +1462,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_LocalizationWithNumericKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Plumber);
 
             // Act
@@ -1475,7 +1476,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_LocalizationWithNonNumericKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(EggRoll);
 
             // Act
@@ -1491,7 +1492,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Essay);
 
             // Act
@@ -1509,7 +1510,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(IDE);
 
             // Act
@@ -1526,7 +1527,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PregnancyTest);
 
             // Act
@@ -1543,7 +1544,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(EgyptianPyramid);
 
             // Act
@@ -1557,7 +1558,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pajamas);
 
             // Act
@@ -1574,7 +1575,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChronicleOfNarnia);
 
             // Act
@@ -1590,7 +1591,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NewsAnchor);
 
             // Act
@@ -1603,7 +1604,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Galaxy);
 
             // Act
@@ -1620,7 +1621,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NestedLocalizationWithNumericKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Megafauna);
 
             // Act
@@ -1635,7 +1636,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NestedLocalizationWithNonNumericKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(VenusFlyTrap);
 
             // Act
@@ -1652,7 +1653,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CircleDance);
 
             // Act
@@ -1666,7 +1667,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(KosherAgency);
 
             // Act
@@ -1683,7 +1684,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CarpoolKaraoke);
 
             // Act
@@ -1700,7 +1701,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_FieldWithNumericDataConversionTarget() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Airline);
 
             // Act
@@ -1714,7 +1715,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_FieldWithNumericDataConversionSource_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Elevator);
 
             // Act
@@ -1730,7 +1731,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_ScalarConstrainedMultipleTimes_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Shoe);
 
             // Act
@@ -1744,7 +1745,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Igloo);
 
             // Act
@@ -1760,7 +1761,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cryptocurrency);
 
             // Act
@@ -1776,7 +1777,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Encomienda);
 
             // Act
@@ -1792,7 +1793,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Smoothie);
 
             // Act
@@ -1808,7 +1809,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Antibiotic);
 
             // Act
@@ -1824,7 +1825,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Chopsticks);
 
             // Act
@@ -1840,7 +1841,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TongueTwister);
 
             // Act
@@ -1856,7 +1857,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HallPass);
 
             // Act
@@ -1872,7 +1873,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Casserole);
 
             // Act
@@ -1888,7 +1889,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GarbageTruck);
 
             // Act
@@ -1904,7 +1905,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Imam);
 
             // Act
@@ -1920,7 +1921,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Haberdashery);
 
             // Act
@@ -1936,7 +1937,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pulley);
 
             // Act
@@ -1952,7 +1953,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonZero_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ceviche);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/StringLengthConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/StringLengthConstraints.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kvasir.Schema;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -14,7 +15,7 @@ namespace UT.Kvasir.Translation {
     public class IsNonEmptyTests {
         [TestMethod] public void IsNonEmpty_NonNullableStringField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Chocolate);
 
             // Act
@@ -28,7 +29,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NullableStringField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Scholarship);
 
             // Act
@@ -43,7 +44,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NumericField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Biography);
 
             // Act
@@ -59,7 +60,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_CharacterField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MovieTicket);
 
             // Act
@@ -75,7 +76,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FortuneCookie);
 
             // Act
@@ -91,7 +92,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_DateOnlyField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Fudge);
 
             // Act
@@ -107,7 +108,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_DateTimeField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ScubaDive);
 
             // Act
@@ -123,7 +124,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hormone);
 
             // Act
@@ -139,7 +140,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Moustache);
 
             // Act
@@ -155,7 +156,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_LocalizationFieldWithStringKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Frisbee);
 
             // Act
@@ -169,7 +170,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_LocalizationFieldWithNonStringKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Elegy);
 
             // Act
@@ -185,7 +186,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BarGraph);
 
             // Act
@@ -200,7 +201,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BackyardBaseballPlayer);
 
             // Act
@@ -217,7 +218,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(OilField);
 
             // Act
@@ -234,7 +235,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(VacuumCleaner);
 
             // Act
@@ -248,7 +249,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(IronChef);
 
             // Act
@@ -264,7 +265,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Limerick);
 
             // Act
@@ -281,7 +282,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PornStar);
 
             // Act
@@ -294,7 +295,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RomanBaths);
 
             // Act
@@ -311,7 +312,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NestedLocalizationFieldWithStringKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FunkoPop);
 
             // Act
@@ -325,7 +326,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NestedLocalizationFieldWithNonStringKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GrandWizard);
 
             // Act
@@ -342,7 +343,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Boycott);
 
             // Act
@@ -356,7 +357,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MallSanta);
 
             // Act
@@ -373,7 +374,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ConnectingWall);
 
             // Act
@@ -390,7 +391,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_FieldWithStringDataConversionTarget() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hourglass);
 
             // Act
@@ -404,7 +405,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_FieldWithStringDataConversionSource_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(FoodChain);
 
             // Act
@@ -420,7 +421,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_ScalarConstrainedMultipleTimes_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Top10List);
 
             // Act
@@ -434,7 +435,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Hoedown);
 
             // Act
@@ -450,7 +451,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ASLSign);
 
             // Act
@@ -466,7 +467,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sutra);
 
             // Act
@@ -482,7 +483,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Kaiju);
 
             // Act
@@ -498,7 +499,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Peerage);
 
             // Act
@@ -514,7 +515,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BountyHunter);
 
             // Act
@@ -530,7 +531,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Linker);
 
             // Act
@@ -546,7 +547,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Nymph);
 
             // Act
@@ -562,7 +563,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DatingApp);
 
             // Act
@@ -578,7 +579,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AdBlocker);
 
             // Act
@@ -594,7 +595,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GarbageCollector);
 
             // Act
@@ -610,7 +611,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Eulogy);
 
             // Act
@@ -626,7 +627,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void IsNonEmpty_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AztecGod);
 
             // Act
@@ -642,7 +643,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsNonEmpty_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lollipop);
 
             // Act
@@ -662,7 +663,7 @@ namespace UT.Kvasir.Translation {
     public class LengthIsAtLeastTests {
         [TestMethod] public void LengthIsAtLeast_NonNullableStringField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NFLPenalty);
 
             // Act
@@ -676,7 +677,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NullableStringField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ben10Alien);
 
             // Act
@@ -690,7 +691,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NumericField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HashFunction);
 
             // Act
@@ -706,7 +707,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_CharacterField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Kanji);
 
             // Act
@@ -722,7 +723,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Magazine);
 
             // Act
@@ -738,7 +739,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_DateOnlyField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Skateboard);
 
             // Act
@@ -754,7 +755,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_DateTimeField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Camerlengo);
 
             // Act
@@ -770,7 +771,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Rainforest);
 
             // Act
@@ -786,7 +787,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cybersite);
 
             // Act
@@ -802,7 +803,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_LocalizationFieldWithStringKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TermsOfService);
 
             // Act
@@ -816,7 +817,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_LocalizationFieldWithNonStringKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChessGrandmaster);
 
             // Act
@@ -832,7 +833,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Dubbing);
 
             // Act
@@ -847,7 +848,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BaseballMogul);
 
             // Act
@@ -864,7 +865,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MagicSystem);
 
             // Act
@@ -881,7 +882,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TEDTalk);
 
             // Act
@@ -895,7 +896,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Arrondissement);
 
             // Act
@@ -912,7 +913,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LEPBranch);
 
             // Act
@@ -928,7 +929,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Circus);
 
             // Act
@@ -941,7 +942,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Constellation);
 
             // Act
@@ -958,7 +959,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NestedLocalizationFieldWithStringKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(UsefulChart);
 
             // Act
@@ -972,7 +973,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NestedLocalizationFieldWithNonStringKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Furbie);
 
             // Act
@@ -989,7 +990,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(UNSecretaryGeneral);
 
             // Act
@@ -1006,7 +1007,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MemoryBuffer);
 
             // Act
@@ -1023,7 +1024,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HotTub);
 
             // Act
@@ -1040,7 +1041,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_FieldWithStringDataConversionTarget() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Ambassador);
 
             // Act
@@ -1054,7 +1055,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_FieldWithStringDataConversionSource_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Campfire);
 
             // Act
@@ -1070,7 +1071,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_AnchorIsZero_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HolyRomanEmperor);
 
             // Act
@@ -1084,7 +1085,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_AnchorIsNegative_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LaborOfHeracles);
 
             // Act
@@ -1100,7 +1101,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_ScalarConstrainedMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bagel);
 
             // Act
@@ -1114,7 +1115,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LocalizedData);
 
             // Act
@@ -1130,7 +1131,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Histogram);
 
             // Act
@@ -1146,7 +1147,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cactus);
 
             // Act
@@ -1162,7 +1163,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SederPlate);
 
             // Act
@@ -1178,7 +1179,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Crusade);
 
             // Act
@@ -1194,7 +1195,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(StateOfTheUnion);
 
             // Act
@@ -1210,7 +1211,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Triptych);
 
             // Act
@@ -1226,7 +1227,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cigar);
 
             // Act
@@ -1242,7 +1243,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MarijuanaStrain);
 
             // Act
@@ -1258,7 +1259,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BankRobber);
 
             // Act
@@ -1274,7 +1275,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TrailerPark);
 
             // Act
@@ -1290,7 +1291,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BeitDin);
 
             // Act
@@ -1306,7 +1307,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MaskedSinger);
 
             // Act
@@ -1322,7 +1323,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtLeast_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Briefcase);
 
             // Act
@@ -1342,7 +1343,7 @@ namespace UT.Kvasir.Translation {
     public class LengthIsAtMostTests {
         [TestMethod] public void LengthIsAtMost_NonNullableStringField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Snake);
 
             // Act
@@ -1358,7 +1359,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NullableStringField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WinterStorm);
 
             // Act
@@ -1372,7 +1373,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NumericField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GasStation);
 
             // Act
@@ -1388,7 +1389,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_CharacterField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BinaryTest);
 
             // Act
@@ -1404,7 +1405,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Diamond);
 
             // Act
@@ -1420,7 +1421,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_DateOnlyField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MontyPythonSkit);
 
             // Act
@@ -1436,7 +1437,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_DateTimeField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Marathon);
 
             // Act
@@ -1452,7 +1453,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CppHeader);
 
             // Act
@@ -1468,7 +1469,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ComputerVirus);
 
             // Act
@@ -1484,7 +1485,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_LocalizationFieldWithStringKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SearsCatalog);
 
             // Act
@@ -1498,7 +1499,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_LocalizationFieldWithNonStringKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Crucifixion);
 
             // Act
@@ -1514,7 +1515,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MafiaFamily);
 
             // Act
@@ -1529,7 +1530,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Kayak);
 
             // Act
@@ -1546,7 +1547,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MaddenNFL);
 
             // Act
@@ -1563,7 +1564,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Denarian);
 
             // Act
@@ -1577,7 +1578,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(IceCreamSundae);
 
             // Act
@@ -1594,7 +1595,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TonyAward);
 
             // Act
@@ -1610,7 +1611,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bust);
 
             // Act
@@ -1623,7 +1624,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Orgasm);
 
             // Act
@@ -1640,7 +1641,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NestedLocalizationFieldWithStringKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(WeddingRegistry);
 
             // Act
@@ -1654,7 +1655,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NestedLocalizationFieldWithNonStringKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Beautician);
 
             // Act
@@ -1671,7 +1672,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Golem);
 
             // Act
@@ -1685,7 +1686,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BalsamicVinegar);
 
             // Act
@@ -1702,7 +1703,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TerroristOrganization);
 
             // Act
@@ -1719,7 +1720,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_FieldWithStringDataConversionTarget() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(OilSpill);
 
             // Act
@@ -1733,7 +1734,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_FieldWithStringDataConversionSource_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(RandomNumberGenerator);
 
             // Act
@@ -1749,7 +1750,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_AnchorIsZero() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(KnockKnockJoke);
 
             // Act
@@ -1764,7 +1765,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_AnchorIsNegative_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Fraternity);
 
             // Act
@@ -1780,7 +1781,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_ScalarConstrainedMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(OceanicTrench);
 
             // Act
@@ -1794,7 +1795,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Passport);
 
             // Act
@@ -1810,7 +1811,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Nebula);
 
             // Act
@@ -1826,7 +1827,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ImaginaryFriend);
 
             // Act
@@ -1842,7 +1843,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Newscast);
 
             // Act
@@ -1858,7 +1859,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PhaseDiagram);
 
             // Act
@@ -1874,7 +1875,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sundial);
 
             // Act
@@ -1890,7 +1891,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Zoombini);
 
             // Act
@@ -1906,7 +1907,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Antipope);
 
             // Act
@@ -1922,7 +1923,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Cabaret);
 
             // Act
@@ -1938,7 +1939,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TikTok);
 
             // Act
@@ -1954,7 +1955,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Swimsuit);
 
             // Act
@@ -1970,7 +1971,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GorillaTroop);
 
             // Act
@@ -1986,7 +1987,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Obi);
 
             // Act
@@ -2002,7 +2003,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsAtMost_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Speakeasy);
 
             // Act
@@ -2022,7 +2023,7 @@ namespace UT.Kvasir.Translation {
     public class LengthIsBetweenTests {
         [TestMethod] public void LengthIsBetween_NonNullableStringField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sorority);
 
             // Act
@@ -2037,7 +2038,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NullableStringField() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Telescope);
 
             // Act
@@ -2052,7 +2053,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NumericField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Capacitor);
 
             // Act
@@ -2068,7 +2069,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_CharacterField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lipstick);
 
             // Act
@@ -2084,7 +2085,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_BooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Process);
 
             // Act
@@ -2100,7 +2101,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_DateOnlyField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Tumbleweed);
 
             // Act
@@ -2116,7 +2117,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_DateTimeField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mummy);
 
             // Act
@@ -2132,7 +2133,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_GuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CelticGod);
 
             // Act
@@ -2148,7 +2149,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_EnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Kinesis);
 
             // Act
@@ -2164,7 +2165,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_LocalizationFieldWithStringKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(NonDisclosureAgreement);
 
             // Act
@@ -2179,7 +2180,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_LocalizationFieldWithNonStringKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ObstacleCourse);
 
             // Act
@@ -2195,7 +2196,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_AggregateNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LiteraryTrope);
 
             // Act
@@ -2212,7 +2213,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_AggregateNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(OvernightCamp);
 
             // Act
@@ -2229,7 +2230,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NestedAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Dentist);
 
             // Act
@@ -2246,7 +2247,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_ReferenceNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Onomatopoeia);
 
             // Act
@@ -2261,7 +2262,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_ReferenceNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(TrivialPursuitPie);
 
             // Act
@@ -2278,7 +2279,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NestedReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SumoWrestler);
 
             // Act
@@ -2295,7 +2296,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NestedLocalizationFieldWithStringKey() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Visa);
 
             // Act
@@ -2310,7 +2311,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NestedLocalizationFieldWithNonStringKey_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DDoS);
 
             // Act
@@ -2327,7 +2328,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_RelationNestedApplicableScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ComicBook);
 
             // Act
@@ -2344,7 +2345,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetwen_RelationNestedInapplicableScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Wormhole);
 
             // Act
@@ -2361,7 +2362,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NestedRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LunarEclipse);
 
             // Act
@@ -2378,7 +2379,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_PreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HighSchoolMusical);
 
             // Act
@@ -2394,7 +2395,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_OriginalOnReferenceNestedScalar() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Lagoon);
 
             // Act
@@ -2407,7 +2408,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_FieldWithStringDataConversionTarget() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AesSedai);
 
             // Act
@@ -2422,7 +2423,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_FieldWithStringDataConversionSource_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(AtmosphericLayer);
 
             // Act
@@ -2438,7 +2439,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_LowerBoundEqualsUpperBound() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DNACodon);
 
             // Act
@@ -2452,7 +2453,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_LowerBoundGreaterThanUpperBound_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ChristmasCarol);
 
             // Act
@@ -2468,7 +2469,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NegativeLowerBound_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ShenGongWu);
 
             // Act
@@ -2484,7 +2485,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NegativeLowerAndUpperBounds_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MilitaryBase);
 
             // Act
@@ -2500,7 +2501,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_ScalarConstrainedMultipleTimes() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Aria);
 
             // Act
@@ -2515,7 +2516,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_PathIsNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Apocalypse);
 
             // Act
@@ -2531,7 +2532,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_PathOnScalar_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SetCard);
 
             // Act
@@ -2547,7 +2548,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NonExistentPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(InternetCraze);
 
             // Act
@@ -2563,7 +2564,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NoPathOnAggregate_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MesopotamianGod);
 
             // Act
@@ -2579,7 +2580,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NonExistentPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HeatWave);
 
             // Act
@@ -2595,7 +2596,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NonPrimaryKeyPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Sprachbund);
 
             // Act
@@ -2611,7 +2612,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NoPathOnReference_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Leprechaun);
 
             // Act
@@ -2627,7 +2628,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NonExistentPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MarsRover);
 
             // Act
@@ -2643,7 +2644,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NonAnchorPrimaryKeyPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BlackOp);
 
             // Act
@@ -2659,7 +2660,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NoPathOnRelation_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(HeartAttack);
 
             // Act
@@ -2675,7 +2676,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NonExistentPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(ThoughtExperiment);
 
             // Act
@@ -2691,7 +2692,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_NestedPathOnLocalization_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MusicVideo);
 
             // Act
@@ -2707,7 +2708,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_DefaultValueDoesNotSatisfyConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PeanutButter);
 
             // Act
@@ -2723,7 +2724,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LengthIsBetween_ValidDefaultValueIsInvalidatedByConstraint_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Kebab);
 
             // Act

--- a/test/UnitTests/Kvasir/Translation/TableNaming.cs
+++ b/test/UnitTests/Kvasir/Translation/TableNaming.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Kvasir.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static UT.Kvasir.Translation.Globals;
@@ -10,7 +11,7 @@ namespace UT.Kvasir.Translation {
     public class TableNamingTests {
         [TestMethod] public void PrimaryTableRenamedToBrandNewName() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PlayingCard);
 
             // Act
@@ -22,7 +23,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationTableRenamedToBrandNewName() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Placebo);
 
             // Act
@@ -34,7 +35,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NamespaceExcludedFromDefaultPrimaryTableName() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Pokemon);
 
             // Act
@@ -46,7 +47,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void NamespaceExcludedFromRelationTableName() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PrisonerExchange);
 
             // Act
@@ -59,7 +60,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PrimaryTable_DuplicateNameWithPrimaryTable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var firstSource = typeof(Flight);
             var secondSource = typeof(Battle);
 
@@ -76,7 +77,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PrimaryTable_NameIsUnchanged_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Bookmark);
 
             // Act
@@ -88,7 +89,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PrimaryTable_NameChangedToNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(SmokeDetector);
 
             // Act
@@ -104,7 +105,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void PrimaryTable_NameChangedToEmptyString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LogIn);
 
             // Act
@@ -120,7 +121,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CombinedAnnotation_TableAndExcludeNamespaceFromName_Equivalent_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Umbrella);
 
             // Act
@@ -136,7 +137,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CombinedAnnotation_TableAndExcludeNamespaceFromName_Prefixed_LatterEnforced() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Blender);
 
             // Act
@@ -148,7 +149,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CombinedAnnotation_TableAndExcludeNamespaceFromName_Infixed_LatterRedundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(BoardingSchool);
 
             // Act
@@ -160,7 +161,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CombinedAnnotation_TableAndExcludeNamespaceFromName_Suffixed_LatterRedundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PolygraphTest);
 
             // Act
@@ -172,7 +173,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void CombinedAnnotation_TableAndExcludeNamespaceFromName_NoOverlap_LatterRedundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Encryption);
 
             // Act
@@ -184,7 +185,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTableRenamedToBrandNewName() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(MagicalPreserve);
 
             // Act
@@ -197,7 +198,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_NameIsUnchanged_Redundant() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(PacerTest);
 
             // Act
@@ -210,7 +211,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_NameChangedToNull_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Dwarf);
 
             // Act
@@ -226,7 +227,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_NameChangedToEmptyString_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Rodent);
 
             // Act
@@ -242,7 +243,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_DuplicateNameWithRelationTable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Vowel);
 
             // Act
@@ -257,7 +258,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_DuplicateNameWithPrimaryTable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(VPN);
 
             // Act
@@ -272,7 +273,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_AppliedToNumericField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Shofar);
 
             // Act
@@ -288,7 +289,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_AppliedToTextualField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LawnGnome);
 
             // Act
@@ -304,7 +305,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_AppliedToBooleanField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(GovernmentShutdown);
 
             // Act
@@ -320,7 +321,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_AppliedToDateTimeField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(CoalMine);
 
             // Act
@@ -336,7 +337,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_AppliedToGuidField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(LawnMower);
 
             // Act
@@ -352,7 +353,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_AppliedToEnumerationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Triplets);
 
             // Act
@@ -368,7 +369,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_AppliedToAggregateField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Toothbrush);
 
             // Act
@@ -384,7 +385,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_AppliedToReferenceField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Valet);
 
             // Act
@@ -400,7 +401,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_AppliedToPreDefinedInstance_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(DEFCON);
 
             // Act
@@ -415,7 +416,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void RelationTable_AppliedToLocalizationField_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Mattress);
 
             // Act
@@ -431,7 +432,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationTable_DuplicateNameWithLocalizationTable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var firstSource = typeof(Target.LocalizedAddress);
             var secondSource = typeof(Target.LocalizedString);
 
@@ -448,7 +449,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationTable_DuplicateNameWithPrincipalTable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var firstSource = typeof(Overlord);
             var secondSource = typeof(Overlord.LocalizedCount);
 
@@ -465,7 +466,7 @@ namespace UT.Kvasir.Translation {
 
         [TestMethod] public void LocalizationTable_DuplicateNameWithRelationTable_IsError() {
             // Arrange
-            var translator = new Translator(NO_ENTITIES);
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var firstSource = typeof(SportsAgent);
             var secondSource = typeof(SportsAgent.LocalizedSalary);
 


### PR DESCRIPTION
This commit adds basic logging to the Translation and Transaction paths. In particular, we log before every piece of SQL is executed and the progress of translating individual entity types. We also log the order of the topologically sorted commands, as well as errors when it comes to failed transactions and rollbacks. For unit tests, we use a NullLogger.