### PR TITLE
Clean-Up Visual Studio Non-Warning Messages

### DIFF
--- a/src/Atropos/FullCheck/Comparison.cs
+++ b/src/Atropos/FullCheck/Comparison.cs
@@ -204,7 +204,7 @@ namespace Atropos {
 
                         var method = typeof(FullCheck).GetMethod(funcName, funcFlags)!;
                         var target = method.MakeGenericMethod(arg);
-                        var result = (Option<string>)target.Invoke(null, new object?[] { lhs, rhs, trichotomy })!;
+                        var result = (Option<string>)target.Invoke(null, [lhs, rhs, trichotomy])!;
 
                         if (result.HasValue) {
                             return result;

--- a/src/Atropos/FullCheck/Equality.cs
+++ b/src/Atropos/FullCheck/Equality.cs
@@ -93,7 +93,7 @@ namespace Atropos {
 
                         var method = typeof(FullCheck).GetMethod(funcName, funcFlags)!;
                         var target = method.MakeGenericMethod(arg);
-                        var result = (Option<string>)target.Invoke(null, new object?[] { lhs, rhs, expectedEqual })!;
+                        var result = (Option<string>)target.Invoke(null, [lhs, rhs, expectedEqual])!;
 
                         if (result.HasValue) {
                             return result;

--- a/src/Atropos/FullCheck/Operators.cs
+++ b/src/Atropos/FullCheck/Operators.cs
@@ -55,7 +55,7 @@ namespace Atropos {
                     // The first argument to `MethodInfo.Invoke` is the `this` parameter for the method. These
                     // operators are all static, so the `this` parameter is irrelevant; this is fortuitous, because we
                     // don't have a way to obtain a guaranteed-non-null instance of T.
-                    result = (l, r) => (bool)method.Invoke(null, new object?[] { l, r })!;
+                    result = (l, r) => (bool)method.Invoke(null, [l, r])!;
                 }
 
                 // Memoize the result so that we only perform the reflection on time per type per operator
@@ -87,8 +87,8 @@ namespace Atropos {
         private delegate bool BinaryOp(object? lhs, object? rhs);
         private enum Operator : byte { EQ, NEQ, LT, GT, LTE, GTE };
 
-        private static readonly IDictionary<(Type, Operator), BinaryOp?> memoizer_;
-        private static readonly IReadOnlyDictionary<Operator, string> opNames_;
+        private static readonly ConcurrentDictionary<(Type, Operator), BinaryOp?> memoizer_;
+        private static readonly Dictionary<Operator, string> opNames_;
         private static readonly BindingFlags OPERATOR_FLAGS;
     }
 }

--- a/src/Atropos/GlobalSuppressions.cs
+++ b/src/Atropos/GlobalSuppressions.cs
@@ -5,3 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Naming", "VSSpell001:Spell Check", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0290:Use primary constructor", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0090:'new' expression can be simplified", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0039:Use local function", Scope = "module")]

--- a/src/Cybele/Collections/StickyList.cs
+++ b/src/Cybele/Collections/StickyList.cs
@@ -89,7 +89,7 @@ namespace Cybele.Collections {
         ///   for <typeparamref name="T"/> for comparison purposes.
         /// </summary>
         public StickyList()
-            : this(Enumerable.Empty<T>()) {}
+            : this([]) {}
 
         /// <summary>
         ///   Constructs a new <see cref="StickyList{T}"/> that uses the default <see cref="IEqualityComparer"/> for
@@ -111,7 +111,7 @@ namespace Cybele.Collections {
         ///   The <see cref="IEqualityComparer{T}"/> that the new StickyList should use for comparisons.
         /// </param>
         public StickyList(IEqualityComparer<T> comparer)
-            : this(Enumerable.Empty<T>(), comparer) {}
+            : this([], comparer) {}
 
         /// <summary>
         ///   Constructs a new <see cref="StickyList{T}"/> that uses a custom <see cref="IEqualityComparer{T}"/> for
@@ -128,7 +128,7 @@ namespace Cybele.Collections {
             Guard.Against.Null(enumerable, nameof(enumerable));
             Guard.Against.Null(comparer, nameof(comparer));
 
-            elements_ = enumerable.Select(i => Option.Some((i, false))).ToList();
+            elements_ = [..enumerable.Select(i => Option.Some((i, false)))];
             comparer_ = comparer;
 
             Count = elements_.Count;

--- a/src/Cybele/Core/PropertyChain.cs
+++ b/src/Cybele/Core/PropertyChain.cs
@@ -78,7 +78,7 @@ namespace Cybele.Core {
                 throw new ArgumentException(BAD_PROPERTY_MSG, nameof(firstProperty));
             }
 
-            chain_ = new List<PropertyInfo>() { firstProperty };
+            chain_ = [firstProperty];
         }
 
         /// <summary>

--- a/src/Cybele/Extensions/Enum.cs
+++ b/src/Cybele/Extensions/Enum.cs
@@ -110,7 +110,7 @@ namespace Cybele.Extensions {
             // If the enum type is a regular enum, as opposed to a flags enum, then we can just return the result of the
             // standard library's Enum.GetValues() function, as there is no combinatorics involved
             if (!isFlags) {
-                return Enum.GetValues(self).Cast<Enum>().ToArray();
+                return [..Enum.GetValues(self).Cast<Enum>()];
             }
 
             var flags = Enum.GetValues(self)                    // get named enumerators
@@ -145,7 +145,7 @@ namespace Cybele.Extensions {
             }
 
             // Memoize the results
-            valuesMemoizer_[self] = results.ToArray();
+            valuesMemoizer_[self] = [..results];
             return valuesMemoizer_[self];
         }
 
@@ -186,8 +186,8 @@ namespace Cybele.Extensions {
         }
 
 
-        private static readonly IDictionary<Type, bool> isFlagsMemoizer_;
-        private static readonly IDictionary<Type, long> bitsMemoizer_;
-        private static readonly IDictionary<Type, Enum[]> valuesMemoizer_;
+        private static readonly ConcurrentDictionary<Type, bool> isFlagsMemoizer_;
+        private static readonly ConcurrentDictionary<Type, long> bitsMemoizer_;
+        private static readonly ConcurrentDictionary<Type, Enum[]> valuesMemoizer_;
     }
 }

--- a/src/Cybele/Extensions/Object.cs
+++ b/src/Cybele/Extensions/Object.cs
@@ -65,7 +65,7 @@ namespace Cybele.Extensions {
                 if (str.StartsWith("1E")) {
                     return str;
                 }
-                else if (str.EndsWith("∞") || str.EndsWith("Infinity")) {
+                else if (str.EndsWith('∞') || str.EndsWith("Infinity")) {
                     // The representation of various infinities is different on Windows vs. Ubuntu
                     return str;
                 }

--- a/src/Cybele/GlobalSuppressions.cs
+++ b/src/Cybele/GlobalSuppressions.cs
@@ -5,3 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Naming", "VSSpell001:Spell Check", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0290:Use primary constructor", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0090:'new' expression can be simplified", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0039:Use local function", Scope = "module")]

--- a/src/Kvasir/Annotations/CheckAttribute.cs
+++ b/src/Kvasir/Annotations/CheckAttribute.cs
@@ -79,7 +79,7 @@ namespace Kvasir.Annotations {
         ///   Constructs a new instance of the <see cref="CheckAttribute{TConstraintGenerator}"/> class.
         /// </summary>
         public CheckAttribute()
-            : this(Array.Empty<object>()) {}
+            : this([]) {}
 
         /// <summary>
         ///   Constructs a new instance of the <see cref="CheckAttribute{TConstraintGenerator}"/> class.

--- a/src/Kvasir/Annotations/CheckComplexAttribute.cs
+++ b/src/Kvasir/Annotations/CheckComplexAttribute.cs
@@ -71,7 +71,7 @@ namespace Kvasir.Annotations {
             ///   imposed by this annotation applies.
             /// </param>
             public ComplexAttribute(string[] fieldNames)
-                : this(fieldNames, Array.Empty<object?>()) {}
+                : this(fieldNames, []) {}
 
             /// <summary>
             ///   Constructs a new instance of the <see cref="ComplexAttribute{TConstraintGenerator}"/> class.
@@ -85,7 +85,7 @@ namespace Kvasir.Annotations {
             /// </param>
             public ComplexAttribute(string[] fieldNames, params object?[] args) {
                 impl_ = new CheckAttribute<TConstraintGenerator>(args);
-                fieldNames_ = fieldNames.Select(n => new FieldName(n)).ToList();
+                fieldNames_ = [..fieldNames.Select(n => new FieldName(n))];
             }
 
 

--- a/src/Kvasir/Annotations/InclusionAttributes.cs
+++ b/src/Kvasir/Annotations/InclusionAttributes.cs
@@ -45,7 +45,7 @@ namespace Kvasir.Annotations {
                 Debug.Assert(!anchor.IsEmpty());
 
                 Operator = op;
-                Anchor = anchor.Select(v => v ?? DBNull.Value).ToArray();
+                Anchor = [..anchor.Select(v => v ?? DBNull.Value)];
             }
 
             /// <summary>

--- a/src/Kvasir/Annotations/UniqueAttribute.cs
+++ b/src/Kvasir/Annotations/UniqueAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Kvasir.Annotations {
     /// <summary>
@@ -28,7 +29,7 @@ namespace Kvasir.Annotations {
         ///   Constructs a new instance of the <see cref="UniqueAttribute"/> class with an implementation-defined name.
         /// </summary>
         public UniqueAttribute() {
-            lock (LOCK) {
+            lock (lock_) {
                 Name = $"{ANONYMOUS_PREFIX}UNIQUE_FIELD_{sequence_++}";
             }
             IsAnonymous = true;
@@ -76,7 +77,7 @@ namespace Kvasir.Annotations {
         }
 
 
-        private static readonly object LOCK = new();
+        private static readonly Lock lock_ = new();
         private static int sequence_ = 0;
         private static readonly string SYNTHETIC_NAME = $"{ANONYMOUS_PREFIX}-SYNTHETIC";
     }

--- a/src/Kvasir/Core/EntityDepot.cs
+++ b/src/Kvasir/Core/EntityDepot.cs
@@ -27,7 +27,7 @@ namespace Kvasir.Core {
         ///   Constructs a new <see cref="EntityDepot"/> with no stored Entities.
         /// </summary>
         public EntityDepot() {
-            entities_ = new Dictionary<Type, HashSet<object>>();
+            entities_ = [];
         }
 
         /// <summary>

--- a/src/Kvasir/Core/EnumConverters.cs
+++ b/src/Kvasir/Core/EnumConverters.cs
@@ -32,7 +32,7 @@ namespace Kvasir.Core {
 
             var underlyingType = Enum.GetUnderlyingType(enumType);
             var maker = MAKE_IMPL_FN.MakeGenericMethod(enumType, underlyingType);
-            impl_ = (DataConverter)maker.Invoke(null, Array.Empty<object?>())!;
+            impl_ = (DataConverter)maker.Invoke(null, [])!;
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Kvasir.Core {
             Debug.Assert(enumType.IsEnum);
 
             var maker = MAKE_IMPL_FN.MakeGenericMethod(enumType);
-            impl_ = (DataConverter)maker.Invoke(null, Array.Empty<object?>())!;
+            impl_ = (DataConverter)maker.Invoke(null, [])!;
         }
 
         /// <summary>

--- a/src/Kvasir/Extraction/DataExtractionPlan.cs
+++ b/src/Kvasir/Extraction/DataExtractionPlan.cs
@@ -26,7 +26,7 @@ namespace Kvasir.Extraction {
             Debug.Assert(extractors is not null && !extractors.IsEmpty());
             Debug.Assert(extractors.AllSame(e => e.SourceType));
 
-            extractors_ = new List<IMultiExtractor>(extractors);
+            extractors_ = [..extractors];
             SourceType = extractors_[0].SourceType;
         }
 

--- a/src/Kvasir/Extraction/DecomposingExtractor.cs
+++ b/src/Kvasir/Extraction/DecomposingExtractor.cs
@@ -23,7 +23,7 @@ namespace Kvasir.Extraction {
             Debug.Assert(extractors is not null && !extractors.IsEmpty());
             Debug.Assert(extractors.AllSame(e => e.SourceType));
 
-            extractors_ = new List<IMultiExtractor>(extractors);
+            extractors_ = [..extractors];
             SourceType = extractors_[0].SourceType;
         }
 

--- a/src/Kvasir/GlobalSuppressions.cs
+++ b/src/Kvasir/GlobalSuppressions.cs
@@ -5,3 +5,8 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Naming", "VSSpell001:Spell Check", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0290:Use primary constructor", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0090:'new' expression can be simplified", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0039:Use local function", Scope = "module")]
+[assembly: SuppressMessage("Style", "CA1873:Evaluation of this argument may be expensive and unnecessary if logging is disabled", Scope = "module")]

--- a/src/Kvasir/Localization/Localization.cs
+++ b/src/Kvasir/Localization/Localization.cs
@@ -124,7 +124,7 @@ namespace Kvasir.Localization {
             Guard.Against.Null(localizationKey);
 
             Key = localizationKey;
-            Relation = new RelationMap<TLocale, TValue>();
+            Relation = [];
         }
 
         /// <summary>

--- a/src/Kvasir/Providers/MySQL/ConstraintBuilder.cs
+++ b/src/Kvasir/Providers/MySQL/ConstraintBuilder.cs
@@ -188,7 +188,7 @@ namespace Kvasir.Providers.MySQL {
         private readonly static string PREDICATE_PLACEHOLDER = "{:P:}";
         private readonly static string CONSTRAINT_TEMPLATE = $"{NAME_PLACEHOLDER}CHECK ({PREDICATE_PLACEHOLDER})";
 
-        private Stack<string> clauses_;
+        private readonly Stack<string> clauses_;
         private string declaration_;
         private Option<MaxLengthConstraintDecl> maxLengthDecl_;
     }

--- a/src/Kvasir/Providers/MySQL/FieldBuilder.cs
+++ b/src/Kvasir/Providers/MySQL/FieldBuilder.cs
@@ -58,7 +58,7 @@ namespace Kvasir.Providers.MySQL {
         }
 
 
-        private static ulong MAX_LENGTH_UPPER_BOUND = 65535;
+        private static readonly ulong MAX_LENGTH_UPPER_BOUND = 65535;
         private string declaration_;
     }
 
@@ -186,7 +186,7 @@ namespace Kvasir.Providers.MySQL {
             // This isn't the prettiest, but for some reason I find this more logical than having an Optional that is
             // guaranteed to be eventually populated. This logic falls apart if there is a backtick in the actual name
             // of the Field, but I'm pretty sure that's not permitted.
-            var name = new FieldName(declaration_[1..declaration_.IndexOf("`", 1)]);
+            var name = new FieldName(declaration_[1..declaration_.IndexOf('`', 1)]);
             return new FieldDecl(name, declaration_);
         }
 

--- a/src/Kvasir/Providers/MySQL/TableBuilder.cs
+++ b/src/Kvasir/Providers/MySQL/TableBuilder.cs
@@ -15,11 +15,11 @@ namespace Kvasir.Providers.MySQL {
         /// </summary>
         public TableBuilder() {
             declaration_ = TEMPLATE;
-            fields_ = new List<FieldDecl>();
-            candidateKeys_ = new List<SqlSnippet>();
-            constraints_ = new List<IConstraintDecl>();
-            foreignKeys_ = new List<SqlSnippet>();
-            fieldIndexFromName_ = new Dictionary<FieldName, int>();
+            fields_ = [];
+            candidateKeys_ = [];
+            constraints_ = [];
+            foreignKeys_ = [];
+            fieldIndexFromName_ = [];
         }
 
         /// <inheritdoc/>
@@ -118,10 +118,10 @@ namespace Kvasir.Providers.MySQL {
             FKS_PLACEHOLDER;
 
         private string declaration_;
-        private List<FieldDecl> fields_;
-        private List<SqlSnippet> candidateKeys_;
-        private List<IConstraintDecl> constraints_;
-        private List<SqlSnippet> foreignKeys_;
-        private Dictionary<FieldName, int> fieldIndexFromName_;
+        private readonly List<FieldDecl> fields_;
+        private readonly List<SqlSnippet> candidateKeys_;
+        private readonly List<IConstraintDecl> constraints_;
+        private readonly List<SqlSnippet> foreignKeys_;
+        private readonly Dictionary<FieldName, int> fieldIndexFromName_;
     }
 }

--- a/src/Kvasir/Reconstitution/ConstructingCreator.cs
+++ b/src/Kvasir/Reconstitution/ConstructingCreator.cs
@@ -39,7 +39,7 @@ namespace Kvasir.Reconstitution {
 
             constructFromAllNulls_ = allowAllNulls;
             constructor_ = ctor;
-            argumentCreators_ = new List<ICreator>(argumentCreators);
+            argumentCreators_ = [..argumentCreators];
             ResultType = constructor_.ReflectedType!;
         }
 
@@ -58,7 +58,7 @@ namespace Kvasir.Reconstitution {
             }
             else {
                 var arguments = argumentCreators_.Select(c => c.CreateFrom(dbValues));
-                return constructor_.Invoke(arguments.ToArray());
+                return constructor_.Invoke([..arguments]);
             }
         }
 

--- a/src/Kvasir/Reconstitution/CreatorFacade.cs
+++ b/src/Kvasir/Reconstitution/CreatorFacade.cs
@@ -54,7 +54,7 @@ namespace Kvasir.Reconstitution {
             Debug.Assert(start_ + length_ <= dbValues.Count);
 
             var view = dbValues.Skip(start_).Take(length_);
-            return creator_.CreateFrom(view.ToList());
+            return creator_.CreateFrom([..view]);
         }
 
 

--- a/src/Kvasir/Reconstitution/KeyLookupCreator.cs
+++ b/src/Kvasir/Reconstitution/KeyLookupCreator.cs
@@ -68,7 +68,7 @@ namespace Kvasir.Reconstitution {
             keyExtractor_ = keyExtractor;
             domainGenerator_ = domainGenerator;
             keyCache_ = new(new ListEqualityComparer());
-            cachedPossibleMatches_ = new HashSet<object>();
+            cachedPossibleMatches_ = [];
             ResultType = keyExtractor_.SourceType;
         }
 

--- a/src/Kvasir/Reconstitution/ReconstitutingCreator.cs
+++ b/src/Kvasir/Reconstitution/ReconstitutingCreator.cs
@@ -30,7 +30,7 @@ namespace Kvasir.Reconstitution {
             Debug.Assert(mutators.All(m => creator.ResultType.IsInstanceOf(m.SourceType)));
 
             creator_ = creator;
-            mutators_ = new List<IMutator>(mutators);
+            mutators_ = [..mutators];
             ResultType = creator_.ResultType;
         }
 

--- a/src/Kvasir/Relations/RelationList.cs
+++ b/src/Kvasir/Relations/RelationList.cs
@@ -100,9 +100,9 @@ namespace Kvasir.Relations {
         ///   initial capacity.
         /// </summary>
         public RelationList() {
-            impl_ = new List<T>();
-            statuses_ = new List<Status>();
-            deletions_ = new List<T>();
+            impl_ = [];
+            statuses_ = [];
+            deletions_ = [];
         }
 
         /// <summary>
@@ -113,9 +113,9 @@ namespace Kvasir.Relations {
         ///   The element whose names are copied to the new list.
         /// </param>
         public RelationList(IEnumerable<T> collection) {
-            impl_ = new List<T>(collection);
-            statuses_ = Enumerable.Repeat(Status.New, impl_.Count).ToList();
-            deletions_ = new List<T>();
+            impl_ = [..collection];
+            statuses_ = [..Enumerable.Repeat(Status.New, impl_.Count)];
+            deletions_ = [];
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Kvasir.Relations {
         public RelationList(int capacity) {
             impl_ = new List<T>(capacity);
             statuses_ = new List<Status>(capacity);
-            deletions_ = new List<T>();
+            deletions_ = [];
         }
 
         // **************************************** METHODS *****************************************
@@ -1006,7 +1006,7 @@ namespace Kvasir.Relations {
         /// </returns>
         [ExcludeFromCodeCoverage]
         public T[] ToArray() {
-            return impl_.ToArray();
+            return [..impl_];
         }
 
         /// <inheritdoc/>

--- a/src/Kvasir/Relations/RelationMap.cs
+++ b/src/Kvasir/Relations/RelationMap.cs
@@ -113,9 +113,9 @@ namespace Kvasir.Relations {
         ///   default initial capacity, and uses the default equality comparer for the key type.
         /// </summary>
         public RelationMap() {
-            impl_ = new Dictionary<TKey, TValue>();
-            statuses_ = new Dictionary<TKey, Status>();
-            deletions_ = new Dictionary<TKey, TValue>();
+            impl_ = [];
+            statuses_ = [];
+            deletions_ = [];
         }
 
         /// <summary>
@@ -502,7 +502,7 @@ namespace Kvasir.Relations {
 
         /// <inheritdoc/>
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item) {
-            if (impl_.ContainsKey(item.Key) && Equals(impl_[item.Key], item.Value)) {
+            if (impl_.TryGetValue(item.Key, out TValue? value) && Equals(value, item.Value)) {
                 Remove(item.Key);
                 return true;
             }
@@ -581,8 +581,10 @@ namespace Kvasir.Relations {
         // ************************************ HELPER FUNCTIONS ************************************
 
         private Status BookkeepAddition(TKey keyAddition, TValue valueAddition) {
-            var addedStatus = deletions_.ContainsKey(keyAddition) && deletions_[keyAddition]!.Equals(valueAddition)
-                ? Status.Saved : Status.New;
+            var addedStatus = Status.New;
+            if (deletions_.TryGetValue(keyAddition, out TValue? deletedValue) && Equals(deletedValue, valueAddition)) {
+                addedStatus = Status.Saved;
+            }
 
             if (addedStatus == Status.Saved) {
                 deletions_.Remove(keyAddition);

--- a/src/Kvasir/Relations/RelationOrderedList.cs
+++ b/src/Kvasir/Relations/RelationOrderedList.cs
@@ -103,8 +103,8 @@ namespace Kvasir.Relations {
         ///   default initial capacity.
         /// </summary>
         public RelationOrderedList() {
-            impl_ = new List<T>();
-            lastSaved_ = new List<T>();
+            impl_ = [];
+            lastSaved_ = [];
         }
 
         /// <summary>
@@ -115,8 +115,8 @@ namespace Kvasir.Relations {
         ///   The element whose names are copied to the new list.
         /// </param>
         public RelationOrderedList(IEnumerable<T> collection) {
-            impl_ = new List<T>(collection);
-            lastSaved_ = new List<T>();
+            impl_ = [..collection];
+            lastSaved_ = [];
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Kvasir.Relations {
         /// </exception>
         public RelationOrderedList(int capacity) {
             impl_ = new List<T>(capacity);
-            lastSaved_ = new List<T>();
+            lastSaved_ = [];
         }
 
         // **************************************** METHODS *****************************************
@@ -954,7 +954,7 @@ namespace Kvasir.Relations {
         /// </returns>
         [ExcludeFromCodeCoverage]
         public T[] ToArray() {
-            return impl_.ToArray();
+            return [..impl_];
         }
 
         /// <inheritdoc/>

--- a/src/Kvasir/Relations/RelationSet.cs
+++ b/src/Kvasir/Relations/RelationSet.cs
@@ -72,9 +72,9 @@ namespace Kvasir.Relations {
         ///   equality comparer for the set type.
         /// </summary>
         public RelationSet() {
-            impl_ = new HashSet<T>();
-            statuses_ = new Dictionary<T, Status>();
-            deletions_ = new List<T>();
+            impl_ = [];
+            statuses_ = [];
+            deletions_ = [];
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Kvasir.Relations {
         public RelationSet(int capacity) {
             impl_ = new HashSet<T>(capacity);
             statuses_ = new Dictionary<T, Status>(capacity);
-            deletions_ = new List<T>();
+            deletions_ = [];
         }
 
         /// <summary>
@@ -99,9 +99,9 @@ namespace Kvasir.Relations {
         ///   The collection whose elements are copied to the new set.
         /// </param>
         public RelationSet(IEnumerable<T> collection) {
-            impl_ = new HashSet<T>(collection);
+            impl_ = [..collection];
             statuses_ = new Dictionary<T, Status>(impl_.Select(v => new KeyValuePair<T, Status>(v, Status.New)));
-            deletions_ = new List<T>();
+            deletions_ = [];
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Kvasir.Relations {
         public RelationSet(IEqualityComparer<T>? comparer) {
             impl_ = new HashSet<T>(comparer);
             statuses_ = new Dictionary<T, Status>(comparer);
-            deletions_ = new List<T>();
+            deletions_ = [];
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Kvasir.Relations {
         public RelationSet(int capacity, IEqualityComparer<T>? comparer) {
             impl_ = new HashSet<T>(capacity, comparer);
             statuses_ = new Dictionary<T, Status>(capacity, comparer);
-            deletions_ = new List<T>();
+            deletions_ = [];
         }
 
         /// <summary>
@@ -153,10 +153,8 @@ namespace Kvasir.Relations {
         /// </param>
         public RelationSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer) {
             impl_ = new HashSet<T>(collection, comparer);
-            statuses_ = new Dictionary<T, Status>(
-                impl_.Select(v => new KeyValuePair<T, Status>(v, Status.New)), comparer
-            );
-            deletions_ = new List<T>();
+            statuses_ = new Dictionary<T, Status>(impl_.Select(v => new KeyValuePair<T, Status>(v, Status.New)), comparer);
+            deletions_ = [];
         }
 
         // **************************************** METHODS *****************************************

--- a/src/Kvasir/Schema/CandidateKey.cs
+++ b/src/Kvasir/Schema/CandidateKey.cs
@@ -66,7 +66,7 @@ namespace Kvasir.Schema {
             Debug.Assert(!fields.IsEmpty());
 
             Name = name;
-            Fields = new List<IField>(fields);
+            Fields = [..fields];
 
             // We have to use a List as opposed to, e.g., a HashSet because the order of the Fields within a Key is
             // important. Even though the order doesn't have any impact on the generated SQL (i.e. the Key [A,B] is

--- a/src/Kvasir/Schema/DBType.cs
+++ b/src/Kvasir/Schema/DBType.cs
@@ -256,10 +256,10 @@ namespace Kvasir.Schema {
         static DBType() {
             ENUM_SENTINEL = typeof(Enum);
 
-            STRING_FORMS = new string[] {
+            STRING_FORMS = [
                 "Int32", "Boolean", "Character", "Date/Time", "Decimal", "Double", "Enumeration", "GUID", "Int8",
                 "Int16", "Int64", "Single", "Text", "UInt8", "UInt16", "UInt32", "UInt64", "Date"
-            };
+            ];
 
             Debug.Assert(default(byte) == 0, $"Sequence of IDs for {nameof(DBType)} is not starting at 0");
             Int32 = new DBType(default);
@@ -339,7 +339,7 @@ namespace Kvasir.Schema {
 
 
         private readonly byte id_;
-        private static readonly IReadOnlyDictionary<Type, DBType> lookup_;
+        private static readonly Dictionary<Type, DBType> lookup_;
         private static readonly Type ENUM_SENTINEL;
         private static readonly string[] STRING_FORMS;
     }

--- a/src/Kvasir/Schema/EnumField.cs
+++ b/src/Kvasir/Schema/EnumField.cs
@@ -87,7 +87,7 @@ namespace Kvasir.Schema {
             DataType = DBType.Enumeration;
             Nullability = nullability;
             DefaultValue = defaultValue;
-            Enumerators = new List<DBValue>(enumerators);
+            Enumerators = [..enumerators];
 
             // These two Asserts are placed after the constructor body so that we can refer to the DataType property
             // after its value is set, eliminating some duplication of the constant value

--- a/src/Kvasir/Schema/ForeignKey.cs
+++ b/src/Kvasir/Schema/ForeignKey.cs
@@ -167,7 +167,7 @@ namespace Kvasir.Schema {
             Debug.Assert(OnUpdate.IsValid());
 
             Name = name;
-            ReferencingFields = new List<IField>(fields);
+            ReferencingFields = [..fields];
             ReferencedTable = reference;
             OnDelete = onDelete;
             OnUpdate = onUpdate;

--- a/src/Kvasir/Schema/Table.cs
+++ b/src/Kvasir/Schema/Table.cs
@@ -95,11 +95,11 @@ namespace Kvasir.Schema {
             Debug.Assert(checkConstraints.All(c => c.Condition.GetDependentFields().All(f => fields.Contains(f))));
 
             Name = name;
-            Fields = new List<IField>(fields);
+            Fields = [..fields];
             PrimaryKey = primaryKey;
-            CandidateKeys = new List<CandidateKey>(candidateKeys);
-            ForeignKeys = new List<ForeignKey>(foreignKeys);
-            CheckConstraints = new List<CheckConstraint>(checkConstraints);
+            CandidateKeys = [..candidateKeys];
+            ForeignKeys = [..foreignKeys];
+            CheckConstraints = [..checkConstraints];
         }
 
         /* Because Table is record type, the following methods are synthesized automatically by the compiler:

--- a/src/Kvasir/Transaction/Topology.cs
+++ b/src/Kvasir/Transaction/Topology.cs
@@ -45,7 +45,7 @@ namespace Kvasir.Transaction {
             // that the graph is acyclic.
             var adjacencyMatrix = new List<List<bool>>();
             for (int i = 0; i < translations.Count; ++i) {
-                adjacencyMatrix.Add(Enumerable.Repeat(false, translations.Count).ToList());
+                adjacencyMatrix.Add([..Enumerable.Repeat(false, translations.Count)]);
             }
 
             // We're also going to keep a degree counter; this will make our topological sort algorithm slightly more

--- a/src/Kvasir/Transaction/Transactor.cs
+++ b/src/Kvasir/Transaction/Transactor.cs
@@ -118,7 +118,7 @@ namespace Kvasir.Transaction {
             var localizationCommands = new List<ICommands>();
             var tables = new Dictionary<ITable, int>();
             var sourceTypes = new Dictionary<ITable, Type>();
-            foreach (var principal in Topology.OrderEntities(entityTranslations.ToList())) {
+            foreach (var principal in Topology.OrderEntities([..entityTranslations])) {
                 tables[principal.Table] = principalCommands.Count;
                 sourceTypes[principal.Table] = principal.Extractor.SourceType;
                 principalCommands.Add(commandsFactory_.CreateCommands(principal.Table, isPrincipalTable: true));
@@ -145,7 +145,7 @@ namespace Kvasir.Transaction {
             // one another. The relative order of the Relation Tables is likewise not relevant because they cannot
             // reference each other, either.
             localizationStartIdx_ = principalCommands.Count + relationCommands.Count;
-            commands_ = principalCommands.Concat(relationCommands).Concat(localizationCommands).ToList();
+            commands_ = [..principalCommands.Concat(relationCommands).Concat(localizationCommands)];
             tables_ = tables;
             sourceTypes_ = sourceTypes;
 
@@ -184,7 +184,7 @@ namespace Kvasir.Transaction {
             var preDefineds = entityTranslations_.Values.SelectMany(translation => translation.Principal.PreDefinedInstances);
             preDefineds = preDefineds.Concat(localizationTranslations_.Values.SelectMany(translation => translation.Principal.PreDefinedInstances));
             if (!preDefineds.IsEmpty()) {
-                Insert(preDefineds.ToList());
+                Insert([..preDefineds]);
             }
         }
 
@@ -213,8 +213,8 @@ namespace Kvasir.Transaction {
                 while (reader.Read()) {
                     var fields = Enumerable.Range(0, reader.FieldCount).Select(i => DBValue.Create(reader[i])).ToList();
                     if (!rows.TryGetValue(fields[0], out List<List<DBValue>>? currentRows)) {
-                        currentRows = new List<List<DBValue>>();
-                        var instance = localizationTranslations[idx].Principal.Reconstitutor.ReconstituteFrom(fields.Take(1).ToList());
+                        currentRows = [];
+                        var instance = localizationTranslations[idx].Principal.Reconstitutor.ReconstituteFrom([..fields.Take(1)]);
                         rows[fields[0]] = currentRows;
                         instances[fields[0]] = instance;
                     }
@@ -425,7 +425,7 @@ namespace Kvasir.Transaction {
                     foreach (var entity in mapping[translation.CLRSource]) {
                         var ownerFields = translation.Principal.KeyExtractor.ExtractFrom(entity);
                         var relationFields = relation.Extractor.ExtractFrom(entity);
-                        var relationPKFieldsCount = relation.Table.PrimaryKey.Fields.Count - ownerFields.Count();
+                        var relationPKFieldsCount = relation.Table.PrimaryKey.Fields.Count - ownerFields.Count;
 
                         deleteRows.AddRange(relationFields.Deletions.Select(r => ownerFields.Concat(r.Take(relationPKFieldsCount)).ToList()));
                         updateRows.AddRange(relationFields.Modifications.Select(r => ownerFields.Concat(r).ToList()));
@@ -577,7 +577,7 @@ namespace Kvasir.Transaction {
             // provided on construction and we need to translate them. We'll use default settings since we're only
             // dealing with framework-controlled Tables anyway, and we know that the table names are reserved. There
             // also won't be any referential fields, so we don't have to worry about the Entity lookup.
-            var translator = new Translator(t => Enumerable.Empty<object>(), logger_);
+            var translator = new Translator(t => [], logger_);
 
             ManageSchemaMigration(translator);
         }
@@ -673,7 +673,7 @@ namespace Kvasir.Transaction {
         private readonly IReadOnlyDictionary<Type, EntityTranslation> entityTranslations_;
         private readonly IReadOnlyDictionary<Type, LocalizationTranslation> localizationTranslations_;
         private readonly IReadOnlyDictionary<ITable, int> tables_;          // maps to index in `commands_` list
-        private readonly IReadOnlyDictionary<ITable, Type> sourceTypes_;
+        private readonly Dictionary<ITable, Type> sourceTypes_;
         private readonly IDbConnection connection_;
         private readonly ICommandsFactory commandsFactory_;
         private readonly Action<object> entityStorage_;

--- a/src/Kvasir/Translation/Categorization.cs
+++ b/src/Kvasir/Translation/Categorization.cs
@@ -152,6 +152,8 @@ namespace Kvasir.Translation {
         private TypeCategory(string description) { description_ = description; }
         public override string ToString() { return description_; }
         public bool Equals(TypeCategory rhs) { return description_ == rhs.description_; }
+        public override bool Equals(object? rhs) { return (rhs is TypeCategory r) && Equals(r); }
+        public override int GetHashCode() { return description_.GetHashCode(); }
         private readonly string description_;
     }
 
@@ -169,6 +171,8 @@ namespace Kvasir.Translation {
         private PropertyCategory(string description) { description_ = description; }
         public override string ToString() { return description_;  }
         public bool Equals(PropertyCategory rhs) { return description_ == rhs.description_; }
+        public override bool Equals(object? rhs) { return (rhs is PropertyCategory r) && Equals(r); }
+        public override int GetHashCode() { return description_.GetHashCode(); }
         private readonly string description_;
     }
 }

--- a/src/Kvasir/Translation/Context.cs
+++ b/src/Kvasir/Translation/Context.cs
@@ -32,9 +32,9 @@ namespace Kvasir.Translation {
 
             frozen_ = false;
             initialType_ = initial;
-            history_ = new List<PropertyInfo>();
+            history_ = [];
             current_ = Option.None<PropertyInfo>();
-            references_ = new List<Type>() { initial };
+            references_ = [initial];
             TranslatingEntity = true;
         }
 
@@ -49,9 +49,9 @@ namespace Kvasir.Translation {
 
             frozen_ = true;
             initialType_ = source.initialType_;
-            history_ = new List<PropertyInfo>(source.history_);
+            history_ = [..source.history_];
             current_ = source.current_;
-            references_ = new List<Type>(source.references_);
+            references_ = [..source.references_];
             TranslatingEntity = source.TranslatingEntity;
         }
 

--- a/src/Kvasir/Translation/Exceptions/ReferenceCycleException.cs
+++ b/src/Kvasir/Translation/Exceptions/ReferenceCycleException.cs
@@ -12,7 +12,7 @@
         public ReferenceCycleException(Context context)
             : base(
                 new Location(context.ToString()),
-                new Problem($"reference cycle detected")
+                new Problem("reference cycle detected")
               )
         {}
     }

--- a/src/Kvasir/Translation/FieldDescriptors/BooleanFieldDescriptor.cs
+++ b/src/Kvasir/Translation/FieldDescriptors/BooleanFieldDescriptor.cs
@@ -11,14 +11,14 @@ namespace Kvasir.Translation {
             : base(context, source) {
 
             Debug.Assert(FieldType == typeof(bool));
-            SetDomain(new object[] { true, false });
+            SetDomain([true, false]);
         }
 
         public BooleanFieldDescriptor(Context context, PropertyInfo source, DataConverterAttribute annotation)
             : base(context, source, annotation) {
 
             Debug.Assert(FieldType == typeof(bool));
-            SetDomain(new object[] { true, false });
+            SetDomain([true, false]);
         }
 
         public sealed override BooleanFieldDescriptor Clone() {

--- a/src/Kvasir/Translation/FieldDescriptors/FieldDescriptor.cs
+++ b/src/Kvasir/Translation/FieldDescriptors/FieldDescriptor.cs
@@ -492,11 +492,11 @@ namespace Kvasir.Translation {
             converter_ = source.converter_;
             default_ = source.default_;
             inPrimaryKey_ = source.inPrimaryKey_;
-            keyMemberships_ = new HashSet<KeyName>(source.keyMemberships_);
-            allowedValues_ = new HashSet<object>(source.allowedValues_);
-            disallowedValues_ = new HashSet<object>(source.disallowedValues_);
-            restrictedDomain_ = new HashSet<object>(source.restrictedDomain_);
-            checks_ = new List<(CheckAttribute, Context)>(source.checks_);
+            keyMemberships_ = [..source.keyMemberships_];
+            allowedValues_ = [..source.allowedValues_];
+            disallowedValues_ = [..source.disallowedValues_];
+            restrictedDomain_ = [..source.restrictedDomain_];
+            checks_ = [..source.checks_];
             annotationsSeen_ = Annotation.None;
 
             // Only the [Check.IsPositive] and [Check.IsNegative] annotations carry over. Those annotations get
@@ -531,11 +531,11 @@ namespace Kvasir.Translation {
             converter_ = source.converter_;
             default_ = Option.None<object?>();
             inPrimaryKey_ = false;
-            keyMemberships_ = new HashSet<KeyName>();
-            allowedValues_ = new HashSet<object>();
-            disallowedValues_ = new HashSet<object>();
-            restrictedDomain_ = new HashSet<object>(source.restrictedDomain_);
-            checks_ = new List<(CheckAttribute, Context)>();
+            keyMemberships_ = [];
+            allowedValues_ = [];
+            disallowedValues_ = [];
+            restrictedDomain_ = [..source.restrictedDomain_];
+            checks_ = [];
             annotationsSeen_ = Annotation.None;
         }
 
@@ -558,11 +558,11 @@ namespace Kvasir.Translation {
             converter_ = Option.None<DataConverter>();
             default_ = Option.None<object?>();
             inPrimaryKey_ = false;
-            keyMemberships_ = new HashSet<KeyName>();
-            allowedValues_ = new HashSet<object>();
-            disallowedValues_ = new HashSet<object>();
-            restrictedDomain_ = new HashSet<object>();
-            checks_ = new List<(CheckAttribute, Context)>();
+            keyMemberships_ = [];
+            allowedValues_ = [];
+            disallowedValues_ = [];
+            restrictedDomain_ = [];
+            checks_ = [];
             annotationsSeen_ = Annotation.None;
         }
 
@@ -617,14 +617,14 @@ namespace Kvasir.Translation {
             // won't be a restricted image; instead, the enumerators are fed through the Data Converter and the results
             // become the set of allowed values, as if via a [Check.IsOneOf] constraint
             if (conv.SourceType.IsEnum && !conv.ResultType.IsEnum) {
-                restrictedDomain_ = conv.SourceType.ValidValues().Select(e => conv.TryConvert(e, context)!).ToHashSet();
+                restrictedDomain_ = [..conv.SourceType.ValidValues().Select(e => conv.TryConvert(e, context)!)];
             }
 
             // Similarly, if the CLR type of the property is `bool` but the result of the Data Converter is not, then
             // we have to pass { true, false } through the Data Converter for the results to become the set of allowed
             // values.
             else if (conv.SourceType == typeof(bool) && conv.ResultType != typeof(bool)) {
-                restrictedDomain_ = new bool[] { true, false }.Select(b => conv.TryConvert(b, context)!).ToHashSet();
+                restrictedDomain_ = [..BOOLEANS.Select(b => conv.TryConvert(b, context)!)];
             }
         }
 
@@ -658,7 +658,7 @@ namespace Kvasir.Translation {
             // won't be a restricted image; instead, the enumerators are fed through the Data Converter and the results
             // become the set of allowed values, as if via a [Check.IsOneOf] constraint
             if (converter.SourceType.IsEnum && !converter.ResultType.IsEnum) {
-                restrictedDomain_ = converter.SourceType.ValidValues().Select(e => converter.TryConvert(e, context)!).ToHashSet();
+                restrictedDomain_ = [..converter.SourceType.ValidValues().Select(e => converter.TryConvert(e, context)!)];
             }
 
             // No need for a Boolean check here, because the only annotations that can trigger this constructor are
@@ -1005,6 +1005,7 @@ namespace Kvasir.Translation {
         private readonly HashSet<object> restrictedDomain_;
         private readonly List<(CheckAttribute Annotation, Context Context)> checks_;
         private Annotation annotationsSeen_;
+        private static readonly List<bool> BOOLEANS = [true, false];
 
 
         // A discriminator for the constructor to indicate that metadata should be reset

--- a/src/Kvasir/Translation/FieldDescriptors/OrderableFieldDescriptor.cs
+++ b/src/Kvasir/Translation/FieldDescriptors/OrderableFieldDescriptor.cs
@@ -142,19 +142,19 @@ namespace Kvasir.Translation {
 
         private Interval comparisonConstraint_;
 
-        private static readonly object[] MINIMA = new object[] {
+        private static readonly object[] MINIMA = [
             byte.MinValue, sbyte.MinValue,
             ushort.MinValue, short.MinValue,
             uint.MinValue, int.MinValue,
             ulong.MinValue, ulong.MinValue,
             double.MinValue, float.MinValue, decimal.MinValue
-        };
-        private static readonly object[] MAXIMA = new object[] {
+        ];
+        private static readonly object[] MAXIMA = [
             byte.MaxValue, sbyte.MaxValue,
             ushort.MaxValue, short.MaxValue,
             uint.MaxValue, int.MaxValue,
             ulong.MaxValue, ulong.MaxValue,
             double.MaxValue, float.MaxValue, decimal.MaxValue
-        };
+        ];
     }
 }

--- a/src/Kvasir/Translation/FieldGroups/MultiFieldGroup.cs
+++ b/src/Kvasir/Translation/FieldGroups/MultiFieldGroup.cs
@@ -83,7 +83,7 @@ namespace Kvasir.Translation {
         ///   modified (i.e. already <see cref="FieldGroup.Clone">cloned</see>).
         /// </param>
         protected MultiFieldGroup(Context context, PropertyInfo source, IEnumerable<FieldGroup> fields)
-            : this(context, source, fields, Enumerable.Empty<RelationTracker>()) {}
+            : this(context, source, fields, []) {}
 
         /// <summary>
         ///   Constructs a new <see cref="MultiFieldGroup"/> that may, but does not necessarily, have at least one
@@ -125,7 +125,7 @@ namespace Kvasir.Translation {
             fields_ = fields.ToDictionary(f => f.Source.Name.Split('.')[^1], f => f);
             trackers_ = trackers.ToDictionary(t => t.Property.Name.Split('.')[^1], t => t);
             IsCalculated = source.HasAttribute<CalculatedAttribute>();
-            SetNamePrefix(context, new List<string>() {});
+            SetNamePrefix(context, []);
             ProcessAnnotations(context);
 
             // The if-block is only skipped if we have an Aggregate consisting of only Relations, in which case it will
@@ -570,6 +570,6 @@ namespace Kvasir.Translation {
         private bool nullabilityAnnotated_;
         private bool nameAnnotated_;
         private readonly IReadOnlyDictionary<string, FieldGroup> fields_;
-        private readonly IReadOnlyDictionary<string, RelationTracker> trackers_;
+        private readonly Dictionary<string, RelationTracker> trackers_;
     }
 }

--- a/src/Kvasir/Translation/FieldGroups/SingleFieldGroup.cs
+++ b/src/Kvasir/Translation/FieldGroups/SingleFieldGroup.cs
@@ -207,7 +207,7 @@ namespace Kvasir.Translation {
 
         /// <inheritdoc/>
         public sealed override IEnumerable<ReferenceFieldGroup> References() {
-            return Enumerable.Empty<ReferenceFieldGroup>();
+            return [];
         }
 
         /// <inheritdoc/>
@@ -270,7 +270,7 @@ namespace Kvasir.Translation {
             Debug.Assert(prefix is not null && !prefix.IsEmpty());
             Debug.Assert(prefix.None(s => s is null || s == ""));
 
-            field_.SetNamePrefix(context, new List<string>(prefix));
+            field_.SetNamePrefix(context, [..prefix]);
             // changing the name prefix is only done for nested fields, so it doesn't affect the Reconstitution argument
         }
 

--- a/src/Kvasir/Translation/LocalizationTracker.cs
+++ b/src/Kvasir/Translation/LocalizationTracker.cs
@@ -25,7 +25,7 @@ namespace Kvasir.Translation {
             Debug.Assert(Translator.IsLocalizationType(source.PropertyType));
 
             Property = source;
-            decontextualizedAccessPath_ = new List<string>() { source.Name.Split('.')[^1] };
+            decontextualizedAccessPath_ = [source.Name.Split('.')[^1]];
         }
 
         /// <summary>

--- a/src/Kvasir/Translation/Reconstitution.cs
+++ b/src/Kvasir/Translation/Reconstitution.cs
@@ -77,7 +77,7 @@ namespace Kvasir.Translation {
                     return new Candidate() {
                         Constructor = constructor,
                         Arguments = arguments,
-                        Mutations = mutators.Values.Select(g => new WritePropertyMutator(g.Source, CreatorFor(g))).ToList(),
+                        Mutations = [..mutators.Values.Select(g => new WritePropertyMutator(g.Source, CreatorFor(g)))],
                         IsViable = true
                     };
                 }
@@ -90,7 +90,7 @@ namespace Kvasir.Translation {
             var constructors = source.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             if (source.IsValueType && constructors.IsEmpty()) {
                 var defaultCtor = new SyntheticConstructorInfo(source);
-                constructors = new ConstructorInfo[] { defaultCtor };
+                constructors = [defaultCtor];
             }
 
             // Make one candidate per constructor; not all will be viable
@@ -159,8 +159,8 @@ namespace Kvasir.Translation {
             public static Candidate Failure(ConstructorInfo constructor) {
                 return new Candidate() {
                     Constructor = constructor,
-                    Arguments = new List<CreatorFacade>(),
-                    Mutations = new List<WritePropertyMutator>(),
+                    Arguments = [],
+                    Mutations = [],
                     IsViable = false
                 };
             }

--- a/src/Kvasir/Translation/RelationTracker.cs
+++ b/src/Kvasir/Translation/RelationTracker.cs
@@ -42,9 +42,9 @@ namespace Kvasir.Translation {
 
             AnnotatedName = Option.None<string>();
             Property = source;
-            contextualizedAccessPath_ = new List<string>() { source.Name.Split('.')[^1] };
-            decontextualizedAccessPath_ = new List<string>() { source.Name.Split('.')[^1] };
-            annotations_ = new Dictionary<string, List<Attribute>>();
+            contextualizedAccessPath_ = [source.Name.Split('.')[^1]];
+            decontextualizedAccessPath_ = [source.Name.Split('.')[^1]];
+            annotations_ = [];
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Kvasir.Translation {
                 var field = annotation.NextPath;
                 var stepped = annotation.Step();
                 var effective = stepped.Annotation.WithPath(stepped.NextPath);
-                annotations_.TryAdd(field, new List<Attribute>());
+                annotations_.TryAdd(field, []);
                 annotations_[field].Add((effective as Attribute)!);
             }
         }
@@ -198,7 +198,7 @@ namespace Kvasir.Translation {
 
 
         private readonly IReadOnlyList<string> contextualizedAccessPath_;
-        private readonly IReadOnlyList<string> decontextualizedAccessPath_;
+        private readonly List<string> decontextualizedAccessPath_;
         private readonly Dictionary<string, List<Attribute>> annotations_;
     }
 }

--- a/src/Kvasir/Translation/Synthetics/SyntheticConstructorInfo.cs
+++ b/src/Kvasir/Translation/Synthetics/SyntheticConstructorInfo.cs
@@ -44,7 +44,7 @@ namespace Kvasir.Translation {
             Debug.Assert(type is not SyntheticType && type.IsValueType);
 
             DeclaringType = type;
-            parameters_ = Array.Empty<SyntheticParameterInfo>();
+            parameters_ = [];
         }
 
         /// <summary>
@@ -62,12 +62,12 @@ namespace Kvasir.Translation {
             Debug.Assert(properties is not null);
 
             DeclaringType = type;
-            parameters_ = properties.Select(p => new SyntheticParameterInfo(this, p.Name, p.PropertyType)).ToArray();
+            parameters_ = [..properties.Select(p => new SyntheticParameterInfo(this, p.Name, p.PropertyType))];
         }
 
         /// <inheritdoc/>
         public sealed override IList<CustomAttributeData> GetCustomAttributesData() {
-            return new List<CustomAttributeData>();
+            return [];
         }
 
         /// <inheritdoc/>

--- a/src/Kvasir/Translation/Synthetics/SyntheticParameterInfo.cs
+++ b/src/Kvasir/Translation/Synthetics/SyntheticParameterInfo.cs
@@ -33,7 +33,7 @@ namespace Kvasir.Translation {
 
         /// <inheritdoc/>
         public sealed override IList<CustomAttributeData> GetCustomAttributesData() {
-            return new List<CustomAttributeData>();
+            return [];
         }
     }
 }

--- a/src/Kvasir/Translation/Synthetics/SyntheticPropertyInfo.cs
+++ b/src/Kvasir/Translation/Synthetics/SyntheticPropertyInfo.cs
@@ -56,7 +56,7 @@ namespace Kvasir.Translation {
             Name = name;
             PropertyType = propertyType;
             getter_ = new SyntheticMethodInfo(this);
-            annotations_ = annotations.ToList();
+            annotations_ = [..annotations];
         }
 
         /// <inheritdoc/>
@@ -73,7 +73,7 @@ namespace Kvasir.Translation {
 
         /// <inheritdoc/>
         public sealed override IList<CustomAttributeData> GetCustomAttributesData() {
-            return new List<CustomAttributeData>();
+            return [];
         }
 
         /// <inheritdoc/>
@@ -83,7 +83,7 @@ namespace Kvasir.Translation {
 
         /// <inheritdoc/>
         public sealed override ParameterInfo[] GetIndexParameters() {
-            return Array.Empty<ParameterInfo>();
+            return [];
         }
 
         /// <inheritdoc/>

--- a/src/Kvasir/Translation/Synthetics/SyntheticReturnInfo.cs
+++ b/src/Kvasir/Translation/Synthetics/SyntheticReturnInfo.cs
@@ -8,7 +8,7 @@ namespace Kvasir.Translation {
     internal sealed class SyntheticReturnInfo : ParameterInfo {
         /// <inheritdoc/>
         public sealed override IList<CustomAttributeData> GetCustomAttributesData() {
-            return new List<CustomAttributeData>();
+            return [];
         }
     }
 }

--- a/src/Kvasir/Translation/Synthetics/SyntheticType.cs
+++ b/src/Kvasir/Translation/Synthetics/SyntheticType.cs
@@ -84,11 +84,11 @@ namespace Kvasir.Translation {
             ActualType = actualType;
             IsNativelyNullable = nativelyNullable;
             Assembly = assmebly;
-            properties_ = properties(this).ToList();
+            properties_ = [..properties(this)];
 
             // We want to be able to construct a SyntheticType, conceptually, from just the element; the first property
             // is always that of the owning Entity
-            constructors_ = new ConstructorInfo[] { new SyntheticConstructorInfo(this, properties_.Skip(1)) };
+            constructors_ = [new SyntheticConstructorInfo(this, properties_.Skip(1))];
 
             Debug.Assert(properties_.Count >= 2);
         }
@@ -238,12 +238,12 @@ namespace Kvasir.Translation {
 
         /// <inheritdoc/>
         public sealed override IList<CustomAttributeData> GetCustomAttributesData() {
-            return new List<CustomAttributeData>();
+            return [];
         }
 
         /// <inheritdoc/>
         public sealed override Type[] GetInterfaces() {
-            return Array.Empty<Type>();
+            return [];
         }
 
         /// <inheritdoc/>
@@ -251,7 +251,7 @@ namespace Kvasir.Translation {
             Debug.Assert(bindingAttr.HasFlag(BindingFlags.Public) && bindingAttr.HasFlag(BindingFlags.NonPublic));
             Debug.Assert(bindingAttr.HasFlag(BindingFlags.Instance) && bindingAttr.HasFlag(BindingFlags.Static));
 
-            return properties_.ToArray();
+            return [..properties_];
         }
 
         /// <inheritdoc/>

--- a/src/Kvasir/Translation/TranslateEntity.cs
+++ b/src/Kvasir/Translation/TranslateEntity.cs
@@ -114,7 +114,7 @@ namespace Kvasir.Translation {
             // an additional clone
             var pkDescriptors = schemas.Where(s => primaryKey.Fields.Contains(s.Field)).Select(s => s.Descriptor);
             var pkGroups = fieldGroups.Select(g => g.Filter(pkDescriptors)).Where(o => o.HasValue).Select(o => o.Unwrap());
-            pkCache_[source] = pkGroups.ToList();
+            pkCache_[source] = [..pkGroups];
             var pkExtractor = new DataExtractionPlan(pkGroups.OrderBy(g => g.Column.Unwrap()).Select(g => g.Extractor));
 
             var tableName = GetTableName(context, source);
@@ -130,13 +130,13 @@ namespace Kvasir.Translation {
             if (!IsPreDefined(source)) {
                 var reconstitutor = ReconstitutionHelper.MakeCreator(context, source, fieldGroups, false, false);
                 var creator = new DataReconstitutionPlan(reconstitutor);
-                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor, new List<object>());
+                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor, []);
             }
             else {
                 var instances = GetPreDefinedInstances(context, source);
                 var matcher = new KeyMatcher(() => instances, pkExtractor);
                 var creator = MakePreDefinedReconstitutionPlan(context, table, matcher, source);
-                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor, instances.ToList());
+                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor, [..instances]);
             }
 
             principalTableCache_.Add(source, principal);
@@ -355,7 +355,7 @@ namespace Kvasir.Translation {
             // an additional clone
             var pkDescriptors = schemas.Where(s => primaryKey.Fields.Contains(s.Field)).Select(s => s.Descriptor);
             var pkGroups = fieldGroups.Select(g => g.Filter(pkDescriptors)).Where(o => o.HasValue).Select(o => o.Unwrap());
-            pkCache_[source] = pkGroups.ToList();
+            pkCache_[source] = [..pkGroups];
 
             var tableName = GetTableName(context, source);
             if (tableNameCache_.TryGetValue(tableName, out Type? match)) {
@@ -392,7 +392,7 @@ namespace Kvasir.Translation {
                 var instances = GetPreDefinedInstances(context, source);
                 var matcher = new KeyMatcher(() => instances, keyPlan);
                 var creator = MakePreDefinedReconstitutionPlan(context, table, matcher, source);
-                principal = new LocalizationTableDef(table, extractionPlan, creator, repopulationPlan, keyPlan, instances.ToList());
+                principal = new LocalizationTableDef(table, extractionPlan, creator, repopulationPlan, keyPlan, [..instances]);
             }
 
             localizationTableCache_.Add(source, principal);
@@ -400,9 +400,7 @@ namespace Kvasir.Translation {
 
             // The `KeyMatcher` may have been added earlier by `TranslateType`, since we delay the actual translation of
             // the full Localization but need the `KeyMatcher` for extraction logic
-            if (!keyMatchers_.ContainsKey(source)) {
-                keyMatchers_.Add(source, keyMatcher);
-            }
+            keyMatchers_.TryAdd(source, keyMatcher);
 
             logger_.LogDebug("Translation of Principal Table for {} . . .", source.Name);
             return principal;

--- a/src/Kvasir/Translation/TranslatePreDefineds.cs
+++ b/src/Kvasir/Translation/TranslatePreDefineds.cs
@@ -49,7 +49,7 @@ namespace Kvasir.Translation {
             var statics = source.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
             var possibleInstances = statics.Where(p => p.PropertyType == source);
 
-            List<object> instances = new List<object>();
+            List<object> instances = [];
             foreach (var candidate in possibleInstances) {
                 using var propGuard = context.Push(candidate);
 
@@ -134,7 +134,7 @@ namespace Kvasir.Translation {
             }
 
             var creator = new PreDefinedCreator(table, matcher);
-            var reconstitutor = new ReconstitutingCreator(creator, Enumerable.Empty<IMutator>());
+            var reconstitutor = new ReconstitutingCreator(creator, []);
             return new DataReconstitutionPlan(reconstitutor);
         }
     }

--- a/src/Kvasir/Translation/TranslateType.cs
+++ b/src/Kvasir/Translation/TranslateType.cs
@@ -228,14 +228,14 @@ namespace Kvasir.Translation {
             }
 
             AssignColumns(context, translation);
-            typeCache_[source] = translation.ToList();
+            typeCache_[source] = [..translation];
             relationTrackersCache_[source] = relationTrackers;
             localizationTrackersCache_[source] = localizationTrackers;
 
             // It's important to return a concrete collection here rather than the result of a LINQ query because we do
             // not want to re-evaluate the `Clone()` operation multiple times. Doing so will cause issues with Primary
             // Key extraction due to the use of identity equality.
-            return translation.Select(g => g.Clone()).ToList();
+            return [..translation.Select(g => g.Clone())];
         }
 
         /// <summary>

--- a/src/Kvasir/Translation/Translator.cs
+++ b/src/Kvasir/Translation/Translator.cs
@@ -162,17 +162,17 @@ namespace Kvasir.Translation {
             settings_ = settings;
             callingAssembly_ = Assembly.GetCallingAssembly();
             entityLookup_ = entityLookup;
-            typeCache_ = new Dictionary<Type, IReadOnlyList<FieldGroup>>();
-            translationCache_ = new Dictionary<Type, EntityTranslation>();
-            localizationCache_ = new Dictionary<Type, LocalizationTranslation>();
-            principalTableCache_ = new Dictionary<Type, PrincipalTableDef>();
-            localizationTableCache_ = new Dictionary<Type, LocalizationTableDef>();
-            tableNameCache_ = new Dictionary<TableName, Type>();
-            pkCache_ = new Dictionary<Type, IReadOnlyList<FieldGroup>>();
-            relationTrackersCache_ = new Dictionary<Type, IReadOnlyList<RelationTracker>>();
-            localizationTrackersCache_ = new Dictionary<Type, IReadOnlyList<LocalizationTracker>>();
-            keyMatchers_ = new Dictionary<Type, KeyMatcher>();
-            relationTypesFromEntity_ = new Dictionary<Type, IReadOnlyList<Type>>();
+            typeCache_ = [];
+            translationCache_ = [];
+            localizationCache_ = [];
+            principalTableCache_ = [];
+            localizationTableCache_ = [];
+            tableNameCache_ = [];
+            pkCache_ = [];
+            relationTrackersCache_ = [];
+            localizationTrackersCache_ = [];
+            keyMatchers_ = [];
+            relationTypesFromEntity_ = [];
             logger_ = logger;
         }
 

--- a/src/Kvasir/Translation/Utility/Display.cs
+++ b/src/Kvasir/Translation/Utility/Display.cs
@@ -122,7 +122,7 @@ namespace Kvasir.Translation {
                 // Anything else
                 else {
                     var generic = self.GetGenericTypeDefinition().Name;
-                    return $"`{generic[..generic.IndexOf("`")]}<{string.Join(", ", args)}>`";
+                    return $"`{generic[..generic.IndexOf('`')]}<{string.Join(", ", args)}>`";
                 }
             }
 

--- a/src/Kvasir/Translation/Utility/FieldName.cs
+++ b/src/Kvasir/Translation/Utility/FieldName.cs
@@ -37,7 +37,7 @@ namespace Kvasir.Translation {
             Debug.Assert(name is not null && name != "");
 
             namePart_ = name;
-            prefixPart_ = new List<string>();
+            prefixPart_ = [];
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Kvasir.Translation {
             Debug.Assert(source is not null);
 
             namePart_ = source.namePart_;
-            prefixPart_ = new List<string>(source.prefixPart_);
+            prefixPart_ = [..source.prefixPart_];
         }
 
         /// <summary>

--- a/test/UnitTests/Atropos/FullCheck/_TestClass.cs
+++ b/test/UnitTests/Atropos/FullCheck/_TestClass.cs
@@ -33,7 +33,7 @@ namespace UT.Atropos {
             }
 
 
-            private readonly IDictionary<CallKey, int> tracker_;
+            private readonly ConcurrentDictionary<CallKey, int> tracker_;
         }
         protected sealed class Controller {
             public enum EqFailureKey { LeqR, ReqL, LneqR, RneqL, LstrongR, RstrongL, LweakR, RweakL, Hash };
@@ -115,8 +115,8 @@ namespace UT.Atropos {
             }
 
 
-            private readonly IReadOnlyDictionary<EqFailureKey, CallKey> equalityFamilies_;
-            private readonly IReadOnlyDictionary<CompFailureKey, CallKey> comparisonFamilies_;
+            private readonly Dictionary<EqFailureKey, CallKey> equalityFamilies_;
+            private readonly Dictionary<CompFailureKey, CallKey> comparisonFamilies_;
             private int hashCodeInvokeCount_;
         }
 

--- a/test/UnitTests/Cybele/Collections/StickyListTests.cs
+++ b/test/UnitTests/Cybele/Collections/StickyListTests.cs
@@ -112,10 +112,11 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void InsertStickyDisplaceNonStickyToEnd() {
             // Arrange
-            var list = new StickyList<string>();
-            list.Add("Harrisburg");
-            list.Add("Scottsdale");
-            list.Add("Bentonville");
+            var list = new StickyList<string>() {
+                "Harrisburg",
+                "Scottsdale",
+                "Bentonville"
+            };
 
             // Act
             list.HasGaps.Should().BeFalse();
@@ -131,8 +132,7 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void InsertStickyDisplaceNonStickToGap() {
             // Arrange
-            var list = new StickyList<string>();
-            list.Add("Bakersfield");
+            var list = new StickyList<string>() { "Bakersfield" };
             list[2] = "Lincoln";
 
             // Act
@@ -177,8 +177,7 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void RemoveFromEnd() {
             // Arrange
-            var list = new StickyList<DateTime>();
-            list.Add(new DateTime(1984, 7, 12));
+            var list = new StickyList<DateTime>() { new DateTime(1984, 7, 12) };
             list.Insert(8, new DateTime(2021, 7, 23));
             list.Add(new DateTime(1988, 9, 17));
             list.Insert(4, new DateTime(2000, 9, 15));
@@ -200,8 +199,7 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void RemoveCreateGaps() {
             // Arrange
-            var list = new StickyList<char>();
-            list.Add('*');
+            var list = new StickyList<char>() { '*' };
             list.Insert(3, '+');
             list.Add('0');
             list.Add('\'');
@@ -259,10 +257,11 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void RemoveMissingElement() {
             // Arrange
-            var list = new StickyList<int>();
-            list[8] = 192;
-            list[2] = 192;
-            list[17] = 192;
+            var list = new StickyList<int>() {
+                [8] = 192,
+                [2] = 192,
+                [17] = 192
+            };
 
             // Act
             var result = list.Remove(2);
@@ -301,8 +300,7 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void Clear() {
             // Arrange
-            var list = new StickyList<char>();
-            list.Add('&');
+            var list = new StickyList<char>() { '&' };
             list.Insert(4, '%');
             list.Add('E');
             list.Add('=');
@@ -334,10 +332,7 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void GetItemOutOfBounds() {
             // Arrange
-            var list = new StickyList<int>();
-            list.Add(35);
-            list.Add(-1);
-            list.Add(0);
+            var list = new StickyList<int>() { 35, -1, 0 };
 
             // Act
             Func<int> actPos = () => list[25];
@@ -364,11 +359,7 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void IndexOfExistingItem() {
             // Arrange
-            var list = new StickyList<char>();
-            list.Add('7');
-            list.Add('u');
-            list.Add('_');
-            list.Add('í');
+            var list = new StickyList<char>() { '7', 'u', '_', 'í' };
 
             // Act
             var idx0 = list.IndexOf('7');        // the order of these is guarnated because no removals have occurred
@@ -385,10 +376,11 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void IndexOfExistingItemCustomComparer() {
             // Arrange
-            var list = new StickyList<string>(StringComparer.OrdinalIgnoreCase);
-            list.Add("Lubbock");
-            list.Add("Kalamazoo");
-            list.Add("Mobile");
+            var list = new StickyList<string>(StringComparer.OrdinalIgnoreCase) {
+                "Lubbock",
+                "Kalamazoo",
+                "Mobile"
+            };
 
             // Act
             var idx0 = list.IndexOf("LuBbOCK");  // the order of these is guaranteed because no removals have ocurred
@@ -403,10 +395,7 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void IndexOfMissingItem() {
             // Arrange
-            var list = new StickyList<double>();
-            list.Add(double.MinValue);
-            list.Add(double.MaxValue);
-            list.Add(double.Epsilon);
+            var list = new StickyList<double>() { double.MinValue, double.MaxValue, double.Epsilon };
 
             // Act
             var idx0 = list.IndexOf(38);
@@ -419,8 +408,7 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void ContainsExistingItem() {
             // Arrange
-            var list = new StickyList<string>();
-            list.Add("South Bend");
+            var list = new StickyList<string>() { "South Bend" };
             list.Insert(0, "Pasadena");
             list.Insert(4, "Fargo");
 
@@ -469,12 +457,7 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void QuerySlotsPastTheEnd() {
             // Arrange
-            var list = new StickyList<int>();
-            list.Add(2);
-            list.Add(-110);
-            list.Add(int.MaxValue);
-            list.Add(int.MinValue);
-            list.Add(0);
+            var list = new StickyList<int>() { 2, -110, int.MaxValue, int.MinValue, 0 };
 
             // Act & Assert
             for (var i = list.Count; i < list.Count + 100; ++i) {
@@ -501,9 +484,7 @@ namespace UT.Cybele.Collections {
 
         [TestMethod] public void CopyToArray() {
             // Arrange
-            var list = new StickyList<char>();
-            list.Add('h');
-            list.Add('~');
+            var list = new StickyList<char>() { 'h', '~' };
             list.Insert(37, '(');
             list.Insert(44, ')');
             list.Add(',');

--- a/test/UnitTests/Cybele/Core/DataConverter.cs
+++ b/test/UnitTests/Cybele/Core/DataConverter.cs
@@ -16,8 +16,8 @@ namespace UT.Cybele.Core {
             var converter = DataConverter.Create(fn);
 
             // Assert
-            converter.SourceType.Should().Be(typeof(int));
-            converter.ResultType.Should().Be(typeof(string));
+            converter.SourceType.Should().Be<int>();
+            converter.ResultType.Should().Be<string>();
             converter.IsBidirectional.Should().BeFalse();
         }
 
@@ -30,8 +30,8 @@ namespace UT.Cybele.Core {
             var converter = DataConverter.Create(fwd, bwd);
 
             // Assert
-            converter.SourceType.Should().Be(typeof(int));
-            converter.ResultType.Should().Be(typeof(string));
+            converter.SourceType.Should().Be<int>();
+            converter.ResultType.Should().Be<string>();
             converter.IsBidirectional.Should().BeTrue();
         }
 
@@ -46,7 +46,7 @@ namespace UT.Cybele.Core {
             var conversion = converter.Convert(source);
 
             // Assert
-            conversion!.GetType().Should().Be(typeof(int));
+            conversion!.GetType().Should().Be<int>();
             conversion.Should().Be(expected);
         }
 
@@ -61,7 +61,7 @@ namespace UT.Cybele.Core {
             var conversion = converter.Convert(source);
 
             // Assert
-            conversion!.GetType().Should().Be(typeof(string));
+            conversion!.GetType().Should().Be<string>();
             conversion.Should().Be(expected);
         }
 
@@ -76,7 +76,7 @@ namespace UT.Cybele.Core {
             var conversion = converter.Convert(source);
 
             // Assert
-            conversion!.GetType().Should().Be(typeof(int));
+            conversion!.GetType().Should().Be<int>();
             conversion.Should().Be(expected);
         }
 
@@ -92,7 +92,7 @@ namespace UT.Cybele.Core {
             var reversion = converter.Revert(result);
 
             // Assert
-            reversion!.GetType().Should().Be(typeof(string));
+            reversion!.GetType().Should().Be<string>();
             reversion.Should().Be(expected);
         }
 
@@ -108,13 +108,13 @@ namespace UT.Cybele.Core {
             var reversion = converter.Revert(result);
 
             // Assert
-            reversion!.GetType().Should().Be(typeof(string));
+            reversion!.GetType().Should().Be<string>();
             reversion.Should().Be(expected);
         }
 
         [TestMethod] public void BackwardConversionImplementationType() {
             // Arrange
-            Converter<int, IReadOnlyList<string>> fwd = i => Enumerable.Repeat("???", i).ToList();
+            Converter<int, IReadOnlyList<string>> fwd = i => [..Enumerable.Repeat("???", i)];
             Converter<IReadOnlyList<string>, int> bwd = e => e.Count;
             var converter = DataConverter.Create(fwd, bwd);
             var result = new List<string>() { "Toledo", "Norfolk", "Carson City", "Minneapolis", "Miami" };
@@ -124,7 +124,7 @@ namespace UT.Cybele.Core {
             var reversion = converter.Revert(result);
 
             // Assert
-            reversion!.GetType().Should().Be(typeof(int));
+            reversion!.GetType().Should().Be<int>();
             reversion.Should().Be(expected);
         }
         
@@ -175,8 +175,8 @@ namespace UT.Cybele.Core {
             var reversion = converter.Revert(conversion);
 
             // Assert
-            converter.SourceType.Should().Be(typeof(double));
-            converter.ResultType.Should().Be(typeof(double));
+            converter.SourceType.Should().Be<double>();
+            converter.ResultType.Should().Be<double>();
             converter.IsBidirectional.Should().BeTrue();
             conversion.Should().Be(source);
             reversion.Should().Be(source);
@@ -192,8 +192,8 @@ namespace UT.Cybele.Core {
             var reversion = converter.Revert(conversion);
 
             // Assert
-            converter.SourceType.Should().Be(typeof(double));
-            converter.ResultType.Should().Be(typeof(double));
+            converter.SourceType.Should().Be<double>();
+            converter.ResultType.Should().Be<double>();
             converter.IsBidirectional.Should().BeTrue();
             conversion.Should().Be(source);
             reversion.Should().Be(source);

--- a/test/UnitTests/Cybele/Core/PropertyChain.cs
+++ b/test/UnitTests/Cybele/Core/PropertyChain.cs
@@ -8,7 +8,7 @@ namespace UT.Cybele.Core {
     [TestClass, TestCategory("PropertyChain")]
     public sealed class PropertyChainTests {
         [TestMethod] public void ConstructFromReadableProperty() {
-            void evaluate(string propertyName) {
+            static void evaluate(string propertyName) {
                 // Arrange
                 var property = typeof(Leaf).GetProperty(propertyName, ANY_PROPERTY)!;
 
@@ -48,7 +48,7 @@ namespace UT.Cybele.Core {
         }
 
         [TestMethod] public void ConstructFromReadablePropertyName() {
-            void evaluate(string propertyName) {
+            static void evaluate(string propertyName) {
                 // Arrange
                 var property = typeof(Leaf).GetProperty(propertyName, ANY_PROPERTY)!;
 
@@ -83,8 +83,8 @@ namespace UT.Cybele.Core {
             var chain = new PropertyChain(typeof(Leaf), nameof(Leaf.Hide));
 
             // Assert
-            chain.ReflectedType.Should().Be(typeof(Leaf));
-            chain.PropertyType.Should().Be(typeof(DateTimeOffset));
+            chain.ReflectedType.Should().Be<Leaf>();
+            chain.PropertyType.Should().Be<DateTimeOffset>();
             chain.Length.Should().Be(1);
         }
 
@@ -121,7 +121,7 @@ namespace UT.Cybele.Core {
         }
 
         [TestMethod] public void ImplicitConvertFromReadableProperty() {
-            void evaluate(string propertyName) {
+            static void evaluate(string propertyName) {
                 // Arrange
                 var property = typeof(Leaf).GetProperty(propertyName, ANY_PROPERTY)!;
 
@@ -164,7 +164,7 @@ namespace UT.Cybele.Core {
             // Scenario: Given a PropertyChain whose current PropertyType is T, append a PropertyInfo that represents a
             //   readable property obtained via reflection on exactly T
 
-            void evaluate(string propertyName) {
+            static void evaluate(string propertyName) {
                 // Arrange
                 var original = new PropertyChain(typeof(Leaf), nameof(Leaf.Self));
                 var property = typeof(Leaf).GetProperty(propertyName, ANY_PROPERTY)!;
@@ -291,7 +291,7 @@ namespace UT.Cybele.Core {
             // Scenario: Given a PropertyChain whose current PropertyType is T, append a property by name that is first
             //   defined by T
 
-            void evaluate(string propertyName) {
+            static void evaluate(string propertyName) {
                 // Arrange
                 var original = new PropertyChain(typeof(Leaf), nameof(Leaf.Self));
                 var property = typeof(Leaf).GetProperty(propertyName, ANY_PROPERTY)!;
@@ -349,7 +349,7 @@ namespace UT.Cybele.Core {
             // Assert
             chain.Should().NotBeSameAs(original);
             chain.ReflectedType.Should().Be(original.ReflectedType);
-            chain.PropertyType.Should().Be(typeof(DateTimeOffset));
+            chain.PropertyType.Should().Be<DateTimeOffset>();
             chain.Length.Should().Be(original.Length + 1);
         }
 
@@ -1051,7 +1051,7 @@ namespace UT.Cybele.Core {
         }
 
         [TestMethod] public void GetValueFromNonPublicProperty() {
-            void evaluate(string propertyName, string expectedValue) {
+            static void evaluate(string propertyName, string expectedValue) {
                 // Arrange
                 var chain = new PropertyChain(typeof(Leaf), propertyName);
                 var input = new Leaf();
@@ -1070,7 +1070,7 @@ namespace UT.Cybele.Core {
         }
 
         [TestMethod] public void GetValueFromStaticProperty() {
-            void evaluate(string propertyName, int expectedValue) {
+            static void evaluate(string propertyName, int expectedValue) {
                 // Arrange
                 var chain = new PropertyChain(typeof(Leaf), propertyName);
                 var input = new Leaf();

--- a/test/UnitTests/Cybele/Extensions/Object.cs
+++ b/test/UnitTests/Cybele/Extensions/Object.cs
@@ -176,7 +176,7 @@ namespace UT.Cybele.Extensions {
 
         [TestMethod] public void DispalyEmptyArray() {
             // Arrange
-            var array = new object[] {};
+            var array = Array.Empty<object>();
 
             // Act
             var arrayDisplay = array.ForDisplay();

--- a/test/UnitTests/Cybele/Extensions/Type.cs
+++ b/test/UnitTests/Cybele/Extensions/Type.cs
@@ -279,7 +279,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(char));
+            property.Unwrap().PropertyType.Should().Be<char>();
         }
 
         [TestMethod] public void PrivateInstanceProperty() {
@@ -295,7 +295,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(ushort));
+            property.Unwrap().PropertyType.Should().Be<ushort>();
         }
 
         [TestMethod] public void InternalInstanceProperty() {
@@ -311,7 +311,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(long));
+            property.Unwrap().PropertyType.Should().Be<long>();
         }
 
         [TestMethod] public void ProtectedInstanceProperty() {
@@ -327,7 +327,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(ulong));
+            property.Unwrap().PropertyType.Should().Be<ulong>();
         }
 
         [TestMethod] public void PublicStaticProperty() {
@@ -343,7 +343,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(uint));
+            property.Unwrap().PropertyType.Should().Be<uint>();
         }
 
         [TestMethod] public void PrivateStaticProperty() {
@@ -359,7 +359,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(byte));
+            property.Unwrap().PropertyType.Should().Be<byte>();
         }
 
         [TestMethod] public void InternalStaticProperty() {
@@ -375,7 +375,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(sbyte));
+            property.Unwrap().PropertyType.Should().Be<sbyte>();
         }
 
         [TestMethod] public void ProtectedStaticProperty() {
@@ -391,7 +391,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(decimal));
+            property.Unwrap().PropertyType.Should().Be<decimal>();
         }
 
         [TestMethod] public void InheritedProperty() {
@@ -405,9 +405,9 @@ namespace UT.Cybele.Extensions {
             // Assert
             property.HasValue.Should().BeTrue();
             property.Unwrap().Name.Should().Be(propertyName);
-            property.Unwrap().DeclaringType.Should().Be(typeof(FooBase));
+            property.Unwrap().DeclaringType.Should().Be<FooBase>();
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(double));
+            property.Unwrap().PropertyType.Should().Be<double>();
         }
 
         [TestMethod] public void OverridingProperty() {
@@ -421,9 +421,9 @@ namespace UT.Cybele.Extensions {
             // Assert
             property.HasValue.Should().BeTrue();
             property.Unwrap().Name.Should().Be(propertyName);
-            property.Unwrap().DeclaringType.Should().Be(typeof(Foo));
+            property.Unwrap().DeclaringType.Should().Be<Foo>();
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(string));
+            property.Unwrap().PropertyType.Should().Be<string>();
         }
 
         [TestMethod] public void AbstractProperty() {
@@ -437,9 +437,9 @@ namespace UT.Cybele.Extensions {
             // Assert
             property.HasValue.Should().BeTrue();
             property.Unwrap().Name.Should().Be(propertyName);
-            property.Unwrap().DeclaringType.Should().Be(typeof(FooBase));
+            property.Unwrap().DeclaringType.Should().Be<FooBase>();
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(short));
+            property.Unwrap().PropertyType.Should().Be<short>();
         }
 
         [TestMethod] public void ImplicitInterfaceProperty() {
@@ -453,9 +453,9 @@ namespace UT.Cybele.Extensions {
             // Assert
             property.HasValue.Should().BeTrue();
             property.Unwrap().Name.Should().Be(propertyName);
-            property.Unwrap().DeclaringType.Should().Be(typeof(Foo));
+            property.Unwrap().DeclaringType.Should().Be<Foo>();
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(int));
+            property.Unwrap().PropertyType.Should().Be<int>();
         }
 
         [TestMethod] public void ExplicitInterfaceProperty() {
@@ -469,9 +469,9 @@ namespace UT.Cybele.Extensions {
             // Assert
             property.HasValue.Should().BeTrue();
             property.Unwrap().Name.Should().EndWith($".{propertyName}");
-            property.Unwrap().DeclaringType.Should().Be(typeof(Foo));
+            property.Unwrap().DeclaringType.Should().Be<Foo>();
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(bool));
+            property.Unwrap().PropertyType.Should().Be<bool>();
         }
 
         [TestMethod] public void ExplicitInterfacePropertyAndRegularProperty_IsError() {
@@ -511,7 +511,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(Type));
+            property.Unwrap().PropertyType.Should().Be<Type>();
         }
 
         [TestMethod] public void InheritedNewHidingProperty() {
@@ -525,9 +525,9 @@ namespace UT.Cybele.Extensions {
             // Assert
             property.HasValue.Should().BeTrue();
             property.Unwrap().Name.Should().Be(propertyName);
-            property.Unwrap().DeclaringType.Should().Be(typeof(FooIntermediate));
+            property.Unwrap().DeclaringType.Should().Be<FooIntermediate>();
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(DateTime));
+            property.Unwrap().PropertyType.Should().Be<DateTime>();
         }
 
         [TestMethod] public void SingleIndexer() {
@@ -543,7 +543,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(bool?));
+            property.Unwrap().PropertyType.Should().Be<bool?>();
         }
 
         [TestMethod] public void MultipleIndexers_IsError() {
@@ -571,7 +571,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(ushort?));
+            property.Unwrap().PropertyType.Should().Be<ushort?>();
         }
 
         [TestMethod] public void ReadOnlyProperty() {
@@ -587,7 +587,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(int?));
+            property.Unwrap().PropertyType.Should().Be<int?>();
         }
 
         [TestMethod] public void WriteOnlyProperty() {
@@ -603,7 +603,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(char?));
+            property.Unwrap().PropertyType.Should().Be<char?>();
         }
 
         [TestMethod] public void InitOnlyProperty() {
@@ -619,7 +619,7 @@ namespace UT.Cybele.Extensions {
             property.Unwrap().Name.Should().Be(propertyName);
             property.Unwrap().DeclaringType.Should().Be(type);
             property.Unwrap().ReflectedType.Should().Be(type);
-            property.Unwrap().PropertyType.Should().Be(typeof(double?));
+            property.Unwrap().PropertyType.Should().Be<double?>();
         }
 
 

--- a/test/UnitTests/GlobalSuppressions.cs
+++ b/test/UnitTests/GlobalSuppressions.cs
@@ -5,3 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Naming", "VSSpell001:Spell Check", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0290:Use primary constructor", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0090:'new' expression can be simplified", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0039:Use local function", Scope = "module")]

--- a/test/UnitTests/Kvasir/Annotations/CheckAttributes.cs
+++ b/test/UnitTests/Kvasir/Annotations/CheckAttributes.cs
@@ -142,7 +142,7 @@ namespace UT.Kvasir.Annotations {
             var constraintType = typeof(ErrorConstraint);
 
             // Act
-            var attr = new Check.ComplexAttribute<ErrorConstraint>(new string[] { "F0", "F1" });
+            var attr = new Check.ComplexAttribute<ErrorConstraint>(["F0", "F1"]);
 
             // Assert
             attr.UserError.Should()

--- a/test/UnitTests/Kvasir/Annotations/_Base.cs
+++ b/test/UnitTests/Kvasir/Annotations/_Base.cs
@@ -2,6 +2,6 @@ using System.Collections.Generic;
 
 namespace UT.Kvasir.Annotations {
     public abstract class AnnotationTestBase {
-        protected static readonly HashSet<object> ids_ = new HashSet<object>();
+        protected static readonly HashSet<object> ids_ = [];
     }
 }

--- a/test/UnitTests/Kvasir/Core/EnumConverters.cs
+++ b/test/UnitTests/Kvasir/Core/EnumConverters.cs
@@ -19,7 +19,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(byte));
+            impl.ResultType.Should().Be<byte>();
             conversion.Should().Be((byte)1);
             reversion.Should().Be(enumerator);
         }
@@ -37,7 +37,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(int));
+            impl.ResultType.Should().Be<int>();
             conversion.Should().Be(3);
             reversion.Should().Be(enumerator);
         }
@@ -55,7 +55,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(long));
+            impl.ResultType.Should().Be<long>();
             conversion.Should().Be(2L);
             reversion.Should().Be(enumerator);
         }
@@ -73,7 +73,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(sbyte));
+            impl.ResultType.Should().Be<sbyte>();
             conversion.Should().Be((sbyte)2);
             reversion.Should().Be(enumerator);
         }
@@ -91,7 +91,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(short));
+            impl.ResultType.Should().Be<short>();
             conversion.Should().Be((short)1);
             reversion.Should().Be(enumerator);
         }
@@ -109,7 +109,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(uint));
+            impl.ResultType.Should().Be<uint>();
             conversion.Should().Be(0U);
             reversion.Should().Be(enumerator);
         }
@@ -127,7 +127,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(ulong));
+            impl.ResultType.Should().Be<ulong>();
             conversion.Should().Be(3UL);
             reversion.Should().Be(enumerator);
         }
@@ -145,7 +145,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(ushort));
+            impl.ResultType.Should().Be<ushort>();
             conversion.Should().Be((ushort)2);
             reversion.Should().Be(enumerator);
         }
@@ -163,7 +163,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(byte));
+            impl.ResultType.Should().Be<byte>();
             conversion.Should().Be(null);
             reversion.Should().Be(enumerator);
         }
@@ -181,7 +181,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(int));
+            impl.ResultType.Should().Be<int>();
             conversion.Should().Be(null);
             reversion.Should().Be(enumerator);
         }
@@ -199,7 +199,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(long));
+            impl.ResultType.Should().Be<long>();
             conversion.Should().Be(null);
             reversion.Should().Be(enumerator);
         }
@@ -217,7 +217,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(sbyte));
+            impl.ResultType.Should().Be<sbyte>();
             conversion.Should().Be(null);
             reversion.Should().Be(enumerator);
         }
@@ -235,7 +235,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(short));
+            impl.ResultType.Should().Be<short>();
             conversion.Should().Be(null);
             reversion.Should().Be(enumerator);
         }
@@ -253,7 +253,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(uint));
+            impl.ResultType.Should().Be<uint>();
             conversion.Should().Be(null);
             reversion.Should().Be(enumerator);
         }
@@ -271,7 +271,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(ulong));
+            impl.ResultType.Should().Be<ulong>();
             conversion.Should().Be(null);
             reversion.Should().Be(enumerator);
         }
@@ -289,7 +289,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(ushort));
+            impl.ResultType.Should().Be<ushort>();
             conversion.Should().Be(null);
             reversion.Should().Be(enumerator);
         }
@@ -307,7 +307,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(string));
+            impl.ResultType.Should().Be<string>();
             conversion.Should().Be("Water");
             reversion.Should().Be(enumerator);
         }
@@ -325,7 +325,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(string));
+            impl.ResultType.Should().Be<string>();
             conversion.Should().Be("Disabled");
             reversion.Should().Be(enumerator);
         }
@@ -343,7 +343,7 @@ namespace UT.Kvasir.Core {
 
             // Assert
             impl.SourceType.Should().Be(type);
-            impl.ResultType.Should().Be(typeof(string));
+            impl.ResultType.Should().Be<string>();
             conversion.Should().Be("On|Enabled|Mixed");
             reversion.Should().Be(enumerator);
         }

--- a/test/UnitTests/Kvasir/Extraction/Extractors.cs
+++ b/test/UnitTests/Kvasir/Extraction/Extractors.cs
@@ -28,7 +28,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(path.ReflectedType);
             extractor.ResultType.Should().Be(path.PropertyType);
             datum.Should().Be(source.Nanosecond);
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
         }
 
         [TestMethod] public void ExtractFromDerived() {
@@ -45,12 +45,12 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(path.ReflectedType);
             extractor.ResultType.Should().Be(path.PropertyType);
             datum.Should().Be(source.Message);
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
         }
 
         [TestMethod] public void ExtractFromImplementation() {
             // Arrange
-            var path = new PropertyChain(typeof(ICollection<string>), nameof(ICollection<string>.Count));
+            var path = new PropertyChain(typeof(ICollection<string>), nameof(ICollection<>.Count));
 
             // Act
             var source = new List<string>() { "Pisa", "Manaus", "İzmir", "Abbottabad", "Split" };
@@ -62,7 +62,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(path.ReflectedType);
             extractor.ResultType.Should().Be(path.PropertyType);
             datum.Should().Be(source.Count);
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
         }
 
         [TestMethod] public void ExtractFromNull() {
@@ -78,7 +78,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(path.ReflectedType);
             extractor.ResultType.Should().Be(path.PropertyType);
             datum.Should().BeNull();
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
         }
 
         [TestMethod] public void ExtractFromNonPublicProperty() {
@@ -95,7 +95,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(path.ReflectedType);
             extractor.ResultType.Should().Be(path.PropertyType);
             datum.Should().Be(source.ToString());
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
         }
 
         [TestMethod] public void ExtractFromStaticProperty() {
@@ -112,7 +112,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(path.ReflectedType);
             extractor.ResultType.Should().Be(path.PropertyType);
             datum.Should().Be(DBValue.NULL);
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
         }
 
         [TestMethod] public void ExtractionProducesNull() {
@@ -129,7 +129,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(path.ReflectedType);
             extractor.ResultType.Should().Be(path.PropertyType);
             datum.Should().BeNull();
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
         }
 
         [TestMethod] public void ExtractionPropertyTypeIsNullable() {
@@ -142,7 +142,7 @@ namespace UT.Kvasir.Extraction {
 
             // Assert
             extractor.SourceType.Should().Be(type);
-            extractor.ResultType.Should().Be(typeof(char));
+            extractor.ResultType.Should().Be<char>();
         }
     }
 
@@ -167,7 +167,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(originalExtractor.SourceType);
             extractor.ResultType.Should().Be(converter.ResultType);
             datum.Should().Be(converter.Convert(unconvertedValue));
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
             originalExtractor.Received().ExtractFrom(source);
         }
 
@@ -190,7 +190,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(originalExtractor.SourceType);
             extractor.ResultType.Should().Be(converter.ResultType);
             datum.Should().Be(converter.Convert(unconvertedValue));
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
             originalExtractor.Received().ExtractFrom(source);
         }
 
@@ -213,7 +213,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(originalExtractor.SourceType);
             extractor.ResultType.Should().Be(converter.ResultType);
             datum.Should().Be(converter.Convert(unconvertedValue));
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
             originalExtractor.Received().ExtractFrom(source);
         }
 
@@ -234,7 +234,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(originalExtractor.SourceType);
             extractor.ResultType.Should().Be(converter.ResultType);
             datum.Should().BeNull();
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
         }
 
         [TestMethod] public void OriginalExtractionProducesNull() {
@@ -255,7 +255,7 @@ namespace UT.Kvasir.Extraction {
             extractor.SourceType.Should().Be(originalExtractor.SourceType);
             extractor.ResultType.Should().Be(converter.ResultType);
             datum.Should().BeNull();
-            multiDatum.Should().BeEquivalentTo(new object?[] { datum });
+            multiDatum.Should().BeEquivalentTo([datum]);
             originalExtractor.Received().ExtractFrom(source);
         }
 
@@ -270,8 +270,8 @@ namespace UT.Kvasir.Extraction {
             var extractor = new ConvertingExtractor(originalExtractor, converter);
 
             // Assert
-            extractor.SourceType.Should().Be(typeof(int));
-            extractor.ResultType.Should().Be(typeof(int));
+            extractor.SourceType.Should().Be<int>();
+            extractor.ResultType.Should().Be<int>();
         }
     }
 
@@ -290,7 +290,7 @@ namespace UT.Kvasir.Extraction {
 
             // Act
             var source = new Queue<string>();
-            var extractor = new DecomposingExtractor(new IMultiExtractor[] { firstSubExtractor, secondSubExtractor });
+            var extractor = new DecomposingExtractor([firstSubExtractor, secondSubExtractor]);
             var data = extractor.ExtractFrom(source);
 
             // Assert
@@ -309,7 +309,7 @@ namespace UT.Kvasir.Extraction {
 
             // Act
             var source = typeof(PropertyInfo).GetProperties()[0];
-            var extractor = new DecomposingExtractor(new IMultiExtractor[] { firstSubExtractor });
+            var extractor = new DecomposingExtractor([firstSubExtractor]);
             var data = extractor.ExtractFrom(source);
 
             // Assert
@@ -335,7 +335,7 @@ namespace UT.Kvasir.Extraction {
 
             // Act
             var source = "Mayagüez";
-            var extractor = new DecomposingExtractor(new IMultiExtractor[] { firstSubExtractor, secondSubExtractor, thirdSubExtractor });
+            var extractor = new DecomposingExtractor([firstSubExtractor, secondSubExtractor, thirdSubExtractor]);
             var data = extractor.ExtractFrom(source);
 
             // Assert
@@ -354,7 +354,7 @@ namespace UT.Kvasir.Extraction {
             firstSubExtractor.ExtractFrom(null).Returns(firstValues);
 
             // Act
-            var extractor = new DecomposingExtractor(new IMultiExtractor[] { firstSubExtractor });
+            var extractor = new DecomposingExtractor([firstSubExtractor]);
             var data = extractor.ExtractFrom(null);
 
             // Assert
@@ -375,7 +375,7 @@ namespace UT.Kvasir.Extraction {
             secondSubExtractor.ExtractFrom(null).Returns(secondValues);
 
             // Act
-            var extractor = new DecomposingExtractor(new IMultiExtractor[] { firstSubExtractor, secondSubExtractor });
+            var extractor = new DecomposingExtractor([firstSubExtractor, secondSubExtractor]);
             var data = extractor.ExtractFrom(null);
 
             // Assert

--- a/test/UnitTests/Kvasir/Extraction/LocalizationExtractionPlan.cs
+++ b/test/UnitTests/Kvasir/Extraction/LocalizationExtractionPlan.cs
@@ -238,8 +238,8 @@ namespace UT.Kvasir.Extraction {
         private static DataExtractionPlan MakePlanFor<T>() {
             var identity = Substitute.For<IMultiExtractor>();
             identity.SourceType.Returns(typeof(T));
-            identity.ExtractFrom(Arg.Any<T>()).Returns(args => new object?[] { args[0] });
-            return new DataExtractionPlan(new IMultiExtractor[] { identity });
+            identity.ExtractFrom(Arg.Any<T>()).Returns(args => [args[0]]);
+            return new DataExtractionPlan([identity]);
         }
     }
 }

--- a/test/UnitTests/Kvasir/Extraction/RelationExtractionPlan.cs
+++ b/test/UnitTests/Kvasir/Extraction/RelationExtractionPlan.cs
@@ -226,8 +226,8 @@ namespace UT.Kvasir.Extraction {
         private static DataExtractionPlan MakePlanFor<T>() {
             var identity = Substitute.For<IMultiExtractor>();
             identity.SourceType.Returns(typeof(T));
-            identity.ExtractFrom(Arg.Any<T>()).Returns(args => new object?[] { args[0] });
-            return new DataExtractionPlan(new IMultiExtractor[] { identity });
+            identity.ExtractFrom(Arg.Any<T>()).Returns(args => [args[0]]);
+            return new DataExtractionPlan([identity]);
         }
     }
 }

--- a/test/UnitTests/Kvasir/Providers/MySQL.cs
+++ b/test/UnitTests/Kvasir/Providers/MySQL.cs
@@ -24,7 +24,7 @@ namespace UT.Kvasir.Providers {
 
             // Act
             var builder = new KeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             var sql = builder.Build();
 
             // Assert
@@ -40,7 +40,7 @@ namespace UT.Kvasir.Providers {
             // Act
             var builder = new KeyBuilder();
             builder.SetName(keyName);
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             var sql = builder.Build();
 
             // Assert
@@ -58,7 +58,7 @@ namespace UT.Kvasir.Providers {
 
             // Act
             var builder = new KeyBuilder();
-            builder.SetFields(new[] { field0, field1, field2 });
+            builder.SetFields([field0, field1, field2]);
             var sql = builder.Build();
 
             // Assert
@@ -76,7 +76,7 @@ namespace UT.Kvasir.Providers {
             // Act
             var builder = new KeyBuilder();
             builder.SetName(keyName);
-            builder.SetFields(new[] { field0, field1 });
+            builder.SetFields([field0, field1]);
             var sql = builder.Build();
 
             // Assert
@@ -90,7 +90,7 @@ namespace UT.Kvasir.Providers {
 
             // Act
             var builder = new KeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field ]);
             builder.SetAsPrimaryKey();
             var sql = builder.Build();
 
@@ -107,7 +107,7 @@ namespace UT.Kvasir.Providers {
             // Act
             var builder = new KeyBuilder();
             builder.SetName(keyName);
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetAsPrimaryKey();
             var sql = builder.Build();
 
@@ -128,7 +128,7 @@ namespace UT.Kvasir.Providers {
 
             // Act
             var builder = new KeyBuilder();
-            builder.SetFields(new[] { field0, field1, field2, field3 });
+            builder.SetFields([field0, field1, field2, field3]);
             builder.SetAsPrimaryKey();
             var sql = builder.Build();
 
@@ -147,7 +147,7 @@ namespace UT.Kvasir.Providers {
             // Act
             var builder = new KeyBuilder();
             builder.SetName(keyName);
-            builder.SetFields(new[] { field0, field1 });
+            builder.SetFields([field0, field1]);
             builder.SetAsPrimaryKey();
             var sql = builder.Build();
 
@@ -164,7 +164,7 @@ namespace UT.Kvasir.Providers {
             // Act
             var builder = new KeyBuilder();
             builder.SetName(keyName);
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             var sql = builder.Build();
 
             // Assert
@@ -198,12 +198,12 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("OtherTable"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Clanton"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             var sql = builder.Build();
 
@@ -224,13 +224,13 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("TableBeingReferenced"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Baldur's Gate"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
             builder.SetName(keyName);
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             var sql = builder.Build();
 
@@ -255,12 +255,12 @@ namespace UT.Kvasir.Providers {
             pkField0.Name.Returns(new FieldName("Ciudad Juárez"));
             var pkField1 = Substitute.For<IField>();
             pkField1.Name.Returns(new FieldName("Bandung"));
-            var pk = new PrimaryKey(new[] { pkField0, pkField1 });
+            var pk = new PrimaryKey([pkField0, pkField1]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
-            builder.SetFields(new[] { field0, field1 });
+            builder.SetFields([field0, field1]);
             builder.SetReferencedTable(table);
             var sql = builder.Build();
 
@@ -289,13 +289,13 @@ namespace UT.Kvasir.Providers {
             pkField1.Name.Returns(new FieldName("Belém"));
             var pkField2 = Substitute.For<IField>();
             pkField2.Name.Returns(new FieldName("Donetsk"));
-            var pk = new PrimaryKey(new[] { pkField0, pkField1, pkField2 });
+            var pk = new PrimaryKey([pkField0, pkField1, pkField2]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
             builder.SetName(keyName);
-            builder.SetFields(new[] { field0, field1, field2 });
+            builder.SetFields([field0, field1, field2]);
             builder.SetReferencedTable(table);
             var sql = builder.Build();
 
@@ -316,12 +316,12 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("TableNumber2"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Katowice"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             builder.SetOnDeleteBehavior(OnDelete.Cascade);
             builder.SetOnUpdateBehavior(OnUpdate.Cascade);
@@ -345,12 +345,12 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("AdjacentTable"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Bhopal"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             builder.SetOnDeleteBehavior(OnDelete.Prevent);
             builder.SetOnUpdateBehavior(OnUpdate.Prevent);
@@ -374,12 +374,12 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("NotThisTable"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Almaty"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             builder.SetOnDeleteBehavior(OnDelete.NoAction);
             builder.SetOnUpdateBehavior(OnUpdate.NoAction);
@@ -403,12 +403,12 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("PartnerTable"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Kumasi"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             builder.SetOnDeleteBehavior(OnDelete.SetDefault);
             builder.SetOnUpdateBehavior(OnUpdate.SetDefault);
@@ -432,12 +432,12 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("TableTheSecond"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Soweto"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             builder.SetOnDeleteBehavior(OnDelete.SetNull);
             builder.SetOnUpdateBehavior(OnUpdate.SetNull);
@@ -461,12 +461,12 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("TableNumeroDos"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Tunisia"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             builder.SetOnDeleteBehavior(OnDelete.Cascade);
             builder.SetOnUpdateBehavior(OnUpdate.SetNull);
@@ -490,12 +490,12 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("ThatOtherTableOverThere"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Cuernavaca"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             builder.SetOnDeleteBehavior(OnDelete.NoAction);
             var sql = builder.Build();
@@ -517,12 +517,12 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("GodTable"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Bulawayo"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             builder.SetOnUpdateBehavior(OnUpdate.Prevent);
             var sql = builder.Build();
@@ -545,13 +545,13 @@ namespace UT.Kvasir.Providers {
             table.Name.Returns(new TableName("CousinTable"));
             var pkField = Substitute.For<IField>();
             pkField.Name.Returns(new FieldName("Curitiba"));
-            var pk = new PrimaryKey(new[] { pkField });
+            var pk = new PrimaryKey([pkField]);
             table.PrimaryKey.Returns(pk);
 
             // Act
             var builder = new ForeignKeyBuilder();
             builder.SetName(keyName);
-            builder.SetFields(new[] { field });
+            builder.SetFields([field]);
             builder.SetReferencedTable(table);
             var sql = builder.Build();
 
@@ -1240,7 +1240,7 @@ namespace UT.Kvasir.Providers {
             field1.DataType.Returns(DBType.Int32);
             var clause0 = new CrossFieldClause(new FieldExpression(field0), ComparisonOperator.EQ, new FieldExpression(field1));
             var clause1 = new ConstantClause(new FieldExpression(field1), ComparisonOperator.GTE, DBValue.Create(73));
-            var clause2 = new InclusionClause(new FieldExpression(field0), InclusionOperator.In, new[] { DBValue.Create(0), DBValue.Create(1), DBValue.Create(2), DBValue.Create(3), DBValue.Create(4) });
+            var clause2 = new InclusionClause(new FieldExpression(field0), InclusionOperator.In, [DBValue.Create(0), DBValue.Create(1), DBValue.Create(2), DBValue.Create(3), DBValue.Create(4)]);
             var clause3 = new ConstantClause(new FieldExpression(field1), ComparisonOperator.GT, DBValue.Create(16));
             var clause4 = new ConstantClause(new FieldExpression(field1), ComparisonOperator.LT, DBValue.Create(41));
 
@@ -3757,6 +3757,6 @@ namespace UT.Kvasir.Providers {
             var converter = new EnumToStringConverter(typeof(T)).ConverterImpl;
             return (string)converter.Convert(enumerator)!;
         }
-        private static Func<Type, IEnumerable<object>> NO_ENTITIES => _ => Array.Empty<object>();
+        private readonly static Func<Type, IEnumerable<object>> NO_ENTITIES = _ => [];
     }    
 }

--- a/test/UnitTests/Kvasir/Providers/_Entities.cs
+++ b/test/UnitTests/Kvasir/Providers/_Entities.cs
@@ -17,7 +17,7 @@ namespace UT.Kvasir.Providers {
         // Scenario: CREATE TABLE – Relation Table
         public class CyrillicLetter {
             [PrimaryKey, Column(0)] public string LetterName { get; set; } = "";
-            public RelationMap<ulong, char> Glyphs { get; } = new();
+            public RelationMap<ulong, char> Glyphs { get; } = [];
             [Column(1)] public ushort NumericalValue { get; set; }
             [Column(2)] public bool IsVowel { get; set; }
         }
@@ -172,7 +172,7 @@ namespace UT.Kvasir.Providers {
             [PrimaryKey, Column(0)] public string Manicurist { get; set; } = "";
             [PrimaryKey, Column(1)] public string Manicuree { get; set; } = "";
             [PrimaryKey, Column(2)] public DateTime Timestamp { get; set; }
-            public RelationMap<Finger, bool> WasPainted { get; } = new();
+            public RelationMap<Finger, bool> WasPainted { get; } = [];
             [Column(3)] public bool ManiPedi { get; set; }
             [Column(4)] public decimal Cost { get; set; }
         }
@@ -257,7 +257,7 @@ namespace UT.Kvasir.Providers {
             [Column(3)] public Color HairColor { get; set; }
             [Column(4)] public bool HasBeenSICoverModel { get; set; }
             [Column(5)] public decimal NetWorth { get; set; }
-            public RelationOrderedList<string> Agencies { get; } = new();
+            public RelationOrderedList<string> Agencies { get; } = [];
         }
 
         // Scenario: UPDATE – Multi-Key Associative Relation Table
@@ -267,7 +267,7 @@ namespace UT.Kvasir.Providers {
             [PrimaryKey, Column(0)] public string IndexName { get; set; } = "";
             [Column(1)] public decimal MarketCap { get; set; }
             [Column(2)] public string? NYSESymbol { get; set; }
-            public RelationMap<Stock, float> Constituents { get; } = new();
+            public RelationMap<Stock, float> Constituents { get; } = [];
             [Column(3)] public double YearOverYear { get; set; }
         }
 
@@ -351,7 +351,7 @@ namespace UT.Kvasir.Providers {
             [Column(3)] public double RecoveryPercent { get; set; }
             [Column(4)] public DateTime Istallation { get; set; }
             [PrimaryKey, Column(5)] public uint Iteration { get; set; }
-            public RelationMap<AudioExam, double> ExamResults { get; } = new();
+            public RelationMap<AudioExam, double> ExamResults { get; } = [];
         }
 
         // Scenario: DELETE – All Rows of an Owning Entity from Non-Associative Relation Table
@@ -370,7 +370,7 @@ namespace UT.Kvasir.Providers {
             [Column(1)] public string Location { get; set; } = "";
             [Column(2)] public string Promoter { get; set; } = "";
             [Column(3)] public string Bull { get; set; } = "";
-            public RelationMap<string, float> Bullriders { get; } = new();
+            public RelationMap<string, float> Bullriders { get; } = [];
             [Column(4)] public decimal Revenue { get; set; }
         }
 
@@ -384,7 +384,7 @@ namespace UT.Kvasir.Providers {
             [Column(2)] public string Name { get; set; } = "";
             [Column(3)] public ushort ChildrenBirthed { get; set; }
             [Column(4)] public DateTime FirstPregnancy { get; set; }
-            public RelationMap<Thing, double> BioStats { get; } = new();
+            public RelationMap<Thing, double> BioStats { get; } = [];
             [Column(5)] public decimal Cost { get; set; }
         }
 
@@ -392,7 +392,7 @@ namespace UT.Kvasir.Providers {
         public class AbortionClinic {
             [PrimaryKey, Column(0)] public Guid ID { get; set; }
             [Column(1)] public bool IsPlannedParenthood { get; set; }
-            public RelationSet<string> Doctors { get; } = new();
+            public RelationSet<string> Doctors { get; } = [];
             [Column(2)] public uint AbortionsPerformed { get; set; }
             [Column(3)] public decimal Budget { get; set; }
             [Column(4)] public string Address { get; set; } = "";

--- a/test/UnitTests/Kvasir/Reconstitution/Creators.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/Creators.cs
@@ -22,10 +22,10 @@ namespace UT.Kvasir.Reconstitution {
 
             // Act
             var creator = new IdentityCreator(typeof(string));
-            var value = creator.CreateFrom(new DBValue[] { source });
+            var value = creator.CreateFrom([source]);
 
             // Assert
-            creator.ResultType.Should().Be(typeof(string));
+            creator.ResultType.Should().Be<string>();
             value.Should().BeNull();
         }
 
@@ -42,38 +42,38 @@ namespace UT.Kvasir.Reconstitution {
 
             // Act
             var sbyteCreator = new IdentityCreator(typeof(sbyte));
-            var sbyteValue = sbyteCreator.CreateFrom(new DBValue[] { sbyteSource });
+            var sbyteValue = sbyteCreator.CreateFrom([sbyteSource]);
             var byteCreator = new IdentityCreator(typeof(byte));
-            var byteValue = byteCreator.CreateFrom(new DBValue[] { byteSource });
+            var byteValue = byteCreator.CreateFrom([byteSource]);
             var shortCreator = new IdentityCreator(typeof(short));
-            var shortValue = shortCreator.CreateFrom(new DBValue[] { shortSource });
+            var shortValue = shortCreator.CreateFrom([shortSource]);
             var ushortCreator = new IdentityCreator(typeof(ushort));
-            var ushortValue = ushortCreator.CreateFrom(new DBValue[] { ushortSource });
+            var ushortValue = ushortCreator.CreateFrom([ushortSource]);
             var intCreator = new IdentityCreator(typeof(int));
-            var intValue = intCreator.CreateFrom(new DBValue[] { intSource });
+            var intValue = intCreator.CreateFrom([intSource]);
             var uintCreator = new IdentityCreator(typeof(uint));
-            var uintValue = uintCreator.CreateFrom(new DBValue[] { uintSource });
+            var uintValue = uintCreator.CreateFrom([uintSource]);
             var longCreator = new IdentityCreator(typeof(long));
-            var longValue = longCreator.CreateFrom(new DBValue[] { longSource });
+            var longValue = longCreator.CreateFrom([longSource]);
             var ulongCreator = new IdentityCreator(typeof(ulong));
-            var ulongValue = ulongCreator.CreateFrom(new DBValue[] { ulongSource });
+            var ulongValue = ulongCreator.CreateFrom([ulongSource]);
 
             // Assert
-            sbyteCreator.ResultType.Should().Be(typeof(sbyte));
+            sbyteCreator.ResultType.Should().Be<sbyte>();
             sbyteValue.Should().Be(sbyteSource.Datum);
-            byteCreator.ResultType.Should().Be(typeof(byte));
+            byteCreator.ResultType.Should().Be<byte>();
             byteValue.Should().Be(byteSource.Datum);
-            shortCreator.ResultType.Should().Be(typeof(short));
+            shortCreator.ResultType.Should().Be<short>();
             shortValue.Should().Be(shortSource.Datum);
-            ushortCreator.ResultType.Should().Be(typeof(ushort));
+            ushortCreator.ResultType.Should().Be<ushort>();
             ushortValue.Should().Be(ushortSource.Datum);
-            intCreator.ResultType.Should().Be(typeof(int));
+            intCreator.ResultType.Should().Be<int>();
             intValue.Should().Be(intSource.Datum);
-            uintCreator.ResultType.Should().Be(typeof(uint));
+            uintCreator.ResultType.Should().Be<uint>();
             uintValue.Should().Be(uintSource.Datum);
-            longCreator.ResultType.Should().Be(typeof(long));
+            longCreator.ResultType.Should().Be<long>();
             longValue.Should().Be(longSource.Datum);
-            ulongCreator.ResultType.Should().Be(typeof(ulong));
+            ulongCreator.ResultType.Should().Be<ulong>();
             ulongValue.Should().Be(ulongSource.Datum);
         }
 
@@ -84,14 +84,14 @@ namespace UT.Kvasir.Reconstitution {
 
             // Act
             var charCreator = new IdentityCreator(typeof(char));
-            var charValue = charCreator.CreateFrom(new DBValue[] { charSource });
+            var charValue = charCreator.CreateFrom([charSource]);
             var stringCreator = new IdentityCreator(typeof(string));
-            var stringValue = stringCreator.CreateFrom(new DBValue[] { stringSource });
+            var stringValue = stringCreator.CreateFrom([stringSource]);
 
             // Assert
-            charCreator.ResultType.Should().Be(typeof(char));
+            charCreator.ResultType.Should().Be<char>();
             charValue.Should().Be(charSource.Datum);
-            stringCreator.ResultType.Should().Be(typeof(string));
+            stringCreator.ResultType.Should().Be<string>();
             stringValue.Should().Be(stringSource.Datum);
         }
 
@@ -103,18 +103,18 @@ namespace UT.Kvasir.Reconstitution {
 
             // Act
             var boolCreator = new IdentityCreator(typeof(bool));
-            var boolValue = boolCreator.CreateFrom(new DBValue[] { boolSource });
+            var boolValue = boolCreator.CreateFrom([boolSource]);
             var datetimeCreator = new IdentityCreator(typeof(DateTime));
-            var datetimeValue = datetimeCreator.CreateFrom(new DBValue[] { datetimeSource });
+            var datetimeValue = datetimeCreator.CreateFrom([datetimeSource]);
             var guidCreator = new IdentityCreator(typeof(Guid));
-            var guidValue = guidCreator.CreateFrom(new DBValue[] { guidSource });
+            var guidValue = guidCreator.CreateFrom([guidSource]);
 
             // Assert
-            boolCreator.ResultType.Should().Be(typeof(bool));
+            boolCreator.ResultType.Should().Be<bool>();
             boolValue.Should().Be(boolSource.Datum);
-            datetimeCreator.ResultType.Should().Be(typeof(DateTime));
+            datetimeCreator.ResultType.Should().Be<DateTime>();
             datetimeValue.Should().Be(datetimeSource.Datum);
-            guidCreator.ResultType.Should().Be(typeof(Guid));
+            guidCreator.ResultType.Should().Be<Guid>();
             guidValue.Should().Be(guidSource.Datum);
         }
     }
@@ -229,7 +229,7 @@ namespace UT.Kvasir.Reconstitution {
             var value = creator.CreateFrom(row);
 
             // Assert
-            creator.ResultType.Should().Be(typeof(MemoryStream));
+            creator.ResultType.Should().Be<MemoryStream>();
             value.Should().BeOfType<MemoryStream>();
             (value as MemoryStream)!.CanRead.Should().Be(true);
             (value as MemoryStream)!.CanWrite.Should().Be(true);
@@ -281,7 +281,7 @@ namespace UT.Kvasir.Reconstitution {
             var value = creator.CreateFrom(row);
 
             // Assert
-            creator.ResultType.Should().Be(typeof(Tuple<string, float, DateTime>));
+            creator.ResultType.Should().Be<Tuple<string, float, DateTime>>();
             value.Should().BeOfType<Tuple<string, float, DateTime>>();
             (value as Tuple<string, float, DateTime>)!.Item1.Should().Be(first);
             (value as Tuple<string, float, DateTime>)!.Item2.Should().Be(second);
@@ -320,7 +320,7 @@ namespace UT.Kvasir.Reconstitution {
             var value = creator.CreateFrom(row);
 
             // Assert
-            creator.ResultType.Should().Be(typeof(ApplicationId));
+            creator.ResultType.Should().Be<ApplicationId>();
             value.Should().BeOfType<ApplicationId>();
             (value as ApplicationId)!.PublicKeyToken.Should().BeEquivalentTo(publicKeyToken);
             (value as ApplicationId)!.Name.Should().Be(name);
@@ -353,7 +353,7 @@ namespace UT.Kvasir.Reconstitution {
             var value = creator.CreateFrom(row);
 
             // Assert
-            creator.ResultType.Should().Be(typeof(Tuple<string?, DateTime?, uint?>));
+            creator.ResultType.Should().Be<Tuple<string?, DateTime?, uint?>>();
             value.Should().BeOfType<Tuple<string?, DateTime?, uint?>>();
             (value as Tuple<string?, DateTime?, uint?>)!.Item1.Should().BeNull();
             (value as Tuple<string?, DateTime?, uint?>)!.Item2.Should().BeNull();
@@ -377,7 +377,7 @@ namespace UT.Kvasir.Reconstitution {
             var value = creator.CreateFrom(row);
 
             // Assert
-            creator.ResultType.Should().Be(typeof(ApplicationException));
+            creator.ResultType.Should().Be<ApplicationException>();
             value.Should().BeNull();
             arg0creator.DidNotReceive().CreateFrom(Arg.Any<IReadOnlyList<DBValue>>());
         }
@@ -397,7 +397,7 @@ namespace UT.Kvasir.Reconstitution {
             var value = creator.CreateFrom(row);
 
             // Assert
-            creator.ResultType.Should().Be(typeof(DateTime));
+            creator.ResultType.Should().Be<DateTime>();
             value.Should().BeOfType<DateTime>();
             ((DateTime)value!).Ticks.Should().Be(ticks);
             arg0creator.Received().CreateFrom(row);
@@ -499,11 +499,11 @@ namespace UT.Kvasir.Reconstitution {
 
             // Act
             var row = new DBValue[] { DBValue.Create("Hackensack") };
-            var creator = new ReconstitutingCreator(originalCreator, Array.Empty<IMutator>());
+            var creator = new ReconstitutingCreator(originalCreator, []);
             var value = creator.CreateFrom(row);
 
             // Assert
-            creator.ResultType.Should().Be(typeof(string));
+            creator.ResultType.Should().Be<string>();
             value.Should().Be(str);
         }
 
@@ -523,7 +523,7 @@ namespace UT.Kvasir.Reconstitution {
             var value = creator.CreateFrom(row);
 
             // Assert
-            creator.ResultType.Should().Be(typeof(string));
+            creator.ResultType.Should().Be<string>();
             value.Should().Be(str);
             mutator.Received().Mutate(value, row);
         }
@@ -548,7 +548,7 @@ namespace UT.Kvasir.Reconstitution {
             var value = creator.CreateFrom(row);
 
             // Assert
-            creator.ResultType.Should().Be(typeof(Type));
+            creator.ResultType.Should().Be<Type>();
             value.Should().Be(type);
             Received.InOrder(() => { mutator0.Mutate(value, row); mutator1.Mutate(value, row); mutator2.Mutate(value, row); });
         }
@@ -566,13 +566,13 @@ namespace UT.Kvasir.Reconstitution {
             keyExtractor.ExtractFrom(options[1]).Returns(keys[1]);
             keyExtractor.ExtractFrom(options[2]).Returns(keys[2]);
             keyExtractor.ExtractFrom(options[3]).Returns(keys[3]);
-            var keyPlan = new DataExtractionPlan(new IMultiExtractor[] { keyExtractor });
+            var keyPlan = new DataExtractionPlan([keyExtractor]);
 
             // Act
             var key = keys[0];
             var matcher = new KeyMatcher(() => options, keyPlan);
             var creator = new KeyLookupCreator(matcher);
-            var value = creator.CreateFrom(key.Select(v => DBValue.Create(v)).ToList());
+            var value = creator.CreateFrom([..key.Select(v => DBValue.Create(v))]);
 
             // Assert
             matcher.ResultType.Should().Be(keyPlan.SourceType);
@@ -594,13 +594,13 @@ namespace UT.Kvasir.Reconstitution {
             keyExtractor.ExtractFrom(options[1]).Returns(keys[1]);
             keyExtractor.ExtractFrom(options[2]).Returns(keys[2]);
             keyExtractor.ExtractFrom(options[3]).Returns(keys[3]);
-            var keyPlan = new DataExtractionPlan(new IMultiExtractor[] { keyExtractor });
+            var keyPlan = new DataExtractionPlan([keyExtractor]);
 
             // Act
             var key = keys[1];
             var matcher = new KeyMatcher(() => options, keyPlan);
             var creator = new KeyLookupCreator(matcher);
-            var value = creator.CreateFrom(key.Select(v => DBValue.Create(v)).ToList());
+            var value = creator.CreateFrom([..key.Select(v => DBValue.Create(v))]);
 
             // Assert
             matcher.ResultType.Should().Be(keyPlan.SourceType);
@@ -621,13 +621,13 @@ namespace UT.Kvasir.Reconstitution {
             keyExtractor.ExtractFrom(options[0]).Returns(keys[0]);
             keyExtractor.ExtractFrom(options[1]).Returns(keys[1]);
             keyExtractor.ExtractFrom(options[2]).Returns(keys[2]);
-            var keyPlan = new DataExtractionPlan(new IMultiExtractor[] { keyExtractor });
+            var keyPlan = new DataExtractionPlan([keyExtractor]);
 
             // Act
             var key = keys[^1];
             var matcher = new KeyMatcher(() => options, keyPlan);
             var creator = new KeyLookupCreator(matcher);
-            var value = creator.CreateFrom(key.Select(v => DBValue.Create(v)).ToList());
+            var value = creator.CreateFrom([..key.Select(v => DBValue.Create(v))]);
 
             // Assert
             matcher.ResultType.Should().Be(keyPlan.SourceType);
@@ -648,14 +648,14 @@ namespace UT.Kvasir.Reconstitution {
             keyExtractor.ExtractFrom(options[1]).Returns(keys[1]);
             keyExtractor.ExtractFrom(options[2]).Returns(keys[2]);
             keyExtractor.ExtractFrom(options[3]).Returns(keys[3]);
-            var keyPlan = new DataExtractionPlan(new IMultiExtractor[] { keyExtractor });
+            var keyPlan = new DataExtractionPlan([keyExtractor]);
 
             // Act
             var key = keys[1];
             var matcher = new KeyMatcher(() => options, keyPlan);
             var creator = new KeyLookupCreator(matcher);
-            var firstValue = creator.CreateFrom(key.Select(v => DBValue.Create(v)).ToList());
-            var secondValue = creator.CreateFrom(key.Select(v => DBValue.Create(v)).ToList());
+            var firstValue = creator.CreateFrom([..key.Select(v => DBValue.Create(v))]);
+            var secondValue = creator.CreateFrom([..key.Select(v => DBValue.Create(v))]);
 
             // Assert
             matcher.ResultType.Should().Be(keyPlan.SourceType);
@@ -677,15 +677,15 @@ namespace UT.Kvasir.Reconstitution {
             keyExtractor.ExtractFrom(options[0]).Returns(keys[0]);
             keyExtractor.ExtractFrom(options[1]).Returns(keys[1]);
             keyExtractor.ExtractFrom(options[2]).Returns(keys[2]);
-            var keyPlan = new DataExtractionPlan(new IMultiExtractor[] { keyExtractor });
+            var keyPlan = new DataExtractionPlan([keyExtractor]);
 
             // Act
             var firstKey = keys[1];
             var secondKey = keys[2];
             var matcher = new KeyMatcher(() => options, keyPlan);
             var creator = new KeyLookupCreator(matcher);
-            var firstValue = creator.CreateFrom(firstKey.Select(v => DBValue.Create(v)).ToList());
-            var secondValue = creator.CreateFrom(secondKey.Select(v => DBValue.Create(v)).ToList());
+            var firstValue = creator.CreateFrom([..firstKey.Select(v => DBValue.Create(v))]);
+            var secondValue = creator.CreateFrom([..secondKey.Select(v => DBValue.Create(v))]);
 
             // Assert
             matcher.ResultType.Should().Be(keyPlan.SourceType);
@@ -701,12 +701,12 @@ namespace UT.Kvasir.Reconstitution {
             // Arrange
             var options = new List<string>() { "Lelydorp", "Shizuoka", "Trieste", "Mississauga" };
             var keyExtractor = Substitute.For<IMultiExtractor>();
-            var keyPlan = new DataExtractionPlan(new IMultiExtractor[] { keyExtractor });
+            var keyPlan = new DataExtractionPlan([keyExtractor]);
 
             // Act
             var matcher = new KeyMatcher(() => options, keyPlan);
             var creator = new KeyLookupCreator(matcher);
-            var value = creator.CreateFrom(new List<DBValue>() { DBValue.NULL, DBValue.NULL });
+            var value = creator.CreateFrom([DBValue.NULL, DBValue.NULL]);
 
             // Assert
             matcher.ResultType.Should().Be(keyPlan.SourceType);

--- a/test/UnitTests/Kvasir/Reconstitution/RelationRepopulationPlan.cs
+++ b/test/UnitTests/Kvasir/Reconstitution/RelationRepopulationPlan.cs
@@ -19,11 +19,11 @@ namespace UT.Kvasir.Reconstitution {
             extractor.ResultType.Returns(typeof(IRelation));
             var creator = Substitute.For<ICreator>();
             creator.ResultType.Returns(typeof(ushort));
-            var reconstitutor = new DataReconstitutionPlan(new ReconstitutingCreator(creator, Array.Empty<IMutator>()));
+            var reconstitutor = new DataReconstitutionPlan(new ReconstitutingCreator(creator, []));
             var repopulator = Substitute.For<IRepopulator>();
 
             // Act
-            var rows = new List<DBValue>[] { new() { DBValue.Create(100) } };
+            var rows = new List<DBValue>[] { [DBValue.Create(100)] };
             var plan = new RelationRepopulationPlan(extractor, reconstitutor, repopulator);
             plan.Repopulate(null, rows);
 
@@ -43,7 +43,7 @@ namespace UT.Kvasir.Reconstitution {
             extractor.ExtractFrom(Arg.Any<object?>()).Returns(relation);
             var creator = Substitute.For<ICreator>();
             creator.ResultType.Returns(typeof(ushort));
-            var reconstitutor = new DataReconstitutionPlan(new ReconstitutingCreator(creator, Array.Empty<IMutator>()));
+            var reconstitutor = new DataReconstitutionPlan(new ReconstitutingCreator(creator, []));
             var repopulator = Substitute.For<IRepopulator>();
 
             // Act
@@ -68,12 +68,12 @@ namespace UT.Kvasir.Reconstitution {
             var creator = Substitute.For<ICreator>();
             creator.ResultType.Returns(typeof(ushort));
             creator.CreateFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(elements[0]);
-            var reconstitutor = new DataReconstitutionPlan(new ReconstitutingCreator(creator, Array.Empty<IMutator>()));
+            var reconstitutor = new DataReconstitutionPlan(new ReconstitutingCreator(creator, []));
             var repopulator = Substitute.For<IRepopulator>();
 
             // Act
             var source = typeof(Type);
-            var rows = new List<DBValue>[] { new() { DBValue.Create(100) } };
+            var rows = new List<DBValue>[] { [DBValue.Create(100)] };
             var plan = new RelationRepopulationPlan(extractor, reconstitutor, repopulator);
             plan.Repopulate(source, rows);
 
@@ -93,7 +93,7 @@ namespace UT.Kvasir.Reconstitution {
             var creator = Substitute.For<ICreator>();
             creator.ResultType.Returns(typeof(ushort));
             creator.CreateFrom(Arg.Any<IReadOnlyList<DBValue>>()).Returns(elements[0], elements[1..]);
-            var reconstitutor = new DataReconstitutionPlan(new ReconstitutingCreator(creator, Array.Empty<IMutator>()));
+            var reconstitutor = new DataReconstitutionPlan(new ReconstitutingCreator(creator, []));
             var repopulator = Substitute.For<IRepopulator>();
 
             // Act

--- a/test/UnitTests/Kvasir/Schema/CandidateKey.cs
+++ b/test/UnitTests/Kvasir/Schema/CandidateKey.cs
@@ -82,11 +82,11 @@ namespace UT.Kvasir.Schema {
 
 
         static CandidateKeyTests() {
-            fields_ = new List<IField>() {
+            fields_ = [
                 new BasicField(new FieldName("Field0"), DBType.Int32, IsNullable.No, Option.None<DBValue>()),
                 new BasicField(new FieldName("Field1"), DBType.DateTime, IsNullable.No, Option.None<DBValue>()),
                 new BasicField(new FieldName("Field2"), DBType.Boolean, IsNullable.No, Option.None<DBValue>())
-            };
+            ];
         }
 
         private static readonly IEnumerable<IField> fields_;

--- a/test/UnitTests/Kvasir/Schema/Clauses.cs
+++ b/test/UnitTests/Kvasir/Schema/Clauses.cs
@@ -57,7 +57,7 @@ namespace UT.Kvasir.Schema {
             clause.LHS.Should().Be(expr);
             clause.Operator.Should().Be(op);
             clause.RHS.Should().Be(value);
-            fields.Should().BeEquivalentTo(new IField[] { mockField });
+            fields.Should().BeEquivalentTo([mockField]);
         }
 
         [TestMethod, TestCategory("SimpleClauses")]
@@ -201,7 +201,7 @@ namespace UT.Kvasir.Schema {
             clause.LHS.Should().Be(expr);
             clause.Operator.Should().Be(op);
             clause.RHS.Should().Be(expr);
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
         }
 
         [TestMethod, TestCategory("SimpleClauses")]
@@ -341,7 +341,7 @@ namespace UT.Kvasir.Schema {
             clause.LHS.Should().Be(expr);
             clause.Operator.Should().Be(op);
             clause.RHS.Should().BeEquivalentTo(values);
-            fields.Should().BeEquivalentTo(new IField[] { mockField });
+            fields.Should().BeEquivalentTo([mockField]);
         }
 
         [TestMethod, TestCategory("SimpleClauses")]
@@ -400,7 +400,7 @@ namespace UT.Kvasir.Schema {
             clause.LHS.Field.Should().Be(mockField);
             clause.LHS.Function.Should().NotHaveValue();
             clause.Operator.Should().Be(op);
-            fields.Should().BeEquivalentTo(new IField[] { mockField });
+            fields.Should().BeEquivalentTo([mockField]);
         }
 
         [TestMethod, TestCategory("SimpleClauses")]
@@ -454,7 +454,7 @@ namespace UT.Kvasir.Schema {
             clause.AddDeclarationTo(mockBuilder);
 
             // Assert
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
             Received.InOrder(() => {
                 mockBuilder.StartClause();
                 mockBuilder.AddClause(lhs.Matcher());
@@ -482,7 +482,7 @@ namespace UT.Kvasir.Schema {
             clause.AddDeclarationTo(mockBuilder);
 
             // Assert
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
             Received.InOrder(() => {
                 mockBuilder.StartClause();
                 mockBuilder.AddClause(lhsNeg.Matcher());
@@ -508,7 +508,7 @@ namespace UT.Kvasir.Schema {
             clause.AddDeclarationTo(mockBuilder);
 
             // Assert
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
             Received.InOrder(() => {
                 mockBuilder.StartClause();
                 mockBuilder.AddClause(lhs.Matcher());
@@ -536,7 +536,7 @@ namespace UT.Kvasir.Schema {
             clause.AddDeclarationTo(mockBuilder);
 
             // Assert
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
             Received.InOrder(() => {
                 mockBuilder.StartClause();
                 mockBuilder.AddClause(lhsNeg.Matcher());
@@ -564,7 +564,7 @@ namespace UT.Kvasir.Schema {
             clause.AddDeclarationTo(mockBuilder);
 
             // Assert
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
             Received.InOrder(() => {
                 mockBuilder.StartClause();
                 mockBuilder.StartClause();
@@ -600,7 +600,7 @@ namespace UT.Kvasir.Schema {
             clause.AddDeclarationTo(mockBuilder);
 
             // Assert
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
             Received.InOrder(() => {
                 mockBuilder.StartClause();
                 mockBuilder.StartClause();
@@ -635,7 +635,7 @@ namespace UT.Kvasir.Schema {
             clause.AddDeclarationTo(mockBuilder);
 
             // Assert
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
             Received.InOrder(() => {
                 mockBuilder.StartClause();
                 mockBuilder.AddClause(subseq.Matcher());
@@ -662,7 +662,7 @@ namespace UT.Kvasir.Schema {
             clause.AddDeclarationTo(mockBuilder);
 
             // Assert
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
             Received.InOrder(() => {
                 mockBuilder.StartClause();
                 mockBuilder.AddClause(subseqNeg.Matcher());
@@ -690,7 +690,7 @@ namespace UT.Kvasir.Schema {
             clause.AddDeclarationTo(mockBuilder);
 
             // Assert
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
             Received.InOrder(() => {
                 mockBuilder.StartClause();
                 mockBuilder.StartClause();
@@ -726,7 +726,7 @@ namespace UT.Kvasir.Schema {
             clause.AddDeclarationTo(mockBuilder);
 
             // Assert
-            fields.Should().BeEquivalentTo(new IField[] { mockField, mockField });
+            fields.Should().BeEquivalentTo([mockField, mockField]);
             Received.InOrder(() => {
                 mockBuilder.StartClause();
                 mockBuilder.StartClause();

--- a/test/UnitTests/Kvasir/Schema/ComponentNames.cs
+++ b/test/UnitTests/Kvasir/Schema/ComponentNames.cs
@@ -69,7 +69,7 @@ namespace UT.Kvasir.Schema {
 
         private static T Create(string rawName) {
             try {
-                return (T)Activator.CreateInstance(typeof(T), new object?[] { rawName })!;
+                return (T)Activator.CreateInstance(typeof(T), [rawName])!;
             }
             catch (TargetInvocationException ex) {
                 throw ex.GetBaseException();

--- a/test/UnitTests/Kvasir/Schema/DBValue.cs
+++ b/test/UnitTests/Kvasir/Schema/DBValue.cs
@@ -180,7 +180,7 @@ namespace UT.Kvasir.Schema {
 
         [TestMethod] public void CreateFromGuidDirectly() {
             // Arrange
-            var rawValue = new Guid(0, 1, 1, new byte[] { 2, 3, 5, 8, 13, 21, 34, 55 });
+            var rawValue = new Guid(0, 1, 1, [2, 3, 5, 8, 13, 21, 34, 55]);
             var expectedType = DBType.Guid;
 
             // Act
@@ -429,7 +429,7 @@ namespace UT.Kvasir.Schema {
 
         [TestMethod] public void CreateFromGuidIndirectly() {
             // Arrange
-            var rawValue = new Guid(0, 1, 1, new byte[] { 2, 3, 5, 8, 13, 21, 34, 55 });
+            var rawValue = new Guid(0, 1, 1, [2, 3, 5, 8, 13, 21, 34, 55]);
             var expectedType = DBType.Guid;
 
             // Act
@@ -609,10 +609,10 @@ namespace UT.Kvasir.Schema {
 
         [TestMethod] public void ZeroIsInstanceOfAnyNumeric() {
             // Arrange
-            DBType[] numerics = new DBType[] {
+            DBType[] numerics = [
                 DBType.Int8, DBType.Int16, DBType.Int32, DBType.Int64, DBType.UInt8, DBType.UInt16, DBType.UInt32,
                 DBType.UInt64, DBType.Single, DBType.Double
-            };
+            ];
             var zero = DBValue.Create(0);
 
             // Act & Assert

--- a/test/UnitTests/Kvasir/Schema/ForeignKey.cs
+++ b/test/UnitTests/Kvasir/Schema/ForeignKey.cs
@@ -113,7 +113,7 @@ namespace UT.Kvasir.Schema {
             mockKeyField1.Nullability.Returns(IsNullable.No);
             mockKeyField1.DataType.Returns(DBType.Text);
 
-            fields_ = new List<IField>() { mockKeyField0, mockKeyField1 };
+            fields_ = [mockKeyField0, mockKeyField1];
 
             var pk = new PrimaryKey(fields_);
             var mockTable = Substitute.For<ITable>();

--- a/test/UnitTests/Kvasir/Schema/PrimaryKey.cs
+++ b/test/UnitTests/Kvasir/Schema/PrimaryKey.cs
@@ -84,11 +84,11 @@ namespace UT.Kvasir.Schema {
 
 
         static PrimaryKeyTests() {
-            fields_ = new List<IField>() {
+            fields_ = [
                 new BasicField(new FieldName("Field0"), DBType.Int32, IsNullable.No, Option.None<DBValue>()),
                 new BasicField(new FieldName("Field1"), DBType.DateTime, IsNullable.No, Option.None<DBValue>()),
                 new BasicField(new FieldName("Field2"), DBType.Boolean, IsNullable.No, Option.None<DBValue>())
-            };
+            ];
         }
 
         private static readonly IEnumerable<IField> fields_;

--- a/test/UnitTests/Kvasir/Schema/Table.cs
+++ b/test/UnitTests/Kvasir/Schema/Table.cs
@@ -111,17 +111,15 @@ namespace UT.Kvasir.Schema {
             mockField2.DataType.Returns(DBType.Enumeration);
             mockField2.GenerateDeclaration(Arg.Any<IFieldDeclBuilder<SqlSnippet>>()).Returns(snippet_);
 
-            var pkey = new PrimaryKey(new IField[] { mockField0 });
-            var ckey = new CandidateKey(new IField[] { mockField1 });
+            var pkey = new PrimaryKey([mockField0]);
+            var ckey = new CandidateKey([mockField1]);
             var check = new CheckConstraint(Substitute.For<Clause>());
 
             var mockReferenceTable = Substitute.For<ITable>();
             mockReferenceTable.PrimaryKey.Returns(pkey);
             var fkey = new ForeignKey(mockReferenceTable, pkey.Fields, OnDelete.SetNull, OnUpdate.NoAction);
 
-            table_ = new Table(new TableName("TABLE"),
-                new IField[] { mockField1, mockField2, mockField0 }, pkey,
-                new CandidateKey[] { ckey }, new ForeignKey[] { fkey }, new CheckConstraint[] { check });
+            table_ = new Table(new TableName("TABLE"), [mockField1, mockField2, mockField0], pkey, [ckey], [fkey], [check]);
         }
         
         private static readonly Table table_;

--- a/test/UnitTests/Kvasir/Transaction/Administration.cs
+++ b/test/UnitTests/Kvasir/Transaction/Administration.cs
@@ -170,6 +170,6 @@ namespace UT.Kvasir.Transaction {
         }
 
 
-        private static readonly IEnumerable<IReadOnlyList<DBValue>> ANY_ROWS = Enumerable.Empty<IReadOnlyList<DBValue>>();
+        private static readonly IEnumerable<IReadOnlyList<DBValue>> ANY_ROWS = [];
     }
 }

--- a/test/UnitTests/Kvasir/Transaction/Deletion.cs
+++ b/test/UnitTests/Kvasir/Transaction/Deletion.cs
@@ -26,7 +26,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Pinata));
 
             // Act
-            fixture.Transactor.Delete(new object[] { pinata });
+            fixture.Transactor.Delete([pinata]);
             var pinataCmd = fixture.PrincipalCommands<Pinata>().DeleteCommand(ANY_ROWS);
             var pinataDeletions = fixture.DeletionsFor(pinataCmd);
 
@@ -53,7 +53,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Choir));
 
             // Act
-            fixture.Transactor.Delete(new object[] { choir });
+            fixture.Transactor.Delete([choir]);
             var choirCmd = fixture.PrincipalCommands<Choir>().DeleteCommand(ANY_ROWS);
             var choirDeletions = fixture.DeletionsFor(choirCmd);
 
@@ -98,7 +98,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(EquityOption));
 
             // Act
-            fixture.Transactor.Delete(new object[] { microsoft, nvidia, disney });
+            fixture.Transactor.Delete([microsoft, nvidia, disney]);
             var optionCmd = fixture.PrincipalCommands<EquityOption>().DeleteCommand(ANY_ROWS);
             var optionDeletions = fixture.DeletionsFor(optionCmd);
 
@@ -134,7 +134,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(K401));
 
             // Act
-            fixture.Transactor.Delete(new object[] { k401 });
+            fixture.Transactor.Delete([k401]);
             var k401Cmd = fixture.PrincipalCommands<K401>().DeleteCommand(ANY_ROWS);
             var k401Deletions = fixture.DeletionsFor(k401Cmd);
             var depositsCmd = fixture.RelationCommands<K401>(0).DeleteCommand(ANY_ROWS);
@@ -170,7 +170,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(JumpBall));
 
             // Act
-            fixture.Transactor.Delete(new object[] { jumpBall });
+            fixture.Transactor.Delete([jumpBall]);
             var jumpBallCmd = fixture.PrincipalCommands<JumpBall>().DeleteCommand(ANY_ROWS);
             var jumpBallDeletions = fixture.DeletionsFor(jumpBallCmd);
             var participantsCmd = fixture.RelationCommands<JumpBall>(0).DeleteCommand(ANY_ROWS);
@@ -201,17 +201,17 @@ namespace UT.Kvasir.Transaction {
                     { Guid.NewGuid(), 5819725.93M },
                     { Guid.NewGuid(), 871.20M }
                 },
-                Combination = new RelationOrderedList<sbyte>() {
+                Combination = [
                     61,
                     34,
                     17,
                     96
-                }
+                ]
             };
             var fixture = new TestFixture(typeof(BankVault));
 
             // Act
-            fixture.Transactor.Delete(new object[] { vault });
+            fixture.Transactor.Delete([vault]);
             var vaultCmd = fixture.PrincipalCommands<BankVault>().DeleteCommand(ANY_ROWS);
             var vaultDeletions = fixture.DeletionsFor(vaultCmd);
             var combinationCmd = fixture.RelationCommands<BankVault>(0).DeleteCommand(ANY_ROWS);
@@ -239,12 +239,12 @@ namespace UT.Kvasir.Transaction {
                 Restaurant = "The Koi Pond",
                 Price = 15.99M,
                 RiceType = SushiRoll.Color.White,
-                Ingredients = new RelationSet<string>() {
+                Ingredients = [
                     "King Crab",
                     "Tobiko",
                     "Cucumber",
                     "Cream Cheese"
-                }
+                ]
             };
             (sushi.Ingredients as IRelation).Canonicalize();
             sushi.Ingredients.Add("Avocado");
@@ -253,7 +253,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(SushiRoll));
 
             // Act
-            fixture.Transactor.Delete(new object[] { sushi });
+            fixture.Transactor.Delete([sushi]);
             var sushiCmd = fixture.PrincipalCommands<SushiRoll>().DeleteCommand(ANY_ROWS);
             var sushiDeletions = fixture.DeletionsFor(sushiCmd);
             var ingredientsCmd = fixture.RelationCommands<SushiRoll>(0).DeleteCommand(ANY_ROWS);
@@ -279,13 +279,13 @@ namespace UT.Kvasir.Transaction {
                 Owner = "Mariah Sroru",
                 TotalIncidents = 35,
                 InsuranceCoverage = 275000M,
-                Tools = new RelationSet<string>(),
-                TypesOfWood = new RelationOrderedList<Woodshop.Wood>()
+                Tools = [],
+                TypesOfWood = []
             };
             var fixture = new TestFixture(typeof(Woodshop));
 
             // Act
-            fixture.Transactor.Delete(new object[] { woodshop });
+            fixture.Transactor.Delete([woodshop]);
             var woodshopCmd = fixture.PrincipalCommands<Woodshop>().DeleteCommand(ANY_ROWS);
             var woodshopDeletions = fixture.DeletionsFor(woodshopCmd);
             var toolsCmd = fixture.RelationCommands<Woodshop>(0).DeleteCommand(ANY_ROWS);
@@ -319,11 +319,11 @@ namespace UT.Kvasir.Transaction {
                     { "Pizza Slice", 13.00M },
                     { "Cigarettes", 18.34M }
                 },
-                Employees = new RelationOrderedList<string>() {
+                Employees = [
                     "Donald Evervass",
                     "Kathleen Tuasaa",
                     "Bri'Ann Camelson"
-                }
+                ]
             };
             var store1 = new ConvenienceStore() {
                 StoreBrand = "La Bodegita",
@@ -334,9 +334,9 @@ namespace UT.Kvasir.Transaction {
                     { "Fountain Drink", 1.50M },
                     { "Churro", 0.75M }
                 },
-                Employees = new RelationOrderedList<string>() {
+                Employees = [
                     "Carl X. Wassel"
-                }
+                ]
             };
             (store0.Products as IRelation).Canonicalize();
             (store0.Employees as IRelation).Canonicalize();
@@ -345,7 +345,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(ConvenienceStore));
 
             // Act
-            fixture.Transactor.Delete(new object[] { store0, store1 });
+            fixture.Transactor.Delete([store0, store1]);
             var storeCmd = fixture.PrincipalCommands<ConvenienceStore>().DeleteCommand(ANY_ROWS);
             var storeDeletions = fixture.DeletionsFor(storeCmd);
             var employeesCmd = fixture.RelationCommands<ConvenienceStore>(0).DeleteCommand(ANY_ROWS);
@@ -383,7 +383,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Showtime));
 
             // Act
-            fixture.Transactor.Delete(new object[] { showtime });
+            fixture.Transactor.Delete([showtime]);
             var showtimeCmd = fixture.PrincipalCommands<Showtime>().DeleteCommand(ANY_ROWS);
             var showtimeDeletions = fixture.DeletionsFor(showtimeCmd);
 
@@ -405,7 +405,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(TermOfEndearment));
 
             // Act
-            fixture.Transactor.Delete(new object[] { termOfEndearment });
+            fixture.Transactor.Delete([termOfEndearment]);
             var termOfEndearmentCmd = fixture.PrincipalCommands<TermOfEndearment>().DeleteCommand(ANY_ROWS);
             var termOfEndearmentDeletions = fixture.DeletionsFor(termOfEndearmentCmd);
 
@@ -427,7 +427,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Label));
 
             // Act
-            fixture.Transactor.Delete(new object[] { label });
+            fixture.Transactor.Delete([label]);
             var labelCmd = fixture.PrincipalCommands<Label>().DeleteCommand(ANY_ROWS);
             var labelDeletions = fixture.DeletionsFor(labelCmd);
 
@@ -454,7 +454,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(ConjugatedVerb));
 
             // Act
-            fixture.Transactor.Delete(new object[] { verb });
+            fixture.Transactor.Delete([verb]);
             var conjugationCmd = fixture.PrincipalCommands<ConjugatedVerb>().DeleteCommand(ANY_ROWS);
             var conjugationDeletions = fixture.DeletionsFor(conjugationCmd);
 
@@ -475,7 +475,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Coordinate));
 
             // Act
-            fixture.Transactor.Delete(new object[] { coordinate0, coordinate1, coordinate2 });
+            fixture.Transactor.Delete([coordinate0, coordinate1, coordinate2]);
             var coordinateCmd = fixture.PrincipalCommands<Coordinate>().DeleteCommand(ANY_ROWS);
             var coordinateDeletions = fixture.DeletionsFor(coordinateCmd);
 
@@ -514,7 +514,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(SeaShanty), typeof(ElginMarble), typeof(CepheidVariable));
 
             // Act
-            fixture.Transactor.Delete(new object[] { shanty, marble, cepheid });
+            fixture.Transactor.Delete([shanty, marble, cepheid]);
             var shantyCmd = fixture.PrincipalCommands<SeaShanty>().DeleteCommand(ANY_ROWS);
             var shantyDeletions = fixture.DeletionsFor(shantyCmd);
             var marbleCmd = fixture.PrincipalCommands<ElginMarble>().DeleteCommand(ANY_ROWS);
@@ -558,7 +558,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Sunset), typeof(Wingding), typeof(Sprite));
 
             // Act
-            fixture.Transactor.Delete(new object[] { sunset, wingding, sprite });
+            fixture.Transactor.Delete([sunset, wingding, sprite]);
             var sunsetCmd = fixture.PrincipalCommands<Sunset>().DeleteCommand(ANY_ROWS);
             var sunsetDeletions = fixture.DeletionsFor(sunsetCmd);
             var wingdingCmd = fixture.PrincipalCommands<Wingding>().DeleteCommand(ANY_ROWS);
@@ -606,7 +606,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(CostumeParty), typeof(CostumeParty.Partygoer), typeof(CostumeParty.Costume));
 
             // Act
-            fixture.Transactor.Delete(new object[] { costume, party, partygoer });
+            fixture.Transactor.Delete([costume, party, partygoer]);
             var costumeCmd = fixture.PrincipalCommands<CostumeParty.Costume>().DeleteCommand(ANY_ROWS);
             var costumeDeletios = fixture.DeletionsFor(costumeCmd);
             var partygoerCmd = fixture.PrincipalCommands<CostumeParty.Partygoer>().DeleteCommand(ANY_ROWS);
@@ -654,7 +654,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(WeirdAlParody), typeof(WeirdAlParody.Song), typeof(WeirdAlParody.Album));
 
             // Act
-            fixture.Transactor.Delete(new object[] {album, beatIt, eatIt});
+            fixture.Transactor.Delete([album, beatIt, eatIt]);
             var albumCmd = fixture.PrincipalCommands<WeirdAlParody.Album>().DeleteCommand(ANY_ROWS);
             var albumDeletions = fixture.DeletionsFor(albumCmd);
             var songCmd = fixture.PrincipalCommands<WeirdAlParody.Song>().DeleteCommand(ANY_ROWS);
@@ -712,7 +712,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Affidavit), typeof(Affidavit.Lawyer));
 
             // Act
-            fixture.Transactor.Delete(new object[] { affidavit, lawyer0, lawyer1, lawyer2 });
+            fixture.Transactor.Delete([affidavit, lawyer0, lawyer1, lawyer2]);
             var affidavitCmd = fixture.PrincipalCommands<Affidavit>().DeleteCommand(ANY_ROWS);
             var affidavitDeletions = fixture.DeletionsFor(affidavitCmd);
             var lawyerCmd = fixture.PrincipalCommands<Affidavit.Lawyer>().DeleteCommand(ANY_ROWS);
@@ -752,7 +752,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Bandeirante), typeof(LocalizedText), typeof(LocalizedCurrency));
 
             // Act
-            fixture.Transactor.Delete(new object[] { bandeirante, bandeirante.HomeState, bandeirante.TotalLooted });
+            fixture.Transactor.Delete([bandeirante, bandeirante.HomeState, bandeirante.TotalLooted]);
             var bandeiranteCmd = fixture.PrincipalCommands<Bandeirante>().DeleteCommand(ANY_ROWS);
             var bandeiranteDeletions = fixture.DeletionsFor(bandeiranteCmd);
             var textCmd = fixture.PrincipalCommands<LocalizedText>().DeleteCommand(ANY_ROWS);
@@ -807,7 +807,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(BirthdayParty), typeof(BirthdayParty.YearMonthDay), typeof(BirthdayParty.LocalizedYearMonthDay));
 
             // Act
-            fixture.Transactor.Delete(new object[] { yyyymmdd, wordyDate, party, party.Date });
+            fixture.Transactor.Delete([yyyymmdd, wordyDate, party, party.Date]);
             var partyCmd = fixture.PrincipalCommands<BirthdayParty>().DeleteCommand(ANY_ROWS);
             var partyDeletions = fixture.DeletionsFor(partyCmd);
             var dateCmd = fixture.PrincipalCommands<BirthdayParty.YearMonthDay>().DeleteCommand(ANY_ROWS);
@@ -841,10 +841,10 @@ namespace UT.Kvasir.Transaction {
                 BarNumber = Guid.NewGuid(),
                 Name = "Lord Stanley Razzellon IV, Eighteenth Earl of Thornentonshire",
                 AlmaMater = "London Temporary Secondary School of Greengrass-upon-Thames-upon-Earth",
-                Employers = new RelationOrderedList<LocalizedNullableText>() {
+                Employers = [
                     text0,
                     text1
-                },
+                ],
                 WinPercentage = 0.03,
                 AnnualSalary = 57000M,
                 HasBeenDisbarred = false,
@@ -854,7 +854,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Lawyer), typeof(LocalizedNullableText));
 
             // Act
-            fixture.Transactor.Delete(new object[] { text0, text1, lawyer });
+            fixture.Transactor.Delete([text0, text1, lawyer]);
             var lawyerCmd = fixture.PrincipalCommands<Lawyer>().DeleteCommand(ANY_ROWS);
             var lawyerDeletions = fixture.DeletionsFor(lawyerCmd);
             var textCmd = fixture.PrincipalCommands<LocalizedNullableText>().DeleteCommand(ANY_ROWS);
@@ -917,7 +917,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Masseuse));
 
             // Act
-            fixture.Transactor.Delete(new object[] { masseuse0, masseuse1, masseuse2 });
+            fixture.Transactor.Delete([masseuse0, masseuse1, masseuse2]);
             var masseuseCmd = fixture.PrincipalCommands<Masseuse>().DeleteCommand(ANY_ROWS);
             var masseuseDeletions = fixture.DeletionsFor(masseuseCmd);
             var teachersCmd = fixture.RelationCommands<Masseuse>(0).DeleteCommand(ANY_ROWS);
@@ -972,7 +972,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Radiologist), typeof(Radiologist.OnCallEscalation));
 
             // Act
-            fixture.Transactor.Delete(new object[] { radiologist0, radiologist1, radiologist2, radiologist0.Superior });
+            fixture.Transactor.Delete([radiologist0, radiologist1, radiologist2, radiologist0.Superior]);
             var radiologistCmd = fixture.PrincipalCommands<Radiologist>().DeleteCommand(ANY_ROWS);
             var radiologistDeletions = fixture.DeletionsFor(radiologistCmd);
             var onCallCmd = fixture.PrincipalCommands<Radiologist.OnCallEscalation>().DeleteCommand(ANY_ROWS);
@@ -1003,7 +1003,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Gazebo)).WithCommitError();
 
             // Act
-            var action = () => fixture.Transactor.Insert(new object[] { gazebo });
+            var action = () => fixture.Transactor.Insert([gazebo]);
 
             // Assert
             action.Should().ThrowExactly<InvalidOperationException>();
@@ -1023,7 +1023,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Moai)).WithRollbackError();
 
             // Act
-            var action = () => fixture.Transactor.Delete(new object[] { moai });
+            var action = () => fixture.Transactor.Delete([moai]);
 
             // Assert
             action.Should().ThrowExactly<AggregateException>();
@@ -1036,6 +1036,6 @@ namespace UT.Kvasir.Transaction {
             var converter = new EnumToStringConverter(typeof(T)).ConverterImpl;
             return (string)converter.Convert(enumerator)!;
         }
-        private static readonly IEnumerable<IReadOnlyList<DBValue>> ANY_ROWS = Enumerable.Empty<IReadOnlyList<DBValue>>();
+        private static readonly IEnumerable<IReadOnlyList<DBValue>> ANY_ROWS = [];
     }
 }

--- a/test/UnitTests/Kvasir/Transaction/Insertion.cs
+++ b/test/UnitTests/Kvasir/Transaction/Insertion.cs
@@ -28,7 +28,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Crossbow));
 
             // Act
-            fixture.Transactor.Insert(new object[] { crossbow });
+            fixture.Transactor.Insert([crossbow]);
             var crossbowCmd = fixture.PrincipalCommands<Crossbow>().InsertCommand(ANY_ROWS);
             var crossbowInserts = fixture.InsertionsFor(crossbowCmd);
 
@@ -53,7 +53,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(GoogleDoodle));
 
             // Act
-            fixture.Transactor.Insert(new object[] { doodle });
+            fixture.Transactor.Insert([doodle]);
             var doodleCmd = fixture.PrincipalCommands<GoogleDoodle>().InsertCommand(ANY_ROWS);
             var doodleInserts = fixture.InsertionsFor(doodleCmd);
 
@@ -86,7 +86,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(CountOlafDisguise));
 
             // Act
-            fixture.Transactor.Insert(new object[] { funcoot, genghis, sham });
+            fixture.Transactor.Insert([funcoot, genghis, sham]);
             var disguiseCmd = fixture.PrincipalCommands<CountOlafDisguise>().InsertCommand(ANY_ROWS);
             var disguiseInserts = fixture.InsertionsFor(disguiseCmd);
 
@@ -117,7 +117,7 @@ namespace UT.Kvasir.Transaction {
                     { "Dr. Pepper", false },
                     { "Barq's Root Beer", true }
                 },
-                Inspections = new RelationOrderedList<DateTime>() {
+                Inspections = [
                     new DateTime(2024, 1, 3),
                     new DateTime(2024, 2, 18),
                     new DateTime(2024, 3, 11),
@@ -129,12 +129,12 @@ namespace UT.Kvasir.Transaction {
                     new DateTime(2024, 10, 15),
                     new DateTime(2024, 11, 9),
                     new DateTime(2024, 12, 6)
-                }
+                ]
             };
             var fixture = new TestFixture(typeof(SodaFountain));
 
             // Act
-            fixture.Transactor.Insert(new object[] { fountain });
+            fixture.Transactor.Insert([fountain]);
             var fountainCmd = fixture.PrincipalCommands<SodaFountain>().InsertCommand(ANY_ROWS);
             var fountainInserts = fixture.InsertionsFor(fountainCmd);
             var inspectionsCmd = fixture.RelationCommands<SodaFountain>(0).InsertCommand(ANY_ROWS);
@@ -190,7 +190,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(LetterOfRecommendation));
 
             // Act
-            fixture.Transactor.Insert(new object[] { recLetter });
+            fixture.Transactor.Insert([recLetter]);
             var letterCmd = fixture.PrincipalCommands<LetterOfRecommendation>().InsertCommand(ANY_ROWS);
             var letterInserts = fixture.InsertionsFor(letterCmd);
             var wordsCmd = fixture.RelationCommands<LetterOfRecommendation>(0).InsertCommand(ANY_ROWS);
@@ -246,7 +246,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(MutualFund));
 
             // Act
-            fixture.Transactor.Insert(new object[] { fund0, fund1, fund2 });
+            fixture.Transactor.Insert([fund0, fund1, fund2]);
             var fundCmd = fixture.PrincipalCommands<MutualFund>().InsertCommand(ANY_ROWS);
             var fundInserts = fixture.InsertionsFor(fundCmd);
             var investorsCmd = fixture.RelationCommands<MutualFund>(0).InsertCommand(ANY_ROWS);
@@ -285,7 +285,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Password));
 
             // Act
-            fixture.Transactor.Insert(new object[] { password });
+            fixture.Transactor.Insert([password]);
             var passwordCmd = fixture.PrincipalCommands<Password>().InsertCommand(ANY_ROWS);
             var passwordInserts = fixture.InsertionsFor(passwordCmd);
 
@@ -315,7 +315,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Ordinal));
 
             // Act
-            fixture.Transactor.Insert(new object[] { first, twentyThird, eightMillionth });
+            fixture.Transactor.Insert([first, twentyThird, eightMillionth]);
             var ordinalCmd = fixture.PrincipalCommands<Ordinal>().InsertCommand(ANY_ROWS);
             var ordinalInserts = fixture.InsertionsFor(ordinalCmd);
 
@@ -373,7 +373,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Wheelchair), typeof(Haka), typeof(BetterKnowADistrict), typeof(Invoice));
 
             // Act
-            fixture.Transactor.Insert(new object[] { wheelchair, haka, bkad, invoice });
+            fixture.Transactor.Insert([wheelchair, haka, bkad, invoice]);
             var wheelchairCmd = fixture.PrincipalCommands<Wheelchair>().InsertCommand(ANY_ROWS);
             var wheelchairInserts = fixture.InsertionsFor(wheelchairCmd);
             var hakaCmd = fixture.PrincipalCommands<Haka>().InsertCommand(ANY_ROWS);
@@ -421,7 +421,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Disclaimer), typeof(Tagline), typeof(Polynomial));
 
             // Act
-            fixture.Transactor.Insert(new object[] { disclaimer, tagline, polynomial });
+            fixture.Transactor.Insert([disclaimer, tagline, polynomial]);
             var disclaimerCmd = fixture.PrincipalCommands<Disclaimer>().InsertCommand(ANY_ROWS);
             var disclaimerInserts = fixture.InsertionsFor(disclaimerCmd);
             var taglineCmd = fixture.PrincipalCommands<Tagline>().InsertCommand(ANY_ROWS);
@@ -479,7 +479,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Rhinoceros), typeof(Rhinoceros.Zoo), typeof(Rhinoceros.Person));
 
             // Act
-            fixture.Transactor.Insert(new object[] { rhino, zookeeper, zoo });
+            fixture.Transactor.Insert([rhino, zookeeper, zoo]);
             var zookeeperCmd = fixture.PrincipalCommands<Rhinoceros.Person>().InsertCommand(ANY_ROWS);
             var zookeeperInserts = fixture.InsertionsFor(zookeeperCmd);
             var zooCmd = fixture.PrincipalCommands<Rhinoceros.Zoo>().InsertCommand(ANY_ROWS);
@@ -525,7 +525,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Sheriff), typeof(Sheriff.Badge), typeof(Sheriff.Election));
 
             // Act
-            fixture.Transactor.Insert(new object[] { sheriff, election, badge });
+            fixture.Transactor.Insert([sheriff, election, badge]);
             var badgeCmd = fixture.PrincipalCommands<Sheriff.Badge>().InsertCommand(ANY_ROWS);
             var badgeInserts = fixture.InsertionsFor(badgeCmd);
             var electionCmd = fixture.PrincipalCommands<Sheriff.Election>().InsertCommand(ANY_ROWS);
@@ -585,7 +585,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Coven), typeof(Coven.Witch));
 
             // Act
-            fixture.Transactor.Insert(new object[] { witch0, coven, witch1, witch2, witch3 });
+            fixture.Transactor.Insert([witch0, coven, witch1, witch2, witch3]);
             var covenCmd = fixture.PrincipalCommands<Coven>().InsertCommand(ANY_ROWS);
             var covenInserts = fixture.InsertionsFor(covenCmd);
             var witchCmd = fixture.PrincipalCommands<Coven.Witch>().InsertCommand(ANY_ROWS);
@@ -633,7 +633,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(MemoryLeak), typeof(LocalizedMeasure), typeof(LocalizedDate));
 
             // Act
-            fixture.Transactor.Insert(new object[] { date, measurement, leak });
+            fixture.Transactor.Insert([date, measurement, leak]);
             var dateCmd = fixture.PrincipalCommands<LocalizedDate>().InsertCommand(ANY_ROWS);
             var dateInserts = fixture.InsertionsFor(dateCmd);
             var measurementCmd = fixture.PrincipalCommands<LocalizedMeasure>().InsertCommand(ANY_ROWS);
@@ -692,7 +692,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(PoliceChase), typeof(PoliceChase.Identifier), typeof(PoliceChase.LocalizedID));
 
             // Act
-            fixture.Transactor.Insert(new object[] { chase, id0, id1, id2, localization });
+            fixture.Transactor.Insert([chase, id0, id1, id2, localization]);
             var chaseCmd = fixture.PrincipalCommands<PoliceChase>().InsertCommand(ANY_ROWS);
             var chases = fixture.InsertionsFor(chaseCmd);
             var identifierCmd = fixture.PrincipalCommands<PoliceChase.Identifier>().InsertCommand(ANY_ROWS);
@@ -743,18 +743,18 @@ namespace UT.Kvasir.Transaction {
                 Executor = "Count Egzmur von Twarrendwelft-Schmulagon",
                 TradedShares = 8000000,
                 InitialPercentageControlled = 37.54f,
-                BuyPrices = new RelationSet<LocalizedCurrency>() {
+                BuyPrices = [
                     fiftyDollars,
                     sixtyDollars,
-                     seventyDollars
-                },
+                    seventyDollars
+                ],
                 WasSuccessful = false,
                 ProxyFight = true
             };
             var fixture = new TestFixture(typeof(HostileTakeover), typeof(LocalizedCurrency));
 
             // Act
-            fixture.Transactor.Insert(new object[] { takeover, fiftyDollars, sixtyDollars, seventyDollars });
+            fixture.Transactor.Insert([takeover, fiftyDollars, sixtyDollars, seventyDollars]);
             var takeoverCmd = fixture.PrincipalCommands<HostileTakeover>().InsertCommand(ANY_ROWS);
             var takeoverInserts = fixture.InsertionsFor(takeoverCmd);
             var currencyCmd = fixture.PrincipalCommands<LocalizedCurrency>().InsertCommand(ANY_ROWS);
@@ -820,7 +820,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(MayanGod));
 
             // Act
-            fixture.Transactor.Insert(new object[] { ixchel, itzamna, yumKaax });
+            fixture.Transactor.Insert([ixchel, itzamna, yumKaax]);
             var godCmd = fixture.PrincipalCommands<MayanGod>().InsertCommand(ANY_ROWS);
             var godInserts = fixture.InsertionsFor(godCmd);
             var fathersCmd = fixture.RelationCommands<MayanGod>(0).InsertCommand(ANY_ROWS);
@@ -865,7 +865,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Pizzeria), typeof(Pizzeria.LocalizedStore));
 
             // Act
-            fixture.Transactor.Insert(new object[] { pizzeria, pizzeria.ParentStore });
+            fixture.Transactor.Insert([pizzeria, pizzeria.ParentStore]);
             var pizzeriaCmd = fixture.PrincipalCommands<Pizzeria>().InsertCommand(ANY_ROWS);
             var pizzeriaInserts = fixture.InsertionsFor(pizzeriaCmd);
             var storeCmd = fixture.PrincipalCommands<Pizzeria.LocalizedStore>().InsertCommand(ANY_ROWS);
@@ -897,7 +897,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Blister)).WithCommitError();
 
             // Act
-            var action = () => fixture.Transactor.Insert(new object[] { blister });
+            var action = () => fixture.Transactor.Insert([blister]);
 
             // Assert
             action.Should().ThrowExactly<InvalidOperationException>();
@@ -917,7 +917,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Chainsaw)).WithRollbackError();
 
             // Act
-            var action = () => fixture.Transactor.Insert(new object[] { chainsaw });
+            var action = () => fixture.Transactor.Insert([chainsaw]);
 
             // Assert
             action.Should().ThrowExactly<AggregateException>();
@@ -930,6 +930,6 @@ namespace UT.Kvasir.Transaction {
             var converter = new EnumToStringConverter(typeof(T)).ConverterImpl;
             return (string)converter.Convert(enumerator)!;
         }
-        private static readonly IEnumerable<IReadOnlyList<DBValue>> ANY_ROWS = Enumerable.Empty<IReadOnlyList<DBValue>>();
+        private static readonly IEnumerable<IReadOnlyList<DBValue>> ANY_ROWS = [];
     }
 }

--- a/test/UnitTests/Kvasir/Transaction/Selection.cs
+++ b/test/UnitTests/Kvasir/Transaction/Selection.cs
@@ -558,8 +558,8 @@ namespace UT.Kvasir.Transaction {
                 .WithEntityRow<HailMary>(miracle)
                 .WithEntityRow<HailMary.FootballPlayer>(aaron)
                 .WithEntityRow<HailMary.FootballPlayer>(richard)
-                .WithRelationRow<HailMary>(0, new object[] { miracle[0], miracle[1], aaron[0], aaron[1] })
-                .WithRelationRow<HailMary>(0, new object[] { miracle[0], miracle[1], richard[0], richard[1] });
+                .WithRelationRow<HailMary>(0, [miracle[0], miracle[1], aaron[0], aaron[1]])
+                .WithRelationRow<HailMary>(0, [miracle[0], miracle[1], richard[0], richard[1]]);
 
             // Act
             fixture.Transactor.SelectAll();
@@ -705,9 +705,9 @@ namespace UT.Kvasir.Transaction {
                 .WithLocalizationRow<LocalizedMeasure>(weight0)
                 .WithLocalizationRow<LocalizedMeasure>(weight1)
                 .WithLocalizationRow<LocalizedMeasure>(gestation)
-                .WithRelationRow<Whale>(0, new object[] { whale[0], ConversionOf(Whale.Dimension.Length), length0[0] })
-                .WithRelationRow<Whale>(0, new object[] { whale[0], ConversionOf(Whale.Dimension.Weight), weight0[0] })
-                .WithRelationRow<Whale>(0, new object[] { whale[0], ConversionOf(Whale.Dimension.GestationPeriod), gestation[0] });
+                .WithRelationRow<Whale>(0, [whale[0], ConversionOf(Whale.Dimension.Length), length0[0]])
+                .WithRelationRow<Whale>(0, [whale[0], ConversionOf(Whale.Dimension.Weight), weight0[0]])
+                .WithRelationRow<Whale>(0, [whale[0], ConversionOf(Whale.Dimension.GestationPeriod), gestation[0]]);
 
             // Act
             fixture.Transactor.SelectAll();
@@ -754,8 +754,8 @@ namespace UT.Kvasir.Transaction {
                 .WithEntityRow<IranianShah>(naderShah)
                 .WithEntityRow<IranianShah>(abbas)
                 .WithEntityRow<IranianShah>(tahmasp)
-                .WithRelationRow<IranianShah>(0, new object[] { naderShah[0], abbas[0] })
-                .WithRelationRow<IranianShah>(0, new object[] { abbas[0], tahmasp[0] });
+                .WithRelationRow<IranianShah>(0, [naderShah[0], abbas[0]])
+                .WithRelationRow<IranianShah>(0, [abbas[0], tahmasp[0]]);
 
             // Act
             fixture.Transactor.SelectAll();

--- a/test/UnitTests/Kvasir/Transaction/TableCreation.cs
+++ b/test/UnitTests/Kvasir/Transaction/TableCreation.cs
@@ -283,7 +283,7 @@ namespace UT.Kvasir.Transaction {
             // Act
             fixture.Transactor.CreateTables();
             var createCmd = fixture.PrincipalCommands<Dashavatara>().CreateTableCommand;
-            var insertCmd = fixture.PrincipalCommands<Dashavatara>().InsertCommand(Enumerable.Empty<IReadOnlyList<DBValue>>());
+            var insertCmd = fixture.PrincipalCommands<Dashavatara>().InsertCommand([]);
             var inserts = fixture.InsertionsFor(insertCmd);
 
             // Assert
@@ -313,7 +313,7 @@ namespace UT.Kvasir.Transaction {
             // Act
             fixture.Transactor.CreateTables();
             var createCmd = fixture.PrincipalCommands<CivVITerrain>().CreateTableCommand;
-            var insertCmd = fixture.PrincipalCommands<CivVITerrain>().InsertCommand(Enumerable.Empty<IReadOnlyList<DBValue>>());
+            var insertCmd = fixture.PrincipalCommands<CivVITerrain>().InsertCommand([]);
             var inserts = fixture.InsertionsFor(insertCmd);
 
             // Assert

--- a/test/UnitTests/Kvasir/Transaction/Update.cs
+++ b/test/UnitTests/Kvasir/Transaction/Update.cs
@@ -25,7 +25,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(DifferentialEquation));
 
             // Act
-            fixture.Transactor.Update(new object[] { diffEq });
+            fixture.Transactor.Update([diffEq]);
             var diffEqCmd = fixture.PrincipalCommands<DifferentialEquation>().UpdateCommand(ANY_ROWS);
             var diffEqUpdates = fixture.UpdatesFor(diffEqCmd);
 
@@ -55,7 +55,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Conquistador));
 
             // Act
-            fixture.Transactor.Update(new object[] { cortes, pizarro });
+            fixture.Transactor.Update([cortes, pizarro]);
             var conquistadorCmd = fixture.PrincipalCommands<Conquistador>().UpdateCommand(ANY_ROWS);
             var conquistadorUpdates = fixture.UpdatesFor(conquistadorCmd);
 
@@ -86,7 +86,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(BigFatQuiz));
 
             // Act
-            fixture.Transactor.Update(new object[] { quiz });
+            fixture.Transactor.Update([quiz]);
             var quizCmd = fixture.PrincipalCommands<BigFatQuiz>().UpdateCommand(ANY_ROWS);
             var quizUpdates = fixture.UpdatesFor(quizCmd);
             var teamsInsertCmd = fixture.RelationCommands<BigFatQuiz>(0).InsertCommand(ANY_ROWS);
@@ -115,20 +115,20 @@ namespace UT.Kvasir.Transaction {
                 Preparer = "Chef Miguel C. Espadillo",
                 NumServings = 4,
                 MadeInMolcajete = true,
-                Ingredients = new RelationSet<string>() {
+                Ingredients = [
                     "Avocado",
                     "Cilantro",
                     "Jalapeño",
                     "Lime Juice",
                     "Salt"
-                }
+                ]
             };
             (guacamole.Ingredients as IRelation).Canonicalize();
             guacamole.Ingredients.Clear();
             var fixture = new TestFixture(typeof(Guacamole));
 
             // Act
-            fixture.Transactor.Update(new object[] { guacamole });
+            fixture.Transactor.Update([guacamole]);
             var guacamoleCmd = fixture.PrincipalCommands<Guacamole>().UpdateCommand(ANY_ROWS);
             var guacamoleUpdates = fixture.UpdatesFor(guacamoleCmd);
             var ingredientsInsertCmd = fixture.RelationCommands<Guacamole>(0).InsertCommand(ANY_ROWS);
@@ -181,7 +181,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(EyeDrops));
 
             // Act
-            fixture.Transactor.Update(new object[] { eyeDrops });
+            fixture.Transactor.Update([eyeDrops]);
             var eyeDropsCmd = fixture.PrincipalCommands<EyeDrops>().UpdateCommand(ANY_ROWS);
             var eyeDropsUpdates = fixture.UpdatesFor(eyeDropsCmd);
             var treatmentsInsertCmd = fixture.RelationCommands<EyeDrops>(0).InsertCommand(ANY_ROWS);
@@ -228,7 +228,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(EquestrianStatue));
 
             // Act
-            fixture.Transactor.Update(new object[] { statue });
+            fixture.Transactor.Update([statue]);
             var statueCmd = fixture.PrincipalCommands<EquestrianStatue>().UpdateCommand(ANY_ROWS);
             var statueUpdates = fixture.UpdatesFor(statueCmd);
             var dimensionsInsertCmd = fixture.RelationCommands<EquestrianStatue>(0).InsertCommand(ANY_ROWS);
@@ -262,7 +262,7 @@ namespace UT.Kvasir.Transaction {
                 For = "Anticoagulant Properties of Cnidarian Saliva on Gluten-Free Females Aged 17-23",
                 Style = Bibliography.Standard.Harvard,
                 NumPages = 218,
-                References = new RelationOrderedList<Bibliography.Reference>() {
+                References = [
                     new Bibliography.Reference() {
                         Title = "Nervous Systems of the Animal Kingdom",
                         Author = "F. Maury Cappaneck",
@@ -278,14 +278,14 @@ namespace UT.Kvasir.Transaction {
                         Author = "Gary Zedersztrom",
                         TypeOfWork = Bibliography.Literature.Newscast
                     }
-                }
+                ]
             };
             (bibliography.References as IRelation).Canonicalize();
             bibliography.References[1] = bibliography.References[1] with { TypeOfWork = Bibliography.Literature.Interview };
             var fixture = new TestFixture(typeof(Bibliography));
 
             // Act
-            fixture.Transactor.Update(new object[] { bibliography });
+            fixture.Transactor.Update([bibliography]);
             var bibliographyCmd = fixture.PrincipalCommands<Bibliography>().UpdateCommand(ANY_ROWS);
             var bibliographyUpdates = fixture.UpdatesFor(bibliographyCmd);
             var referencesInsertCmd = fixture.RelationCommands<Bibliography>(0).InsertCommand(ANY_ROWS);
@@ -318,13 +318,13 @@ namespace UT.Kvasir.Transaction {
                 FirmName = "Akuna Capital",
                 NetCapital = 618000000M,
                 IsDesignated = false,
-                Symbols = new RelationOrderedList<string>() {
+                Symbols = [
                     "NVDA",
                     "IBIT",
                     "APL",
                     "TSLA",
                     "MSFT"
-                }
+                ]
             };
             (akuna.Symbols as IRelation).Canonicalize();
             akuna.Symbols[2] = "AAPL";
@@ -332,7 +332,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(MarketMaker));
 
             // Act
-            fixture.Transactor.Update(new object[] { akuna });
+            fixture.Transactor.Update([akuna]);
             var marketMakerCmd = fixture.PrincipalCommands<MarketMaker>().UpdateCommand(ANY_ROWS);
             var marketMakerUpdates = fixture.UpdatesFor(marketMakerCmd);
             var symbolsInsertCmd = fixture.RelationCommands<MarketMaker>(0).InsertCommand(ANY_ROWS);
@@ -369,12 +369,12 @@ namespace UT.Kvasir.Transaction {
                 ScrollLanguage = DeadSeaScroll.Language.Hebrew,
                 BiblicalSource = "Ezekiel 16:31-33",
                 DiscoveryYear = 1952,
-                VerifiedAuthors = new RelationSet<string>()
+                VerifiedAuthors = []
             };
             var fixture = new TestFixture(typeof(DeadSeaScroll));
 
             // Act
-            fixture.Transactor.Update(new object[] { scroll });
+            fixture.Transactor.Update([scroll]);
             var scrollCmd = fixture.PrincipalCommands<DeadSeaScroll>().UpdateCommand(ANY_ROWS);
             var scrollUpdates = fixture.UpdatesFor(scrollCmd);
             var authorsInsertCmd = fixture.RelationCommands<DeadSeaScroll>(0).InsertCommand(ANY_ROWS);
@@ -429,7 +429,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Diocese));
 
             // Act
-            fixture.Transactor.Update(new object[] { chicago, derby, perth });
+            fixture.Transactor.Update([chicago, derby, perth]);
             var dioceseCmd = fixture.PrincipalCommands<Diocese>().UpdateCommand(ANY_ROWS);
             var dioceseUpdates = fixture.UpdatesFor(dioceseCmd);
             var bishopsInsertCmd = fixture.RelationCommands<Diocese>(0).InsertCommand(ANY_ROWS);
@@ -472,7 +472,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Placement));
 
             // Act
-            fixture.Transactor.Update(new object[] { placement });
+            fixture.Transactor.Update([placement]);
             var placementInsertCmd = fixture.PrincipalCommands<Placement>().InsertCommand(ANY_ROWS);
             var placementInsertions = fixture.InsertionsFor(placementInsertCmd);
             var placementDeleteCmd = fixture.PrincipalCommands<Placement>().DeleteCommand(ANY_ROWS);
@@ -503,7 +503,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Permissions));
 
             // Act
-            fixture.Transactor.Update(new object[] { permissions });
+            fixture.Transactor.Update([permissions]);
             var permissionsInsertCmd = fixture.PrincipalCommands<Permissions>().InsertCommand(ANY_ROWS);
             var permissionsInsertions = fixture.InsertionsFor(permissionsInsertCmd);
             var permissionsDeleteCmd = fixture.PrincipalCommands<Permissions>().DeleteCommand(ANY_ROWS);
@@ -534,7 +534,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(BinaryValue));
 
             // Act
-            fixture.Transactor.Update(new object[] { binary });
+            fixture.Transactor.Update([binary]);
             var binaryInsertCmd = fixture.PrincipalCommands<BinaryValue>().InsertCommand(ANY_ROWS);
             var binaryInsertions = fixture.InsertionsFor(binaryInsertCmd);
             var binaryDeleteCmd = fixture.PrincipalCommands<BinaryValue>().DeleteCommand(ANY_ROWS);
@@ -572,7 +572,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(BigBad));
 
             // Act
-            fixture.Transactor.Update(new object[] { bigBad });
+            fixture.Transactor.Update([bigBad]);
             var bigBadInsertCmd = fixture.PrincipalCommands<BigBad>().InsertCommand(ANY_ROWS);
             var bigBadInsertions = fixture.InsertionsFor(bigBadInsertCmd);
             var bigBadDeleteCmd = fixture.PrincipalCommands<BigBad>().DeleteCommand(ANY_ROWS);
@@ -617,7 +617,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(MinimumWage));
 
             // Act
-            fixture.Transactor.Update(new object[] { illinois, federal, hawaii });
+            fixture.Transactor.Update([illinois, federal, hawaii]);
             var wageInsertCmd = fixture.PrincipalCommands<MinimumWage>().InsertCommand(ANY_ROWS);
             var wageInsertions = fixture.InsertionsFor(wageInsertCmd);
             var wageDeleteCmd = fixture.PrincipalCommands<MinimumWage>().DeleteCommand(ANY_ROWS);
@@ -680,7 +680,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Waltz), typeof(Pacemaker), typeof(DemigodCamp));
 
             // Act
-            fixture.Transactor.Update(new object[] { waltz, pacemaker, camp });
+            fixture.Transactor.Update([waltz, pacemaker, camp]);
             var waltzCmd = fixture.PrincipalCommands<Waltz>().UpdateCommand(ANY_ROWS);
             var waltzUpdates = fixture.UpdatesFor(waltzCmd);
             var pacemakerCmd = fixture.PrincipalCommands<Pacemaker>().UpdateCommand(ANY_ROWS);
@@ -721,7 +721,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Philosophy), typeof(AlterEgo), typeof(Pain));
 
             // Act
-            fixture.Transactor.Update(new object[] { philosophy, alterEgo, pain });
+            fixture.Transactor.Update([philosophy, alterEgo, pain]);
             var philosophyInsertCmd = fixture.PrincipalCommands<Philosophy>().InsertCommand(ANY_ROWS);
             var philosophyInsertions = fixture.InsertionsFor(philosophyInsertCmd);
             var philosophyDeleteCmd = fixture.PrincipalCommands<Philosophy>().DeleteCommand(ANY_ROWS);
@@ -802,7 +802,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(PromoCode), typeof(PromoCode.Discout), typeof(PromoCode.Company));
 
             // Act
-            fixture.Transactor.Update(new object[] { company, discount, promoCode });
+            fixture.Transactor.Update([company, discount, promoCode]);
             var promoCodeCmd = fixture.PrincipalCommands<PromoCode>().UpdateCommand(ANY_ROWS);
             var promoCodeUpdates = fixture.UpdatesFor(promoCodeCmd);
             var companyCmd = fixture.PrincipalCommands<PromoCode.Company>().UpdateCommand(ANY_ROWS);
@@ -856,7 +856,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(WritOfCertiorari), typeof(WritOfCertiorari.Justice), typeof(WritOfCertiorari.Case), typeof(WritOfCertiorari.President));
 
             // Act
-            fixture.Transactor.Update(new object[] { writ, justice, courtCase, president });
+            fixture.Transactor.Update([writ, justice, courtCase, president]);
             var writeCmd = fixture.PrincipalCommands<WritOfCertiorari>().UpdateCommand(ANY_ROWS);
             var writUpdates = fixture.UpdatesFor(writeCmd);
             var justiceCmd = fixture.PrincipalCommands<WritOfCertiorari.Justice>().UpdateCommand(ANY_ROWS);
@@ -919,7 +919,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(HungerGames), typeof(HungerGames.PanemCitizen));
 
             // Act
-            fixture.Transactor.Update(new object[] { games, katniss, rue, marvel });
+            fixture.Transactor.Update([games, katniss, rue, marvel]);
             var hungerGamesCmd = fixture.PrincipalCommands<HungerGames>().UpdateCommand(ANY_ROWS);
             var hungerGamesUpdates = fixture.UpdatesFor(hungerGamesCmd);
             var citizenCmd = fixture.PrincipalCommands<HungerGames.PanemCitizen>().UpdateCommand(ANY_ROWS);
@@ -969,7 +969,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Daemon), typeof(LocalizedText));
 
             // Act
-            fixture.Transactor.Update(new object[] { daemon, daemon.Animal });
+            fixture.Transactor.Update([daemon, daemon.Animal]);
             var daemonCmd = fixture.PrincipalCommands<Daemon>().UpdateCommand(ANY_ROWS);
             var daemonUpdates = fixture.UpdatesFor(daemonCmd);
             var textInsertCmd = fixture.PrincipalCommands<LocalizedText>().InsertCommand(ANY_ROWS);
@@ -1025,7 +1025,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Vasectomy), typeof(Vasectomy.Doctor), typeof(Vasectomy.LocalizedStage));
 
             // Act
-            fixture.Transactor.Update(new object[] { doctor0, doctor1, vasectomy, vasectomy.Doctors });
+            fixture.Transactor.Update([doctor0, doctor1, vasectomy, vasectomy.Doctors]);
             var doctorUpdateCmd = fixture.PrincipalCommands<Vasectomy.Doctor>().UpdateCommand(ANY_ROWS);
             var doctorUpdates = fixture.UpdatesFor(doctorUpdateCmd);
             var vasectomyUpdateCmd = fixture.PrincipalCommands<Vasectomy>().UpdateCommand(ANY_ROWS);
@@ -1083,7 +1083,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Harbor), typeof(LocalizedText));
 
             // Act
-            fixture.Transactor.Update(new object[] { petapsco, harbor });
+            fixture.Transactor.Update([petapsco, harbor]);
             var harborCmd = fixture.PrincipalCommands<Harbor>().UpdateCommand(ANY_ROWS);
             var harborUpdates = fixture.UpdatesFor(harborCmd);
             var textInsertCmd = fixture.PrincipalCommands<LocalizedText>().InsertCommand(ANY_ROWS);
@@ -1134,49 +1134,49 @@ namespace UT.Kvasir.Transaction {
                 Father = "Dharma Raja",
                 MahabharataMentions = 204,
                 PrimaryWeapon = "spear",
-                Brothers = new RelationList<Pandava>()
+                Brothers = []
             };
             var arjuna = new Pandava() {
                 Name = "Arjuna",
                 Father = "Indra",
                 MahabharataMentions = 320,
                 PrimaryWeapon = "bow and arrow",
-                Brothers = new RelationList<Pandava>() { yudhishthira }
+                Brothers = [yudhishthira]
             };
             var bhima = new Pandava() {
                 Name = "Bhima",
                 Father = "Vayu",
                 MahabharataMentions = 141,
                 PrimaryWeapon = "mace",
-                Brothers = new RelationList<Pandava>() { yudhishthira, arjuna }
+                Brothers = [yudhishthira, arjuna]
             };
             var nakula = new Pandava() {
                 Name = "Nakula",
                 Father = "Nasatya",
                 MahabharataMentions = 13,
                 PrimaryWeapon = "sword",
-                Brothers = new RelationList<Pandava>() { yudhishthira, arjuna, bhima }
+                Brothers = [yudhishthira, arjuna, bhima]
             };
             var sahadeva = new Pandava() {
                 Name = "Sahadeva",
                 Father = "Kumara",
                 MahabharataMentions = 16,
                 PrimaryWeapon = "sword",
-                Brothers = new RelationList<Pandava>() { yudhishthira, arjuna, bhima, nakula }
+                Brothers = [yudhishthira, arjuna, bhima, nakula]
             };
             (yudhishthira.Brothers as IRelation).Canonicalize();
             (arjuna.Brothers as IRelation).Canonicalize();
             (bhima.Brothers as IRelation).Canonicalize();
             (nakula.Brothers as IRelation).Canonicalize();
             (sahadeva.Brothers as IRelation).Canonicalize();
-            yudhishthira.Brothers.AddRange(new Pandava[] { arjuna, bhima, nakula, sahadeva });
-            arjuna.Brothers.AddRange(new Pandava[] {bhima, nakula, sahadeva });
-            bhima.Brothers.AddRange(new Pandava[] { nakula, sahadeva });
-            nakula.Brothers.AddRange(new Pandava[] { sahadeva });
+            yudhishthira.Brothers.AddRange([arjuna, bhima, nakula, sahadeva]);
+            arjuna.Brothers.AddRange([bhima, nakula, sahadeva]);
+            bhima.Brothers.AddRange([nakula, sahadeva]);
+            nakula.Brothers.AddRange([sahadeva]);
             var fixture = new TestFixture(typeof(Pandava));
 
             // Act
-            fixture.Transactor.Update(new object[] { yudhishthira, arjuna, bhima, nakula, sahadeva });
+            fixture.Transactor.Update([yudhishthira, arjuna, bhima, nakula, sahadeva]);
             var pandavaCmd = fixture.PrincipalCommands<Pandava>().UpdateCommand(ANY_ROWS);
             var pandavaUpdates = fixture.UpdatesFor(pandavaCmd);
             var brothersInsertCmd = fixture.RelationCommands<Pandava>(0).InsertCommand(ANY_ROWS);
@@ -1245,7 +1245,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(DisneyPrincess), typeof(DisneyPrincess.Opinion));
 
             // Act
-            fixture.Transactor.Update(new object[] { jasmine, jasmine.ThoughtsOnOthers, nala, nala.ThoughtsOnOthers });
+            fixture.Transactor.Update([jasmine, jasmine.ThoughtsOnOthers, nala, nala.ThoughtsOnOthers]);
             var princessUpdateCmd = fixture.PrincipalCommands<DisneyPrincess>().UpdateCommand(ANY_ROWS);
             var princessUpdates = fixture.UpdatesFor(princessUpdateCmd);
             var opinionInsertCmd = fixture.PrincipalCommands<DisneyPrincess.Opinion>().InsertCommand(ANY_ROWS);
@@ -1291,7 +1291,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(ChatBot)).WithCommitError();
 
             // Act
-            var action = () => fixture.Transactor.Insert(new object[] { chatbot });
+            var action = () => fixture.Transactor.Insert([chatbot]);
 
             // Assert
             action.Should().ThrowExactly<InvalidOperationException>();
@@ -1312,7 +1312,7 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(SurgeonGeneral)).WithRollbackError();
 
             // Act
-            var action = () => fixture.Transactor.Update(new object[] { surgeonGeneral });
+            var action = () => fixture.Transactor.Update([surgeonGeneral]);
 
             // Assert
             action.Should().ThrowExactly<AggregateException>();
@@ -1325,6 +1325,6 @@ namespace UT.Kvasir.Transaction {
             var converter = new EnumToStringConverter(typeof(T)).ConverterImpl;
             return (string)converter.Convert(enumerator)!;
         }
-        private static readonly IEnumerable<IReadOnlyList<DBValue>> ANY_ROWS = Enumerable.Empty<IReadOnlyList<DBValue>>();
+        private static readonly IEnumerable<IReadOnlyList<DBValue>> ANY_ROWS = [];
     }
 }

--- a/test/UnitTests/Kvasir/Transaction/_Entities.cs
+++ b/test/UnitTests/Kvasir/Transaction/_Entities.cs
@@ -25,8 +25,8 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey] public Guid ProductID { get; set; }
             public string Brand { get; set; } = "";
             public Fruit Flavor { get; set; }
-            public RelationMap<string, double> NutritionInfo { get; init; } = new();
-            public RelationSet<Trait> Traits { get; init; } = new();
+            public RelationMap<string, double> NutritionInfo { get; init; } = [];
+            public RelationSet<Trait> Traits { get; init; } = [];
         }
 
         // Test Scenario: Single Localization
@@ -138,8 +138,8 @@ namespace UT.Kvasir.Transaction {
 
             [PrimaryKey] public Guid RegisterID { get; set; }
             public string Location { get; set; } = "";
-            public RelationMap<Currency, ushort> CashOnHand { get; init; } = new RelationMap<Currency, ushort>();
-            public RelationSet<Item> Sellables { get; init; } = new RelationSet<Item>();
+            public RelationMap<Currency, ushort> CashOnHand { get; init; } = [];
+            public RelationSet<Item> Sellables { get; init; } = [];
             public double Weight { get; set; }
             public bool IsDigital { get; set; }
             public string AdminCode { get; set; } = "";
@@ -180,7 +180,7 @@ namespace UT.Kvasir.Transaction {
         public class CrownJewel {
             [PrimaryKey] public Guid ID { get; set; }
             public string KnownAs { get; set; } = "";
-            public RelationList<LocalizedText> Components { get; init; } = new();
+            public RelationList<LocalizedText> Components { get; init; } = [];
             public double WeightPounds { get; set; }
             public string Monarchy { get; set; } = "";
             public ulong? AgeYears { get; set; }
@@ -194,7 +194,7 @@ namespace UT.Kvasir.Transaction {
             public ushort NumRows { get; set; }
             public ushort NumColumns { get; set; }
             public IReadOnlyRelationList<double> Eigenvalues { get; init; } = new RelationList<double>();
-            public RelationSet<Matrix> Inverses { get; init; } = new RelationSet<Matrix>();
+            public RelationSet<Matrix> Inverses { get; init; } = [];
             public Traits MatrixTraits { get; set; }
         }
 
@@ -326,8 +326,8 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public string TableID { get; set; } = "";
             [PrimaryKey, Column(1)] public ushort Year { get; set; }
             [Column(2)] public bool EndorsedBySSA { get; set; }
-            public RelationMap<int, double> MaleDeathProbability { get; init; } = new RelationMap<int, double>();
-            public RelationMap<int, double> FemaleDeathProbability { get; init; } = new RelationMap<int, double>();
+            public RelationMap<int, double> MaleDeathProbability { get; init; } = [];
+            public RelationMap<int, double> FemaleDeathProbability { get; init; } = [];
         }
 
         // Test Scenario: Single Instance of Single Entity with Empty Scalar Relation
@@ -342,7 +342,7 @@ namespace UT.Kvasir.Transaction {
         // Test Scenario: Multiple Instances of Single Entities with Scalar Relations
         public class Deodorant {
             [PrimaryKey, Column(0)] public Guid ProductID { get; set; }
-            public RelationOrderedList<string> Scents { get; init; } = new RelationOrderedList<string>();
+            public RelationOrderedList<string> Scents { get; init; } = [];
             [Column(1)] public string Brand { get; set; } = "";
             [Column(2)] public decimal Price { get; set; }
             [Column(3)] public bool Antipersperant { get; set; }
@@ -582,7 +582,7 @@ namespace UT.Kvasir.Transaction {
             [Column(2)] public Category TypeOfInstitute { get; set; }
             public IReadOnlyRelationMap<string, bool> Sodas { get; init; } = new RelationMap<string, bool>();
             [Column(3)] public bool IsCokeFreestyle { get; set; }
-            public RelationOrderedList<DateTime> Inspections { get; init; } = new();
+            public RelationOrderedList<DateTime> Inspections { get; init; } = [];
         }
 
         // Test Scenario: Single Instance of Single Entity with Empty Scalar Relation
@@ -600,7 +600,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid FundID { get; set; }
             [PrimaryKey, Column(1)] public Guid CompanyID { get; set; }
             [Column(2)] public decimal NAV { get; set; }
-            public RelationMap<string, decimal> Investors { get; init; } = new();
+            public RelationMap<string, decimal> Investors { get; init; } = [];
             [Column(3)] public string FundManager { get; set; } = "";
             [Column(4)] public double ManagementFee { get; set; }
         }
@@ -778,7 +778,7 @@ namespace UT.Kvasir.Transaction {
             [Column(2)] public string Executor { get; set; } = "";
             [Column(3)] public ulong TradedShares { get; set; }
             [Column(4)] public float InitialPercentageControlled { get; set; }
-            public RelationSet<LocalizedCurrency> BuyPrices { get; init; } = new();
+            public RelationSet<LocalizedCurrency> BuyPrices { get; init; } = [];
             [Column(5)] public bool WasSuccessful { get; set; }
             [Column(6)] public bool ProxyFight { get; set; }
         }
@@ -879,7 +879,7 @@ namespace UT.Kvasir.Transaction {
             [Column(2)] public string CompanySponsor { get; set; } = "";
             [Column(3)] public double PercentMatch { get; set; }
             [Column(4)] public decimal Balance { get; set; }
-            public RelationMap<DateTime, decimal> Deposits { get; init; } = new RelationMap<DateTime, decimal>();
+            public RelationMap<DateTime, decimal> Deposits { get; init; } = [];
         }
 
         // Test Scenario: Single Instance of Single Entity with Scalar Relation of Deleted Elements
@@ -889,7 +889,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid GameID { get; set; }
             [PrimaryKey, Column(1)] public uint Instance { get; set; }
             [Column(2)] public Which League { get; set; }
-            public RelationMap<string, string> Participants { get; init; } = new RelationMap<string, string>();
+            public RelationMap<string, string> Participants { get; init; } = [];
             [Column(3)] public string Referee { get; set; } = "";
         }
 
@@ -898,8 +898,8 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid BankID { get; set; }
             [PrimaryKey, Column(1)] public string Branch { get; set; } = "";
             [PrimaryKey, Column(2)] public short VaultNumber { get; set; }
-            public RelationMap<Guid, decimal> Storage { get; init; } = new();
-            public RelationOrderedList<sbyte> Combination { get; init; } = new();
+            public RelationMap<Guid, decimal> Storage { get; init; } = [];
+            public RelationOrderedList<sbyte> Combination { get; init; } = [];
         }
 
         // Test Scenario: Single Instance of Single Entity with Scalar Relation of Mixed-Status Elements
@@ -909,7 +909,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public string RollType { get; set; } = "";
             [PrimaryKey, Column(1)] public string Restaurant { get; set; } = "";
             [Column(2)] public decimal Price { get; set; }
-            public RelationSet<string> Ingredients { get; init; } = new();
+            public RelationSet<string> Ingredients { get; init; } = [];
             [Column(3)] public Color RiceType { get; set; }
         }
 
@@ -918,9 +918,9 @@ namespace UT.Kvasir.Transaction {
             public enum Wood { Birch, Cedar, Ash, Cherry, Cypress, Fir, Pine, Elm, Mahogany, Walnut, Maple, Bamboo }
 
             [PrimaryKey, Column(0)] public Guid WoodshopID { get; set; }
-            public RelationSet<string> Tools { get; init; } = new();
+            public RelationSet<string> Tools { get; init; } = [];
             [Column(1)] public string Owner { get; set; } = "";
-            public RelationOrderedList<Wood> TypesOfWood { get; init; } = new();
+            public RelationOrderedList<Wood> TypesOfWood { get; init; } = [];
             [Column(2)] public uint TotalIncidents { get; set; }
             [Column(3)] public decimal InsuranceCoverage { get; set; }
         }
@@ -932,7 +932,7 @@ namespace UT.Kvasir.Transaction {
             [Column(2)] public string Address { get; set; } = "";
             [Column(3)] public bool IsBodega { get; set; }
             public IReadOnlyRelationMap<string, decimal> Products { get; init; } = new RelationMap<string, decimal>();
-            public RelationOrderedList<string> Employees { get; init; } = new();
+            public RelationOrderedList<string> Employees { get; init; } = [];
         }
 
         // Test Scenario: Single Instance of Single Localization with Saved Values
@@ -983,7 +983,7 @@ namespace UT.Kvasir.Transaction {
             public Coordinate(Guid key) : base(key) {}
             public new string this[CoordinateForm locale] {
                 get { return this[locale]; }
-                set { this[locale] = value; }
+                set { base[locale] = value; }
             }
         }
 
@@ -1140,7 +1140,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid BarNumber { get; set; }
             [Column(1)] public string Name { get; set; } = "";
             [Column(2)] public string AlmaMater { get; set; } = "";
-            public RelationOrderedList<LocalizedNullableText> Employers { get; init; } = new();
+            public RelationOrderedList<LocalizedNullableText> Employers { get; init; } = [];
             [Column(3)] public double WinPercentage { get; set; }
             [Column(4)] public decimal AnnualSalary { get; set; }
             [Column(5)] public bool HasBeenDisbarred { get; set; }
@@ -1227,7 +1227,7 @@ namespace UT.Kvasir.Transaction {
 
             [PrimaryKey, Column(0)] public DateTime Airdate { get; set; }
             [Column(1)] public Kind Variety { get; set; }
-            public RelationMap<string, Team> Teams { get; init; } = new();
+            public RelationMap<string, Team> Teams { get; init; } = [];
             [Column(2)] public ulong YouTubeViews { get; set; }
             [Column(3)] public double TelevisionRating { get; set; }
         }
@@ -1237,7 +1237,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid GuacamoleID { get; set; }
             [Column(1)] public string Preparer { get; set; } = "";
             [Column(2)] public ushort NumServings { get; set; }
-            public RelationSet<string> Ingredients { get; init; } = new();
+            public RelationSet<string> Ingredients { get; init; } = [];
             [Column(3)] public bool MadeInMolcajete { get; set; }
         }
 
@@ -1248,7 +1248,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid DropsID { get; set; }
             [Column(1)] public string BrandName { get; set; } = "";
             [Column(2)] public ulong Prescriptions { get; set; }
-            public RelationMap<Condition, bool> TreatmentPlan { get; init; } = new();
+            public RelationMap<Condition, bool> TreatmentPlan { get; init; } = [];
             [Column(3)] public bool SafeForChildren { get; set; }
             [Column(4)] public bool Dilatory { get; set; }
             [Column(5)] public sbyte MaxDropsPerDay { get; set; }
@@ -1269,7 +1269,7 @@ namespace UT.Kvasir.Transaction {
             [Column(2)] public string? Artist { get; set; }
             [Column(3)] public string HorsebackFigure { get; set; } = "";
             [Column(4)] public sbyte NumHorses { get; set; }
-            public RelationMap<Dimension, Measurement> Dimensions { get; init; } = new();
+            public RelationMap<Dimension, Measurement> Dimensions { get; init; } = [];
         }
 
         // Test Scenario: Single Instance of Single Entity with Scalar Relation of Modified Elements
@@ -1286,7 +1286,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public Guid ID { get; set; }
             [Column(1)] public string For { get; set; } = "";
             [Column(2)] public Standard Style { get; set; }
-            public RelationOrderedList<Reference> References { get; init; } = new();
+            public RelationOrderedList<Reference> References { get; init; } = [];
             [Column(3)] public byte NumPages { get; set; }
         }
 
@@ -1295,7 +1295,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public string PrimaryMPID { get; set; } = "";
             [Column(1)] public string FirmName { get; set; } = "";
             [Column(2)] public decimal NetCapital { get; set; }
-            public RelationOrderedList<string> Symbols { get; init; } = new();
+            public RelationOrderedList<string> Symbols { get; init; } = [];
             [Column(3)] public bool IsDesignated { get; set; }
         }
 
@@ -1308,7 +1308,7 @@ namespace UT.Kvasir.Transaction {
             [Column(2)] public Language ScrollLanguage { get; set; }
             [Column(3)] public string BiblicalSource { get; set; } = "";
             [Column(4)] public ushort DiscoveryYear { get; set; }
-            public RelationSet<string> VerifiedAuthors { get; init; } = new();
+            public RelationSet<string> VerifiedAuthors { get; init; } = [];
         }
 
         // Test Scenario: Multiple Instances of Single Entities with Scalar Relations
@@ -1322,7 +1322,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(1)] public string Church { get; set; } = "";
             [Column(2)] public bool IsArchdiocese { get; set; }
             [Column(3)] public ushort Parishes { get; set; }
-            public RelationMap<string, DateRange> Bishops { get; init; } = new();
+            public RelationMap<string, DateRange> Bishops { get; init; } = [];
         }
 
         // Test Scenario: Single Instance of Single Localization with Saved Values
@@ -1492,7 +1492,7 @@ namespace UT.Kvasir.Transaction {
 
             [PrimaryKey, Column(0)] public int Incarnation { get; set; }
             [Column(1)] public string Gamemaker { get; set; } = "";
-            public RelationMap<PanemCitizen, PanemCitizen?> Killers { get; init; } = new();
+            public RelationMap<PanemCitizen, PanemCitizen?> Killers { get; init; } = [];
             [Column(2)] public bool IsQuarterQuell { get; set; }
             [Column(3)] public string President { get; set; } = "";
         }
@@ -1540,7 +1540,7 @@ namespace UT.Kvasir.Transaction {
             [Column(1)] public ulong ShippingTons { get; set; }
             [Column(2)] public double DraftDepth { get; set; }
             [Column(3)] public double AirDraft { get; set; }
-            public RelationMap<LocalizedText, Flow> Rivers { get; init; } = new();
+            public RelationMap<LocalizedText, Flow> Rivers { get; init; } = [];
             [Column(4)] public string OperatedBy { get; set; } = "";
         }
 
@@ -1549,7 +1549,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
             [Column(1)] public string Father { get; set; } = "";
             [Column(2)] public ulong MahabharataMentions { get; set; }
-            public RelationList<Pandava> Brothers { get; init; } = new();
+            public RelationList<Pandava> Brothers { get; init; } = [];
             [Column(3)] public string PrimaryWeapon { get; set; } = "";
         }
 
@@ -1673,7 +1673,7 @@ namespace UT.Kvasir.Transaction {
             public sbyte Willpower { get; set; }
             public sbyte Lore { get; set; }
             public Color InkColor { get; set; }
-            public RelationOrderedList<string> Effects { get; init; } = new();
+            public RelationOrderedList<string> Effects { get; init; } = [];
         }
 
         // Scenario: Schema Management Table Contains Mismatched Hash for at Least One Principal Table (✗error✗)
@@ -1692,7 +1692,7 @@ namespace UT.Kvasir.Transaction {
             [PrimaryKey] public uint GameID { get; set; }
             public DateTime GameRelease { get; set; }
             public string SolutionCommon { get; set; } = "";
-            public RelationMap<string, string> SolutionScientific { get; init; } = new();
+            public RelationMap<string, string> SolutionScientific { get; init; } = [];
             public double AverageGuesses { get; set; }
         }
 

--- a/test/UnitTests/Kvasir/Transaction/_Fixture.cs
+++ b/test/UnitTests/Kvasir/Transaction/_Fixture.cs
@@ -32,15 +32,15 @@ namespace UT.Kvasir.Transaction {
         public int AdminCommits { get; private set; }
 
         public TestFixture(params Type[] types) {
-            commands_ = new Dictionary<ITable, ICommands>();
-            dbRows_ = new Dictionary<ITable, IEnumerator<IReadOnlyList<object>>>();
+            commands_ = [];
+            dbRows_ = [];
             commandsFactory_ = Substitute.For<ICommandsFactory>();
             Connection = Substitute.For<IDbConnection>();
             Transaction = Connection.BeginTransaction();
             Depot = types.ToDictionary(t => t, _ => new List<object>());
             translator_ = new Translator(t => Depot[t], NullLogger.Instance);
-            ordering_ = new Dictionary<IDbCommand, int>();
-            invocationArgs_ = new Dictionary<IDbCommand, IReadOnlyList<IReadOnlyList<DBValue>>>();
+            ordering_ = [];
+            invocationArgs_ = [];
 
             Connection.State.Returns(ConnectionState.Open);
 
@@ -116,7 +116,7 @@ namespace UT.Kvasir.Transaction {
             while (dbRows_[table].MoveNext()) {
                 rows.Add(dbRows_[table].Current);
             }
-            rows.Add(new List<object>(values));
+            rows.Add([..values]);
 
             dbRows_[table] = rows.GetEnumerator();
             return this;
@@ -127,7 +127,7 @@ namespace UT.Kvasir.Transaction {
             while (dbRows_[table].MoveNext()) {
                 rows.Add(dbRows_[table].Current);
             }
-            rows.Add(new List<object>(values));
+            rows.Add([..values]);
 
             dbRows_[table] = rows.GetEnumerator();
             return this;
@@ -138,7 +138,7 @@ namespace UT.Kvasir.Transaction {
             while (dbRows_[table].MoveNext()) {
                 rows.Add(dbRows_[table].Current);
             }
-            rows.Add(new List<object>(values));
+            rows.Add([..values]);
 
             dbRows_[table] = rows.GetEnumerator();
             return this;
@@ -167,19 +167,19 @@ namespace UT.Kvasir.Transaction {
             if (invocationArgs_.TryGetValue(command, out IReadOnlyList<IReadOnlyList<DBValue>>? value)) {
                 return value;
             }
-            return Enumerable.Empty<IReadOnlyList<DBValue>>();
+            return [];
         }
         public Rows UpdatesFor(IDbCommand command) {
             if (invocationArgs_.TryGetValue(command, out IReadOnlyList<IReadOnlyList<DBValue>>? value)) {
                 return value;
             }
-            return Enumerable.Empty<IReadOnlyList<DBValue>>();
+            return [];
         }
         public Rows DeletionsFor(IDbCommand command) {
             if (invocationArgs_.TryGetValue(command, out IReadOnlyList<IReadOnlyList<DBValue>>? value)) {
                 return value;
             }
-            return Enumerable.Empty<IReadOnlyList<DBValue>>();
+            return [];
         }
 
         public ITable PrincipalTableOf<TEntity>() {

--- a/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
+++ b/test/UnitTests/Kvasir/Translation/ComparisonConstraints.cs
@@ -517,7 +517,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidConstraintValueException>()
                 .WithLocation("`ChristianDenomination` → Founded")
-                .WithProblem($"unable to parse `string` value \"0001_01_01\" as a `DateTime`")
+                .WithProblem("unable to parse `string` value \"0001_01_01\" as a `DateTime`")
                 .WithAnnotations("[Check.IsGreaterThan]")
                 .EndMessage();
         }
@@ -533,7 +533,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidConstraintValueException>()
                 .WithLocation("`GraduateThesis` → Argued")
-                .WithProblem($"unable to parse `string` value \"1873-15-12\" as a `DateTime`")
+                .WithProblem("unable to parse `string` value \"1873-15-12\" as a `DateTime`")
                 .WithAnnotations("[Check.IsGreaterThan]")
                 .EndMessage();
         }
@@ -1312,7 +1312,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidConstraintValueException>()
                 .WithLocation("`Shogunate` → Established")
-                .WithProblem($"unable to parse `string` value \"Wednesday, August 18, 1988\" as a `DateTime`")
+                .WithProblem("unable to parse `string` value \"Wednesday, August 18, 1988\" as a `DateTime`")
                 .WithAnnotations("[Check.IsLessThan]")
                 .EndMessage();
         }
@@ -1328,7 +1328,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidConstraintValueException>()
                 .WithLocation("`ISOStandard` → Adopted")
-                .WithProblem($"unable to parse `string` value \"1735-02-48\" as a `DateTime`")
+                .WithProblem("unable to parse `string` value \"1735-02-48\" as a `DateTime`")
                 .WithAnnotations("[Check.IsLessThan]")
                 .EndMessage();
         }
@@ -2102,7 +2102,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidConstraintValueException>()
                 .WithLocation("`WorldCup` → ChampionshipDate")
-                .WithProblem($"unable to parse `string` value \"1111(11)11\" as a `DateTime`")
+                .WithProblem("unable to parse `string` value \"1111(11)11\" as a `DateTime`")
                 .WithAnnotations("[Check.IsGreaterOrEqualTo]")
                 .EndMessage();
         }
@@ -2118,7 +2118,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidConstraintValueException>()
                 .WithLocation("`SharkTankPitch` → AirDate")
-                .WithProblem($"unable to parse `string` value \"91237-00-16\" as a `DateTime`")
+                .WithProblem("unable to parse `string` value \"91237-00-16\" as a `DateTime`")
                 .WithAnnotations("[Check.IsGreaterOrEqualTo]")
                 .EndMessage();
         }
@@ -2891,7 +2891,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidConstraintValueException>()
                 .WithLocation("`KentuckyDerby` → Racetime")
-                .WithProblem($"unable to parse `string` value \"2317-04-19 @ 2:00pm\" as a `DateTime`")
+                .WithProblem("unable to parse `string` value \"2317-04-19 @ 2:00pm\" as a `DateTime`")
                 .WithAnnotations("[Check.IsLessOrEqualTo]")
                 .EndMessage();
         }
@@ -2907,7 +2907,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidConstraintValueException>()
                 .WithLocation("`Firearm` → Manufactured")
-                .WithProblem($"unable to parse `string` value \"1927-03-109\" as a `DateTime`")
+                .WithProblem("unable to parse `string` value \"1927-03-109\" as a `DateTime`")
                 .WithAnnotations("[Check.IsLessOrEqualTo]")
                 .EndMessage();
         }
@@ -3604,7 +3604,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidConstraintValueException>()
                 .WithLocation("`Mosque` → Established")
-                .WithProblem($"unable to parse `string` value \"1.4.5.0.1.0.3.0\" as a `DateTime`")
+                .WithProblem("unable to parse `string` value \"1.4.5.0.1.0.3.0\" as a `DateTime`")
                 .WithAnnotations("[Check.IsNot]")
                 .EndMessage();
         }
@@ -3620,7 +3620,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidConstraintValueException>()
                 .WithLocation("`Lease` → StartDate")
-                .WithProblem($"unable to parse `string` value \"1637-07-8819\" as a `DateTime`")
+                .WithProblem("unable to parse `string` value \"1637-07-8819\" as a `DateTime`")
                 .WithAnnotations("[Check.IsNot]")
                 .EndMessage();
         }

--- a/test/UnitTests/Kvasir/Translation/Extraction.cs
+++ b/test/UnitTests/Kvasir/Translation/Extraction.cs
@@ -735,7 +735,7 @@ namespace UT.Kvasir.Translation {
             var pretzel = new Pretzel() {
                 PretzelID = Guid.NewGuid(),
                 Name = "Plain Pretzel",
-                Toppings = new(),
+                Toppings = [],
                 RetailPrice = 2.75M,
                 DoughSource = "Flour"
             };
@@ -756,12 +756,12 @@ namespace UT.Kvasir.Translation {
             var teppanyaki = new Teppanyaki() {
                 GrillID = Guid.NewGuid(),
                 GrillSurfaceArea = 88.5,
-                AuthorizedChefs = new() {
+                AuthorizedChefs = [
                     "Daisuke Orinaka",
                     "Kaidon Hotosata",
                     "Hideki Iwanatsuo",
-                },
-                SupportedFoods = new() {
+                ],
+                SupportedFoods = [
                     "Chicken",
                     "Beef",
                     "Onion",
@@ -769,7 +769,7 @@ namespace UT.Kvasir.Translation {
                     "Shrimp",
                     "Daikon",
                     "Fried Rice"
-                },
+                ],
                 MaxTemperature = 140,
                 Restaurant = null,
                 IsHibachi = false
@@ -974,12 +974,12 @@ namespace UT.Kvasir.Translation {
                 BoonName = "Curse of Pain",
                 Benefactor = OlympianBoon.Deity.Ares,
                 AbilityAffected = OlympianBoon.Ability.Special,
-                Progressions = new() {
+                Progressions = [
                     new OlympianBoon.Benefit() { ParameterName = "Damage", ParameterValue = 60 },
                     new OlympianBoon.Benefit() { ParameterName = "Damage", ParameterValue = 80 },
                     new OlympianBoon.Benefit() { ParameterName = "Damage", ParameterValue = 100 },
                     new OlympianBoon.Benefit() { ParameterName = "Damage", ParameterValue = 120 }
-                },
+                ],
                 Likelihood = 0.2
             };
 
@@ -1004,7 +1004,7 @@ namespace UT.Kvasir.Translation {
                 Official = "Samuel Chase",
                 Position = "Associate Justice of the U.S. Supreme Court",
                 Commenced = new DateTime(1804, 3, 12),
-                Counts = new() {
+                Counts = [
                     new Impeachment.Count() {
                         ID = Guid.NewGuid(),
                         Claim = new Impeachment.Charge() {
@@ -1029,7 +1029,7 @@ namespace UT.Kvasir.Translation {
                         },
                         Guilty = false
                     }
-                }
+                ]
             };
 
             // Act
@@ -1051,7 +1051,7 @@ namespace UT.Kvasir.Translation {
             var god = new MaoriGod() {
                 Name = "Tangaroa",
                 Domain = "Sea",
-                Family = new(),
+                Family = [],
                 IsAtua = true,
                 EncounteredMaui = true
             };
@@ -1085,12 +1085,12 @@ namespace UT.Kvasir.Translation {
                     Machines = new DataCenter.Computers() {
                         NumCabinets = 50,
                         RacksPerCabinet = 25,
-                        Brands = new() {
+                        Brands = [
                             "Apple",
                             "Microsoft",
                             "Lenovo",
                             "Dell"
-                        }
+                        ]
                     }
                 }
             };
@@ -1339,12 +1339,12 @@ namespace UT.Kvasir.Translation {
                 Challenge = "Chocolate Fondue Display",
                 WinningBaker = "Aaron Mountford-Myles",
                 WorstBaker = "Nadia Mercuri",
-                Ingredients = new RelationSet<LocalizedText>() {
+                Ingredients = [
                     new LocalizedText("CHOCOLATE_LOC"),
                     new LocalizedText("RASPBERRY_LOC"),
                     new LocalizedText("LEMON_LOC"),
                     new LocalizedText("ALMONDS_LOC")
-                }
+                ]
             };
 
             // Act
@@ -1479,7 +1479,7 @@ namespace UT.Kvasir.Translation {
             var festigal = new Festigal() {
                 Year = 2010,
                 HostCity = "Tel Aviv",
-                Songs = new RelationOrderedList<LocalizedText>() {
+                Songs = [
                     new LocalizedText("Lailah M'toref Festigal"),
                     new LocalizedText("Yeled Im Khalom"),
                     new LocalizedText("LaGa'at Ba'avar"),
@@ -1490,7 +1490,7 @@ namespace UT.Kvasir.Translation {
                     new LocalizedText("K'sh'emtza Otkha"),
                     new LocalizedText("Al Tafsik Tigrov"),
                     new LocalizedText("Nig'm'ru Li HaMilim")
-                },
+                ],
                 Opening = new DateOnly(2010, 12, 2),
                 Theme = "History",
                 NumPerformers = 137

--- a/test/UnitTests/Kvasir/Translation/_Constraints.cs
+++ b/test/UnitTests/Kvasir/Translation/_Constraints.cs
@@ -15,7 +15,7 @@ namespace UT.Kvasir.Translation {
             static CustomCheck() {
                 Generator = Substitute.For<IConstraintGenerator>();
                 Clause = Substitute.For<Clause>();
-                LastCtorArgs = Array.Empty<object?>();
+                LastCtorArgs = [];
 
                 Generator.MakeConstraint(
                     Arg.Any<IEnumerable<IField>>(),

--- a/test/UnitTests/Kvasir/Translation/_Converters.cs
+++ b/test/UnitTests/Kvasir/Translation/_Converters.cs
@@ -32,8 +32,8 @@ namespace UT.Kvasir.Translation {
         }
         public class MakeDate<T> : IDataConverter<T, DateTime> where T : notnull {
             public MakeDate() {
-                conversions_ = new Dictionary<T, DateTime>();
-                reversions_ = new Dictionary<DateTime, T>();
+                conversions_ = [];
+                reversions_ = [];
                 lastDate_ = new DateTime(2000, 1, 1);
             }
             public DateTime Convert(T source) {

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -115,7 +115,7 @@ namespace UT.Kvasir.Translation {
         public class Eigenvector {
             [PrimaryKey] public Guid ID { get; set; }
             public float Eigenvalue { get; set; }
-            public ArrayList Vector { get; set; } = new();
+            public ArrayList Vector { get; set; } = [];
         }
 
         // Test Scenario: Struct Type from the C# Standard Library (✓recognized✓)
@@ -175,7 +175,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid BadgeID { get; set; }
             public string Name { get; set; } = "";
             public Group AwardedBy { get; set; }
-            public uint[] PointsRequired { get; set; } = new uint[] {};
+            public uint[] PointsRequired { get; set; } = [];
             public double PercentAcquired { get; set; }
             public DateTime Introduced { get; set; }
         }
@@ -395,10 +395,10 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public string Project { get; set; } = "";
             [PrimaryKey] public string TargetName { get; set; } = "";
-            public RelationList<string> Files { get; init; } = new();
-            public RelationSet<Macro> Macros { get; init; } = new();
-            public RelationMap<Mode, int> OptimizationLevel { get; init; } = new();
-            public RelationOrderedList<string> LinkAgainst { get; init; } = new();
+            public RelationList<string> Files { get; init; } = [];
+            public RelationSet<Macro> Macros { get; init; } = [];
+            public RelationMap<Mode, int> OptimizationLevel { get; init; } = [];
+            public RelationOrderedList<string> LinkAgainst { get; init; } = [];
         }
 
         // Test Scenario: Read-Only Relations (✓recognized✓)
@@ -451,8 +451,8 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Identifier { get; set; } = "";
             public string? Constellation { get; set; }
             public string? Galaxy { get; set; }
-            public RelationSet<string> AKAs { get; init; } = new();
-            public RelationMap<string, RelationMap<string, double>> Measurements { get; init; } = new();
+            public RelationSet<string> AKAs { get; init; } = [];
+            public RelationMap<string, RelationMap<string, double>> Measurements { get; init; } = [];
         }
 
         // Test Scenario: Relation as Localization Locale (✗not permitted✗)
@@ -529,7 +529,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid PollID { get; set; }
             public string PollTitle { get; set; } = "";
             public string? Pollster { get; set; }
-            public RelationList<Question> Questions { get; init; } = new();
+            public RelationList<Question> Questions { get; init; } = [];
             public ulong Responses { get; set; }
             public double ReponseRate { get; set; }
         }
@@ -561,7 +561,7 @@ namespace UT.Kvasir.Translation {
             public DateTime Date { get; set; }
             public string BirthdayGirl { get; set; } = "";
             public Gift BestGift { get; set; }
-            public RelationMap<string, Gift> Presents { get; } = new();
+            public RelationMap<string, Gift> Presents { get; } = [];
             public bool InMexico { get; set; }
         }
 
@@ -576,7 +576,7 @@ namespace UT.Kvasir.Translation {
             }
 
             public sealed class LocalizedCitation : Localization<string, Version, Citation> {
-                public LocalizedCitation(string key) : base(key) { }
+                public LocalizedCitation(string key) : base(key) {}
             }
 
             [PrimaryKey] public Guid ParableID { get; set; }
@@ -593,7 +593,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid ID { get; set; }
             public string Subject { get; set; } = "";
             public string Artist { get; set; } = "";
-            public RelationSet<KeyValuePair<DateTime, decimal>> SaleHistory { get; init; } = new();
+            public RelationSet<KeyValuePair<DateTime, decimal>> SaleHistory { get; init; } = [];
             public double HeadSize { get; set; }
             public bool Certified { get; set; }
             public Location Source { get; set; }
@@ -613,14 +613,14 @@ namespace UT.Kvasir.Translation {
         public class BugZapper {
             [PrimaryKey] public Guid ProductID { get; set; }
             public decimal RetailPrice { get; set; }
-            public RelationSet<string> SusceptibleSpecies { get; set; } = new();
+            public RelationSet<string> SusceptibleSpecies { get; set; } = [];
             public bool IsScented { get; set; }
             public float MaxVoltage { get; set; }
         }
 
         // Test Scenario: Aggregate Consisting of Only Relations (✓recognized✓)
         public class Loch {
-            public record struct Geography {
+            public readonly record struct Geography {
                 public RelationMap<char, float> Coordinates { get; }
                 public IReadOnlyRelationSet<string> Shires { get; }
             }
@@ -674,7 +674,7 @@ namespace UT.Kvasir.Translation {
         public class AdventCalendar {
             [PrimaryKey] public Guid CalendarID { get; set; }
             public decimal Price { get; set; }
-            public RelationMap<LocalizedDate, string> Gifts { get; } = new();
+            public RelationMap<LocalizedDate, string> Gifts { get; } = [];
             public bool IsPhysical { get; set; }
         }
 
@@ -683,7 +683,7 @@ namespace UT.Kvasir.Translation {
             public enum Means { LethalInjection, ElectricChair, FiringSquad, Guillotine, DrawnAndQuartered, Hanged, Vigilante, Other }
 
             public class LocalizedCrime : Localization<string, LocalizedText, bool> {
-                public LocalizedCrime(string key) : base(key) { }
+                public LocalizedCrime(string key) : base(key) {}
             }
 
             [PrimaryKey] public ushort Year { get; set; }
@@ -908,7 +908,7 @@ namespace UT.Kvasir.Translation {
 
         // Test Scenario: Abstract Localization (✗not permitted✗)
         public abstract class Trademark : Localization<int, Language, string> {
-            protected Trademark(int key) : base(key) { }
+            protected Trademark(int key) : base(key) {}
         }
 
         // Test Scenario: Generic Type (✗not permitted✗)
@@ -1287,7 +1287,7 @@ namespace UT.Kvasir.Translation {
                 GameID = id;
                 Title = title;
                 ReleaseDate = release;
-                Modes = new RelationSet<GamingMode>() { GamingMode.SinglePlayer, GamingMode.MultiPlayer };
+                Modes = [GamingMode.SinglePlayer, GamingMode.MultiPlayer];
             }
         }
 
@@ -1807,7 +1807,7 @@ namespace UT.Kvasir.Translation {
             }
 
             public class LocalizedCompany : Localization<string, char, Company> {
-                public LocalizedCompany(string key) : base(key) { }
+                public LocalizedCompany(string key) : base(key) {}
             }
 
             public struct Corporation {
@@ -2501,9 +2501,9 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public string City { get; set; } = "";
             public ulong PersonsImpacted { get; set; }
-            public RelationList<SingleDay> Dailies { get; init; } = new();
+            public RelationList<SingleDay> Dailies { get; init; } = [];
             public RelationSet<string>? Meteorologists { get; init; }
-            public RelationOrderedList<Extremity> ExtremeWeather { get; init; } = new();
+            public RelationOrderedList<Extremity> ExtremeWeather { get; init; } = [];
         }
 
         // Test Scenario: Relations with Nullable Element Types (✓respected✓)
@@ -2514,9 +2514,9 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid ID { get; set; }
             public string Address { get; set; } = "";
             public ulong MailVolume { get; set; }
-            public RelationMap<short, string?> POBoxes { get; } = new();
-            public RelationMap<DateTime, Stamp?> Stamps { get; } = new();
-            public RelationOrderedList<decimal?> Budgets { get; } = new();
+            public RelationMap<short, string?> POBoxes { get; } = [];
+            public RelationMap<DateTime, Stamp?> Stamps { get; } = [];
+            public RelationOrderedList<decimal?> Budgets { get; } = [];
         }
 
         // Test Scenario: RelationList with Nullable Element (✗illegal✗)
@@ -2537,7 +2537,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public Guid AnthropologicalIdentifier { get; set; }
             public string? Culture { get; set; }
-            public RelationSet<Coordinate?> Locations { get; init; } = new();
+            public RelationSet<Coordinate?> Locations { get; init; } = [];
             public double TotalArea { get; set; }
             public Kind Varieties { get; set; }
         }
@@ -2546,10 +2546,10 @@ namespace UT.Kvasir.Translation {
         public class Naiad {
             public enum Source { Fountain, Spring, Brook, Stream, Well, Other }
 
-            [PrimaryKey] public string Name { get; set; }
+            [PrimaryKey] public string Name { get; set; } = "";
             [PrimaryKey] public byte Discriminator { get; set; }
             public Source FreshwaterSource { get; set; }
-            public RelationMap<string?, string?> Relationships { get; init; }
+            public RelationMap<string?, string?> Relationships { get; init; } = new();
             public string? DeityConsort { get; set; }
         }
 
@@ -2562,7 +2562,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Point Vertex { get; set; }
             [PrimaryKey] public float Eccentricity { get; set; }
             public Direction Concavity { get; set; }
-            public RelationOrderedList<MaybePoint?> Points { get; } = new();
+            public RelationOrderedList<MaybePoint?> Points { get; } = [];
         }
 
         // Test Scenario: Relation Property Marked as [NonNullable] (✓becomes non-nullable✓)
@@ -2572,7 +2572,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string FirstName { get; set; } = "";
             [PrimaryKey] public string LastName { get; set; } = "";
             public bool IsFemale { get; set; }
-            [NonNullable] public RelationList<Episode>? Appearances { get; } = new();
+            [NonNullable] public RelationList<Episode>? Appearances { get; } = [];
             public bool HasTemperancesApproval { get; set; }
         }
 
@@ -2582,7 +2582,7 @@ namespace UT.Kvasir.Translation {
             public string Formulation { get; set; } = "";
             public string? PostulatedBy { get; set; }
             public bool IsLogical { get; set; }
-            [Nullable] public RelationSet<string> DerivedTheories { get; } = new();
+            [Nullable] public RelationSet<string> DerivedTheories { get; } = [];
         }
 
         // Test Scenario: Pre-Defined Instance Property Marked as [NonNullable] (✓redundant✓)
@@ -2712,8 +2712,8 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid SwapID { get; set; }
             public string PartyA { get; set; } = "";
             public string PartyB { get; set; } = "";
-            public RelationSet<ushort> AtoB { get; } = new();
-            public RelationSet<ushort> BtoA { get; } = new();
+            public RelationSet<ushort> AtoB { get; } = [];
+            public RelationSet<ushort> BtoA { get; } = [];
             public DateTime Executed { get; set; }
             public bool Covert { get; set; }
         }
@@ -2832,7 +2832,7 @@ namespace UT.Kvasir.Translation {
         // Test Scenario: New Relation Table Name (✓renamed✓)
         public class MagicalPreserve {
             [PrimaryKey] public string Name { get; set; } = "";
-            [RelationTable("CreaturesTable")] public RelationMap<string, int> Population { get; } = new();
+            [RelationTable("CreaturesTable")] public RelationMap<string, int> Population { get; } = [];
             public string SecretArtifact { get; set; } = "";
             public DateTime? Founding { get; set; }
             public string PrimaryCaretaker { get; set; } = "";
@@ -2849,7 +2849,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public string School { get; set; } = "";
             [PrimaryKey] public ushort Year { get; set; }
-            [RelationTable("UT.Kvasir.Translation.TableNaming+PacerTest.LapsCompletedTable")] public RelationMap<Student, byte> LapsCompleted { get; } = new();
+            [RelationTable("UT.Kvasir.Translation.TableNaming+PacerTest.LapsCompletedTable")] public RelationMap<Student, byte> LapsCompleted { get; } = [];
             public DateTime AdministeredOn { get; set; }
         }
 
@@ -2858,7 +2858,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid DwarfID { get; set; }
             public bool IsFictional { get; set; }
             public string Name { get; set; } = "";
-            [RelationTable(null!)] public RelationMap<DateTime, string> LifeEvents { get; } = new();
+            [RelationTable(null!)] public RelationMap<DateTime, string> LifeEvents { get; } = [];
             public byte Height { get; set; }
             public bool WieldsSword { get; set; }
             public double ShoeSize { get; set; }
@@ -2870,7 +2870,7 @@ namespace UT.Kvasir.Translation {
             public enum IUCN { Extinct, CaptivityOnly, CriticallyEndangered, Endangered, Vulnerable, NearThreatened, LeastConcern }
 
             [PrimaryKey] public string CommonName { get; set; } = "";
-            [RelationTable("")] public RelationMap<Taxon, string> Taxonomy { get; } = new();
+            [RelationTable("")] public RelationMap<Taxon, string> Taxonomy { get; } = [];
             public double AverageAdultMaleWeight { get; set; }
             public double AverageAdultFemaleWeight { get; set; }
             public float TailLength { get; set; }
@@ -2884,7 +2884,7 @@ namespace UT.Kvasir.Translation {
         public class Neuron {
             [PrimaryKey] public Guid NeuronID { get; set; }
             public float Length { get; set; }
-            [RelationTable("_Kvasir_Transmitters")] public RelationSet<string> NeurotransmittersSupported { get; init; } = new();
+            [RelationTable("_Kvasir_Transmitters")] public RelationSet<string> NeurotransmittersSupported { get; init; } = [];
             public float Potential { get; set; }
             public ulong NumDendrites { get; set; }
         }
@@ -2899,8 +2899,8 @@ namespace UT.Kvasir.Translation {
             public bool Closed { get; set; }
             public bool Long { get; set; }
             public Feature Features { get; set; }
-            [RelationTable("AuxiliaryVowelTable")] public RelationSet<string> Languages { get; } = new();
-            [RelationTable("AuxiliaryVowelTable")] public RelationMap<char, char> Diacritics { get; } = new();
+            [RelationTable("AuxiliaryVowelTable")] public RelationSet<string> Languages { get; } = [];
+            [RelationTable("AuxiliaryVowelTable")] public RelationMap<char, char> Diacritics { get; } = [];
         }
 
         // Test Scenario: Table Name Duplicated between Principal Table and Relation Table (✗duplication✗)
@@ -2911,7 +2911,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string IP { get; set; } = "";
             public Kind Type { get; set; }
             public bool PasswordProtected { get; set; }
-            [RelationTable("OfficialInfoVPN")] public RelationList<Guid> AuthorizedUsers { get; } = new();
+            [RelationTable("OfficialInfoVPN")] public RelationList<Guid> AuthorizedUsers { get; } = [];
         }
 
         // Test Scenario: [RelationTable] Applied to Numeric Field (✗impermissible✗)
@@ -3243,20 +3243,20 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid KidneyStoneID { get; set; }
             public float Size { get; set; }
             public string Patient { get; set; } = "";
-            [Name("MaterialsTable")] public RelationSet<string> Composition { get; } = new();
+            [Name("MaterialsTable")] public RelationSet<string> Composition { get; } = [];
             public bool HasPassed { get; set; }
         }
 
         // Test Scenario: Change Relation-Nested Field Name to New Value (✓renamed✓)
         public class SwissCanton {
             [PrimaryKey] public Guid ID { get; set; }
-            [Name("Canton", Path = "SwissCanton")] public RelationMap<string, string> Names { get; } = new();
+            [Name("Canton", Path = "SwissCanton")] public RelationMap<string, string> Names { get; } = [];
             public ulong Area { get; set; }
             public ulong Population { get; set; }
             public string CantonCapital { get; set; } = "";
             public ushort YearJoinedSwissConfederation { get; set; }
-            [Name("CantonID", Path = "SwissCanton.ID"), Name("Councilor", Path = "Item")] public RelationSet<string> Councilors { get; } = new();
-            [Name("Religion", Path = "Key"), Name("%PCNT", Path = "Value")] public RelationMap<string, double> Religions { get; } = new();
+            [Name("CantonID", Path = "SwissCanton.ID"), Name("Councilor", Path = "Item")] public RelationSet<string> Councilors { get; } = [];
+            [Name("Religion", Path = "Key"), Name("%PCNT", Path = "Value")] public RelationMap<string, double> Religions { get; } = [];
         }
 
         // Test Scenario: Change Nested Relation Name (✓affects name of Table✓)
@@ -3324,8 +3324,8 @@ namespace UT.Kvasir.Translation {
                 public string DishName { get; set; } = "";
                 public ushort PrepTime { get; set; }
                 public ushort CookTime { get; set; }
-                public RelationMap<string, Measure> Ingredients { get; } = new();
-                public RelationOrderedList<string> Steps { get; } = new();
+                public RelationMap<string, Measure> Ingredients { get; } = [];
+                public RelationOrderedList<string> Steps { get; } = [];
             }
 
             [PrimaryKey] public string ISBN { get; set; } = "";
@@ -3333,7 +3333,7 @@ namespace UT.Kvasir.Translation {
             public string Author { get; set; } = "";
             public DateTime PublicationDate { get; set; }
             public string AmazonURL { get; set; } = "";
-            [Name("Cookbook.ISBN", Path = "Item.RecipeID")] public RelationList<Recipe> Recipes { get; } = new();
+            [Name("Cookbook.ISBN", Path = "Item.RecipeID")] public RelationList<Recipe> Recipes { get; } = [];
         }
 
         // Test Scenario: Change Two Field Names to Same Value in Relation Table (✗duplication✗)
@@ -3348,7 +3348,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid IncidentID { get; set; }
             public string Location { get; set; } = "";
             public Person HostageTaker { get; set; } = new();
-            [Name("Value", Path = "HostageSituation.IncidentID"), Name("Value", Path = "Item.SSN")] public RelationList<Person> Hostages { get; } = new();
+            [Name("Value", Path = "HostageSituation.IncidentID"), Name("Value", Path = "Item.SSN")] public RelationList<Person> Hostages { get; } = [];
             public ushort Casualties { get; set; }
         }
 
@@ -3482,14 +3482,14 @@ namespace UT.Kvasir.Translation {
             public class Spell {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public string Incantation { get; set; } = "";
-                public RelationSet<string> Components { get; } = new();
+                public RelationSet<string> Components { get; } = [];
                 public bool TimeSensitive { get; set; }
             }
 
             [PrimaryKey] public Guid MagicUserID { get; set; }
             public string? Name { get; set; }
             public AlignedAs Alignment { get; set; }
-            [Name("Spellbook"), Name("Spellbook")] public RelationSet<Spell> Spells { get; } = new();
+            [Name("Spellbook"), Name("Spellbook")] public RelationSet<Spell> Spells { get; } = [];
             public ulong Resurrections { get; set; }
             public byte Level { get; set; }
         }
@@ -3502,7 +3502,7 @@ namespace UT.Kvasir.Translation {
             public string Identifier { get; set; } = "";
             public string EthnicGroup { get; set; } = "";
             public ulong DeathCount { get; set; }
-            [Name("TimelineOfEvents"), Name("Calendar")] public RelationMap<DateTime, Event> Timeline { get; } = new();
+            [Name("TimelineOfEvents"), Name("Calendar")] public RelationMap<DateTime, Event> Timeline { get; } = [];
             public ushort ICCIndictments { get; set; }
         }
 
@@ -3612,7 +3612,7 @@ namespace UT.Kvasir.Translation {
             public string Name { get; set; } = "";
             public string Country { get; set; } = "";
             public ulong Age { get; set; }
-            [Name("TotalArea", Path = "Item.TotalSpace")] public RelationSet<PointOfInterest> Ruins { get; } = new();
+            [Name("TotalArea", Path = "Item.TotalSpace")] public RelationSet<PointOfInterest> Ruins { get; } = [];
         }
 
         // Test Scenario: [Name] Change on Nested Aggregate that Already Has [Name] Change (✓renamed✓)
@@ -3654,7 +3654,7 @@ namespace UT.Kvasir.Translation {
 
         // Test Scenario: [Name] Change on Nested Relation that Already Has [Name] Change (✓affects name of Table✓)
         public class PolarVortex {
-            public struct Temps {
+            public readonly struct Temps {
                 [Name("HighTemps")] public RelationMap<DateTime, double> Highs { get; }
                 [Name("LowTemps")] public RelationMap<DateTime, double> Lows { get; }
             }
@@ -3835,7 +3835,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Identifier { get; set; } = "";
             public Operation AllowedOperations { get; set; }
             public short Size { get; set; }
-            [Name("eax?", Path = "---")] public RelationSet<string> Architectures { get; } = new();
+            [Name("eax?", Path = "---")] public RelationSet<string> Architectures { get; } = [];
             public bool StackPointer { get; set; }
         }
 
@@ -3849,7 +3849,7 @@ namespace UT.Kvasir.Translation {
             public Denom Denomination { get; set; }
             public string ChiefRabbi { get; set; } = "";
             public DateTime Founded { get; set; }
-            [Name("HomeCity", Path = "Yeshiva.City")] public RelationList<Student> Students { get; } = new();
+            [Name("HomeCity", Path = "Yeshiva.City")] public RelationList<Student> Students { get; } = [];
         }
 
         // Test Scenario: <Path> on Localization Does Not Exist (✗non-existent path✗)
@@ -4054,15 +4054,15 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Image { get; set; } = "";
             [PrimaryKey, Default(0)] public int PID { get; set; }
             public string EntryPoint { get; set; } = "";
-            public RelationMap<Directory, string> Mounts { get; } = new();
+            public RelationMap<Directory, string> Mounts { get; } = [];
         }
 
         // Test Scenario: Default on Relation-Nested Field (✓valid✓)
         public class Kami {
             [PrimaryKey] public string Name { get; set; } = "";
             public string CultCenter { get; set; } = "";
-            [Default("n/a", Path = "Item")] public RelationSet<string> AKAs { get; } = new();
-            [Default("Susano'o", Path = "Kami.Name"), Default((short)19, Path = "Value")] public RelationMap<string, short> Appearances { get; } = new();
+            [Default("n/a", Path = "Item")] public RelationSet<string> AKAs { get; } = [];
+            [Default("Susano'o", Path = "Kami.Name"), Default((short)19, Path = "Value")] public RelationMap<string, short> Appearances { get; } = [];
             public string? PrimaryTorii { get; set; }
             public bool Female { get; set; }
         }
@@ -4081,7 +4081,7 @@ namespace UT.Kvasir.Translation {
             public ushort HatchTime { get; set; }
             public byte Age { get; set; }
             public uint Weight { get; set; }
-            [Default(3.75, Path = "Item.Cost")] public RelationList<Accessory> Accessories { get; } = new();
+            [Default(3.75, Path = "Item.Cost")] public RelationList<Accessory> Accessories { get; } = [];
         }
 
         // Test Scenario: Default on Localization Field (✓valid✓)
@@ -4191,7 +4191,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string LastName { get; set; } = "";
             public DateTime BirthDate { get; set; }
             [Default("Marty McFly", Path = "Owners")] public Machine TimeMachine { get; set; }
-            public RelationSet<DateTime> Visitations { get; } = new();
+            public RelationSet<DateTime> Visitations { get; } = [];
             public uint ParadoxesCaused { get; set; }
         }
 
@@ -4479,7 +4479,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid SerialNumber { get; set; }
             public string Title { get; set; } = "";
             public string Name { get; set; } = "";
-            [Default(0.00, Path = "---")] public RelationMap<string, double> HighScores { get; } = new();
+            [Default(0.00, Path = "---")] public RelationMap<string, double> HighScores { get; } = [];
             public ushort NumLevels { get; set; }
             public bool IsSports { get; set; }
         }
@@ -4489,7 +4489,7 @@ namespace UT.Kvasir.Translation {
             public enum Operation { Map, Join, Unit, Bind, Constructor }
 
             [PrimaryKey] public string Name { get; set; } = "";
-            [Default((sbyte)77, Path = "Monad.ModelsOption")] public RelationMap<Operation, string> Traits { get; } = new();
+            [Default((sbyte)77, Path = "Monad.ModelsOption")] public RelationMap<Operation, string> Traits { get; } = [];
             public bool ModelsOption { get; set; }
         }
 
@@ -4498,7 +4498,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid DetergentID { get; set; }
             public string Brand { get; set; } = "";
             public double VolumePerLoad { get; set; }
-            [Default(null)] public RelationSet<string> Ingredients { get; } = new();
+            [Default(null)] public RelationSet<string> Ingredients { get; } = [];
             public bool ToxiToConsume { get; set; }
         }
 
@@ -4588,9 +4588,9 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Issuer { get; set; } = "";
             public short SecurityCode { get; set; }
             public decimal DebitLimit { get; set; }
-            public RelationMap<string, Permission> Account { get; } = new();
+            public RelationMap<string, Permission> Account { get; } = [];
             public DateTime Expiration { get; set; }
-            public RelationList<Transaction> Transactions { get; } = new();
+            public RelationList<Transaction> Transactions { get; } = [];
         }
 
         // Test Scenario: Relation Fields are Manually Ordered (✗impermissible✗)
@@ -4598,7 +4598,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid TapestryID { get; set; }
             public double Length { get; set; }
             public double Width { get; set; }
-            [Column(6)] public RelationList<string> Depictions { get; } = new();
+            [Column(6)] public RelationList<string> Depictions { get; } = [];
             public string? Artist { get; set; }
             public ulong ThreadCount { get; set; }
         }
@@ -4666,7 +4666,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(3)] public Guid DeviceID { get; set; }
             [PrimaryKey, Column(0)] public DateTime Timestamp { get; set; }
             public Result Outcome { get; set; }
-            public RelationList<string> Notifications { get; } = new();
+            public RelationList<string> Notifications { get; } = [];
             public short PassCode { get; set; }
             public bool Mobile { get; set; }
         }
@@ -4867,7 +4867,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public short Year { get; set; }
             [PrimaryKey] public string Country { get; set; } = "";
-            [PrimaryKey(Path = "GrandPrix.Year"), PrimaryKey(Path = "GrandPrix.Country"), PrimaryKey(Path = "Key.CarNumber")] public RelationMap<Driver, short> Results { get; } = new();
+            [PrimaryKey(Path = "GrandPrix.Year"), PrimaryKey(Path = "GrandPrix.Country"), PrimaryKey(Path = "Key.CarNumber")] public RelationMap<Driver, short> Results { get; } = [];
             public byte NumLaps { get; set; }
             public ulong TrackLength { get; set; }
             public uint NumCrashes { get; set; }
@@ -5062,10 +5062,10 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Address { get; set; } = "";
             public string Country { get; set; } = "";
             public string? Proprietor { get; set; }
-            public RelationList<string> Employees { get; } = new();
+            public RelationList<string> Employees { get; } = [];
             public decimal YearlyRevenue { get; set; }
             public bool IsLegal { get; set; }
-            public RelationSet<Service> Services { get; } = new();
+            public RelationSet<Service> Services { get; } = [];
         }
 
         // Test Scenario: Default Deduction for Map Relation (✓identified✓)
@@ -5076,7 +5076,7 @@ namespace UT.Kvasir.Translation {
             public string Leader { get; set; } = "";
             public DateTime Founded { get; set; }
             public DateTime? Shuttered { get; set; }
-            public RelationMap<string, Info> Members { get; } = new();
+            public RelationMap<string, Info> Members { get; } = [];
             public bool FederallyMonitored { get; set; }
             public ulong AttributableDeaths { get; set; }
         }
@@ -5095,7 +5095,7 @@ namespace UT.Kvasir.Translation {
             public double Duration { get; set; }
             public TimeSignature Signature { get; set; }
             public sbyte Movements { get; set; }
-            public RelationOrderedList<Note> Score { get; } = new();
+            public RelationOrderedList<Note> Score { get; } = [];
         }
 
         // Test Scenario: Single Candidate Key on Relation Including Anchor (✓identified✓)
@@ -5105,7 +5105,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid ExtensionID { get; set; }
             public string ExtensionName { get; set; } = "";
             public ulong Downloads { get; set; }
-            [Unique("Key", Path = "ChromeExtension.ExtensionID"), Unique("Key", Path = "Item.Reviewer")] public RelationList<Rating> Reviews { get; } = new();
+            [Unique("Key", Path = "ChromeExtension.ExtensionID"), Unique("Key", Path = "Item.Reviewer")] public RelationList<Rating> Reviews { get; } = [];
             public string CurrentVersion { get; set; } = "";
             public ulong Size { get; set; }
             public bool ByGoogle { get; set; }
@@ -5119,7 +5119,7 @@ namespace UT.Kvasir.Translation {
             public ulong MaxHeight { get; set; }
             public ulong MinHeight { get; set; }
             public float TopSpeed { get; set; }
-            [Unique(Path = "Item")] public RelationSet<string> Precautions { get; } = new();
+            [Unique(Path = "Item")] public RelationSet<string> Precautions { get; } = [];
             public bool Aquatic { get; set; }
             public bool Forested { get; set; }
         }
@@ -5258,7 +5258,7 @@ namespace UT.Kvasir.Translation {
             public float Longitude { get; set; }
             public DateTime CarbonDating { get; set; }
             public string GeologicEra { get; set; } = "";
-            public RelationSet<Fossil> Fossils { get; } = new();
+            public RelationSet<Fossil> Fossils { get; } = [];
         }
 
         // Test Scenario: Primary Key on Relation Table with Candidate Keys Cannot Be Deduced (✗illegal✗)
@@ -5267,7 +5267,7 @@ namespace UT.Kvasir.Translation {
             public string Manager { get; set; } = "";
             public DateTime Opened { get; set; }
             public DateTime? Closed { get; set; }
-            [Unique("V", Path = "Blockbuster.ID"), Unique("V", Path = "Value")] public RelationMap<string, string> Rentals { get; } = new();
+            [Unique("V", Path = "Blockbuster.ID"), Unique("V", Path = "Value")] public RelationMap<string, string> Rentals { get; } = [];
             public ushort TotalVideos { get; set; }
             public decimal LifetimeRevenue { get; set; }
             public bool IsFranchise { get; set; }
@@ -5410,7 +5410,7 @@ namespace UT.Kvasir.Translation {
             public Terrain LaunchedFrom { get; set; }
             public Terrain Targeting { get; set; }
             public ulong MaxRange { get; set; }
-            [PrimaryKey(Path = "---")] public RelationSet<string> Manufacturers { get; } = new();
+            [PrimaryKey(Path = "---")] public RelationSet<string> Manufacturers { get; } = [];
         }
 
         // Test Scenario: <Path> on Relation Refers to Non-Primary-Key Field of Anchor Entity (✗non-existent path✗)
@@ -5421,7 +5421,7 @@ namespace UT.Kvasir.Translation {
             public string? Author { get; set; }
             public decimal TreasureValue { get; set; }
             public Coordinate X { get; set; }
-            [PrimaryKey(Path = "TreasureMap.X")] public RelationList<Coordinate> SuggestedPath { get; } = new();
+            [PrimaryKey(Path = "TreasureMap.X")] public RelationList<Coordinate> SuggestedPath { get; } = [];
             public bool Damaged { get; set; }
         }
 
@@ -5430,7 +5430,7 @@ namespace UT.Kvasir.Translation {
             public Guid ID { get; set; }
             public double Height { get; set; }
             public double AspectRatio { get; set; }
-            [PrimaryKey] public RelationMap<short, string> Copyrights { get; } = new();
+            [PrimaryKey] public RelationMap<short, string> Copyrights { get; } = [];
             public bool ThreeDimensional { get; set; }
         }
 
@@ -5766,7 +5766,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public ushort Episode { get; set; }
             public string ChiefOfStaff { get; set; } = "";
-            [PrimaryKey(Path = "Key.Time"), Unique("X", Path = "BigBlockOfCheeseDay"), Unique("X", Path = "Key.Organization")] public RelationMap<Slot, string> Schedule { get; } = new();
+            [PrimaryKey(Path = "Key.Time"), Unique("X", Path = "BigBlockOfCheeseDay"), Unique("X", Path = "Key.Organization")] public RelationMap<Slot, string> Schedule { get; } = [];
             public double PercentCrackpots { get; set; }
         }
 
@@ -5799,7 +5799,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Name { get; set; } = "";
             public DateTime WarStart { get; set; }
             public DateTime WarEnd { get; set; }
-            [PrimaryKey(Path = "Intifada.Name"), PrimaryKey(Path = "Item.CountryName")] public RelationSet<Country> Belligerents { get; } = new();
+            [PrimaryKey(Path = "Intifada.Name"), PrimaryKey(Path = "Item.CountryName")] public RelationSet<Country> Belligerents { get; } = [];
             public ulong Casualties { get; set; }
         }
 
@@ -5811,7 +5811,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid VoodooID { get; set; }
             public string Target { get; set; } = "";
             public string? PatronLoa { get; set; }
-            [PrimaryKey(Path = "VoodooDoll.VoodooID"), PrimaryKey(Path = "Value"), Unique("Unique", Path = "VoodooDoll.VoodooID"), Unique("Unique", Path = "Key")] public RelationMap<Color, string> Pins { get; } = new();
+            [PrimaryKey(Path = "VoodooDoll.VoodooID"), PrimaryKey(Path = "Value"), Unique("Unique", Path = "VoodooDoll.VoodooID"), Unique("Unique", Path = "Key")] public RelationMap<Color, string> Pins { get; } = [];
             public bool Effective { get; set; }
             public Thing Material { get; set; }
         }
@@ -5826,14 +5826,14 @@ namespace UT.Kvasir.Translation {
             public ulong LungsProcessed { get; set; }
             public ulong LiversProcessed { get; set; }
             public ulong KidneysProcessed { get; set; }
-            [PrimaryKey(Path = "OPO.ID"), PrimaryKey(Path = "Item"), Unique("Unique", Path = "OPO.ID"), Unique("Unique", Path = "Index")] public RelationOrderedList<string> Administrators { get; } = new();
+            [PrimaryKey(Path = "OPO.ID"), PrimaryKey(Path = "Item"), Unique("Unique", Path = "OPO.ID"), Unique("Unique", Path = "Index")] public RelationOrderedList<string> Administrators { get; } = [];
         }
 
         // Test Scenario: Localization Field in Candidate Key (✓recognized✓)
         public class ToDoList {
             [PrimaryKey] public Guid ID { get; set; }
             [Unique] public LocalizedDate Deadline { get; set; } = new(Guid.Empty);
-            public RelationOrderedList<string> Things { get; } = new();
+            public RelationOrderedList<string> Things { get; } = [];
             public string Doer { get; set; } = "";
             public bool IsCompleted { get; set; }
         }
@@ -6035,7 +6035,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Name { get; set; } = "";
             public string Formula { get; set; } = "";
             public double Bioavalability { get; set; }
-            [Unique(Path = "---")] public RelationMap<string, string> MedicalIdentifiers { get; } = new();
+            [Unique(Path = "---")] public RelationMap<string, string> MedicalIdentifiers { get; } = [];
             public Symptom SymptomsRelieved { get; set; }
         }
 
@@ -6044,7 +6044,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public float Latitude { get; set; }
             [PrimaryKey] public float Longitude { get; set; }
             public ulong Water { get; set; }
-            [Unique(Path = "Oasis.Water")] public RelationSet<string> TreeSpecies { get; } = new();
+            [Unique(Path = "Oasis.Water")] public RelationSet<string> TreeSpecies { get; } = [];
             public double AverageTemperature { get; set; }
         }
 
@@ -6223,7 +6223,7 @@ namespace UT.Kvasir.Translation {
         public class Bank {
             [PrimaryKey] public uint FDICNumber { get; set; }
             public string Name { get; set; } = "";
-            [DataConverter<ToInt<RelationMap<ulong, decimal>>>] public RelationMap<ulong, decimal> Accounts { get; } = new();
+            [DataConverter<ToInt<RelationMap<ulong, decimal>>>] public RelationMap<ulong, decimal> Accounts { get; } = [];
             public string VaultModel { get; set; } = "";
             public sbyte NumTellers { get; set; }
             public decimal CashOnHand { get; set; }
@@ -6436,7 +6436,7 @@ namespace UT.Kvasir.Translation {
             public ulong Length { get; set; }
             public ulong Elevation { get; set; }
             public Coordinate? Mouth { get; set; }
-            [Numeric] public RelationSet<string> MineralDeposits { get; } = new();
+            [Numeric] public RelationSet<string> MineralDeposits { get; } = [];
             public sbyte NumOases { get; set; }
         }
 
@@ -6566,7 +6566,7 @@ namespace UT.Kvasir.Translation {
             public DateTime Published { get; set; }
             public string Author { get; set; } = "";
             public string EncryptedText { get; set; } = "";
-            [AsString] public RelationMap<char, char> Solution { get; } = new();
+            [AsString] public RelationMap<char, char> Solution { get; } = [];
         }
 
         // Test Scenario: [AsString] Applied to Localization Field (✗impermissible✗)
@@ -6930,7 +6930,7 @@ namespace UT.Kvasir.Translation {
                 public Type Category { get; set; }
                 public DateTime Debut { get; set; }
                 [Check.IsPositive(Path = "SupportedVersions.Item")] public Support Versions { get; set; }
-                public RelationSet<string> Creators { get; } = new();
+                public RelationSet<string> Creators { get; } = [];
                 public bool CanPassTuringTest { get; set; }
             }
 
@@ -6948,7 +6948,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid MargaritaID { get; set; }
                 public string Tequila { get; set; } = "";
                 public Rimming Rim { get; set; }
-                [Check.IsPositive(Path = "Item.ID")] public RelationSet<Ingredient> Ingredients { get; } = new();
+                [Check.IsPositive(Path = "Item.ID")] public RelationSet<Ingredient> Ingredients { get; } = [];
                 public double AlcoholVolume { get; set; }
                 public decimal Price { get; set; }
             }
@@ -7095,7 +7095,7 @@ namespace UT.Kvasir.Translation {
                 public float Height { get; set; }
                 public float Width { get; set; }
                 public float Length { get; set; }
-                [Check.IsPositive(Path = "---")] public RelationMap<string, short> Builders { get; } = new();
+                [Check.IsPositive(Path = "---")] public RelationMap<string, short> Builders { get; } = [];
                 public bool IsPermanent { get; set; }
                 public int AmountSkakh { get; set; }
                 public DateTime Constructed { get; set; }
@@ -7115,7 +7115,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string FirstName { get; set; } = "";
                 [PrimaryKey] public string LastName { get; set; } = "";
                 public DateTime Birthdate { get; set; }
-                [Check.IsPositive(Path = "Item.WordCount")] public RelationList<Script> Scripts { get; } = new();
+                [Check.IsPositive(Path = "Item.WordCount")] public RelationList<Script> Scripts { get; } = [];
                 public decimal Salary { get; set; }
                 public bool WGAMember { get; set; }
             }
@@ -7123,7 +7123,7 @@ namespace UT.Kvasir.Translation {
             // Test Scenario: <Path> on Relation Not Specified (✗missing path✗)
             public class Typewriter {
                 [PrimaryKey] public Guid TypewriterID { get; set; }
-                [Check.IsPositive] public RelationSet<char> MissingKeys { get;  } = new();
+                [Check.IsPositive] public RelationSet<char> MissingKeys { get;  } = [];
                 public bool OwnedByTomHanks { get; set; }
                 public DateTime Created { get; set; }
                 public uint ClickSoundNumber { get; set; }
@@ -7502,7 +7502,7 @@ namespace UT.Kvasir.Translation {
                 public string Title { get; set; } = "";
                 public string Author { get; set; } = "";
                 public DateTime Copyright { get; set; }
-                [Check.IsNegative(Path = "Item.PageEnd")] public RelationList<Section> Sections { get; } = new();
+                [Check.IsNegative(Path = "Item.PageEnd")] public RelationList<Section> Sections { get; } = [];
                 public ushort NumImages { get; set; }
             }
 
@@ -7670,7 +7670,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public string? DeityHonored { get; set; }
                 public bool Drunken { get; set; }
-                [Check.IsNegative(Path = "---")] public RelationSet<DateTime> PossibleDates { get; } = new();
+                [Check.IsNegative(Path = "---")] public RelationSet<DateTime> PossibleDates { get; } = [];
                 public string? GreekEquivalent { get; set; }
             }
 
@@ -7681,7 +7681,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid AlertID { get; set; }
                 public string ChildsName { get; set; } = "";
                 public DateTime Issued { get; set; }
-                [Check.IsNegative(Path = "AmberAlert.EmergencyContactNumber")] public RelationMap<Category, string> VehicleDescription { get; } = new();
+                [Check.IsNegative(Path = "AmberAlert.EmergencyContactNumber")] public RelationMap<Category, string> VehicleDescription { get; } = [];
                 public ushort EmergencyContactNumber { get; set; }
             }
 
@@ -7700,7 +7700,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime? Disbanded { get; set; }
                 public DateTime? Renunited { get; set; }
                 public ulong RecordsSold { get; set; }
-                [Check.IsNegative] public RelationList<Singer> Members { get; } = new();
+                [Check.IsNegative] public RelationList<Singer> Members { get; } = [];
                 public ushort NumAlbums { get; set; }
                 public ulong InstagramFollowers { get; set; }
             }
@@ -8032,7 +8032,7 @@ namespace UT.Kvasir.Translation {
                 public string Tradition { get; set; } = "";
                 public double Duration { get; set; }
                 public ushort? MaxParticipants { get; set; }
-                [Check.IsNonZero(Path = "Key")] public RelationMap<uint, string> Steps { get; } = new();
+                [Check.IsNonZero(Path = "Key")] public RelationMap<uint, string> Steps { get; } = [];
             }
 
             // Test Scenario: Applied to Relation-Nested Non-Numeric Scalar (✗impermissible✗)
@@ -8050,7 +8050,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public DateTime Established { get; set; }
                 public char CertificationSymbol { get; set; }
-                [Check.IsNonZero(Path = "Item.ID")] public RelationSet<Company> CertifiedCompanies { get; } = new();
+                [Check.IsNonZero(Path = "Item.ID")] public RelationSet<Company> CertifiedCompanies { get; } = [];
                 public Judaism Branch { get; set; }
             }
 
@@ -8217,7 +8217,7 @@ namespace UT.Kvasir.Translation {
                 public string IssuedBy { get; set; } = "";
                 public string School { get; set; } = "";
                 public DateTime LastIssued { get; set; }
-                [Check.IsNonZero(Path = "---")] public RelationList<string> PermittedLocations { get; } = new();
+                [Check.IsNonZero(Path = "---")] public RelationList<string> PermittedLocations { get; } = [];
                 public bool IsExpired { get; set; }
             }
 
@@ -8229,14 +8229,14 @@ namespace UT.Kvasir.Translation {
                 public string Name { get; set; } = "";
                 public Kind Cuisine { get; set; }
                 public float IdealPanDepth { get; set; }
-                [Check.IsNonZero(Path = "Casserole.IdealPanDepth")] public RelationMap<string, bool> Ingredients { get; } = new();
+                [Check.IsNonZero(Path = "Casserole.IdealPanDepth")] public RelationMap<string, bool> Ingredients { get; } = [];
                 public bool IsGratin { get; set; }
             }
 
             // Test Scenario: <Path> on Relation Not Specified (✗missing path✗)
             public class GarbageTruck {
                 [PrimaryKey] public string LicensePlate { get; set; } = "";
-                [Check.IsNonZero] public RelationSet<string> RouteStops { get; } = new();
+                [Check.IsNonZero] public RelationSet<string> RouteStops { get; } = [];
                 public ulong TonnesProcessed { get; set; }
                 public string ManagementCompany { get; set; } = "";
                 public string Driver { get; set; } = "";
@@ -8547,7 +8547,7 @@ namespace UT.Kvasir.Translation {
                 public string LegalName { get; set; } = "";
                 public string Sector { get; set; } = "";
                 public string VoiceActor { get; set; } = "";
-                [Check.IsGreaterThan('@', Path = "Key"), Check.IsGreaterThan(0L, Path = "KidNextDoor.Number")] public RelationMap<char, string> DebutMission { get; } = new();
+                [Check.IsGreaterThan('@', Path = "Key"), Check.IsGreaterThan(0L, Path = "KidNextDoor.Number")] public RelationMap<char, string> DebutMission { get; } = [];
                 public string? ArchNemesis { get; set; } = "";
             }
 
@@ -8565,7 +8565,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public LNDN London { get; set; }
                 public Element StrongestElement { get; set; }
-                [Check.IsGreaterThan("9dc286f1-3ce5-4bd6-9afa-5bb6049e0ffe", Path = "Item.SpellID")] public RelationList<Spell> KnownSpells { get; } = new();
+                [Check.IsGreaterThan("9dc286f1-3ce5-4bd6-9afa-5bb6049e0ffe", Path = "Item.SpellID")] public RelationList<Spell> KnownSpells { get; } = [];
                 public DateTime Birthdate { get; set; }
                 public bool Deceased { get; set; }
                 public byte? BestEssenTaschPlacement { get; set; }
@@ -8855,7 +8855,7 @@ namespace UT.Kvasir.Translation {
                 public string Owner { get; set; } = "";
                 public string? URL { get; set; }
                 public ushort MaxSeating { get; set; }
-                [Check.IsGreaterThan(18752.53f, Path = "---")] public RelationList<MenuItem> MenuItems { get; } = new();
+                [Check.IsGreaterThan(18752.53f, Path = "---")] public RelationList<MenuItem> MenuItems { get; } = [];
                 public bool OffersCatering { get; set; }
                 public bool JewishStyle { get; set; }
             }
@@ -8867,8 +8867,8 @@ namespace UT.Kvasir.Translation {
                 public record struct Card(FaceValue Value, CardSuit Suit);
 
                 [PrimaryKey] public Guid HandID { get; set; }
-                public RelationSet<Card> PlayerCards { get; } = new();
-                [Check.IsGreaterThan(17512UL, Path = "BlackjackHand.TotalPot")] public RelationSet<Card> DealerCards { get; } = new();
+                public RelationSet<Card> PlayerCards { get; } = [];
+                [Check.IsGreaterThan(17512UL, Path = "BlackjackHand.TotalPot")] public RelationSet<Card> DealerCards { get; } = [];
                 public ulong TotalPot { get; set; }
                 public bool DoubleDown { get; set; }
             }
@@ -8879,7 +8879,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public DateTime End { get; set; }
                 public string OfficialTitle { get; set; } = "";
                 public string GrandInquisitor { get; set; } = "";
-                [Check.IsGreaterThan("Religious Persecution")] public RelationSet<string> Victims { get; } = new();
+                [Check.IsGreaterThan("Religious Persecution")] public RelationSet<string> Victims { get; } = [];
                 public bool IncludedWitchTrials { get; set; }
             }
 
@@ -9202,7 +9202,7 @@ namespace UT.Kvasir.Translation {
                 public ulong WishesGranted { get; set; }
                 public Color HairColor { get; set; }
                 public Color EyeColor { get; set; }
-                [Check.IsLessThan("Warmonger", Path = "FairyGodparent.Name"), Check.IsLessThan((ushort)1851, Path = "Key"), Check.IsLessThan((ushort)42144, Path = "Value")] public RelationMap<ushort, ushort> LinesByEpisode { get; } = new();
+                [Check.IsLessThan("Warmonger", Path = "FairyGodparent.Name"), Check.IsLessThan((ushort)1851, Path = "Key"), Check.IsLessThan((ushort)42144, Path = "Value")] public RelationMap<ushort, ushort> LinesByEpisode { get; } = [];
                 public uint TimesDaRulesBroken { get; set; }
             }
 
@@ -9214,7 +9214,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ID { get; set; }
                 public DateTime Instituted { get; set; }
                 public DateTime? Lifted { get; set; }
-                [Check.IsLessThan(AquaKind.Swamp, Path = "Item.Kind")] public RelationSet<Waterway> WaterwaysAffected { get; } = new();
+                [Check.IsLessThan(AquaKind.Swamp, Path = "Item.Kind")] public RelationSet<Waterway> WaterwaysAffected { get; } = [];
                 public decimal EconomicImpact { get; set; }
                 public bool ActOfWar { get; set; }
                 public ushort NumShips { get; set; }
@@ -9222,7 +9222,7 @@ namespace UT.Kvasir.Translation {
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class Blacksmith {
-                public struct Inventory {
+                public readonly struct Inventory {
                     public RelationSet<string> Metals { get; }
                     public RelationSet<string> Hammers { get; }
                 }
@@ -9231,7 +9231,7 @@ namespace UT.Kvasir.Translation {
                 public string Address { get; set; } = "";
                 public DateTime Birthdate { get; set; }
                 [Check.IsLessThan(1000, Path = "Hammers")] public Inventory Materials { get; set; }
-                public RelationMap<string, decimal> Prices { get; } = new();
+                public RelationMap<string, decimal> Prices { get; } = [];
                 public double SlagPerDay { get; set; }
                 public ushort BenchPress { get; set; }
             }
@@ -9475,7 +9475,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid MimeID { get; set; }
                 public string FullName { get; set; } = "";
                 public DateTime Birthdate { get; set; }
-                [Check.IsLessThan(0L, Path = "---")] public RelationList<Performance> Performances { get; } = new();
+                [Check.IsLessThan(0L, Path = "---")] public RelationList<Performance> Performances { get; } = [];
                 public ulong LifetimeWordsSpoken { get; set; }
                 public string GoToMiming { get; set; } = "";
             }
@@ -9487,14 +9487,14 @@ namespace UT.Kvasir.Translation {
                 public DateTime Birthdate { get; set; }
                 public DateTime? DeathDate { get; set; }
                 public DateTime Elevation { get; set; }
-                [Check.IsLessThan("2657-03-19", Path = "CatholicCardinal.DeathDate")] public RelationSet<DateTime> Conclaves { get; } = new();
+                [Check.IsLessThan("2657-03-19", Path = "CatholicCardinal.DeathDate")] public RelationSet<DateTime> Conclaves { get; } = [];
                 public bool PreviouslyArchbishop { get; set; }
             }
 
             // Test Scenario: <Path> on Relation Not Specified (✗missing path✗)
             public class Hemalurgy {
                 [PrimaryKey] public string Metal { get; set; } = "";
-                [Check.IsLessThan("Allomantic Powers")] public RelationSet<string> Steals { get; } = new();
+                [Check.IsLessThan("Allomantic Powers")] public RelationSet<string> Steals { get; } = [];
                 public bool IsDepictedInBooks { get; set; }
             }
 
@@ -9821,7 +9821,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ID { get; set; }
                 public string ShowTitle { get; set; } = "";
                 public double ShowLength { get; set; }
-                [Check.IsGreaterOrEqualTo("Elmo", Path = "Item.Name"), Check.IsGreaterOrEqualTo(22.5, Path = "Item.Value")] public RelationSet<Puppet> Puppets { get; } = new();
+                [Check.IsGreaterOrEqualTo("Elmo", Path = "Item.Name"), Check.IsGreaterOrEqualTo(22.5, Path = "Item.Value")] public RelationSet<Puppet> Puppets { get; } = [];
                 public decimal TicketPrice { get; set; }
                 public ushort Attendees { get; set; }
             }
@@ -9834,7 +9834,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Victim { get; set; } = "";
                 public bool AvadaKedavra { get; set; }
                 public string Object { get; set; } = "";
-                [Check.IsGreaterOrEqualTo(false, Path = "Value.Discovered")] public RelationMap<string, Pair> HidingPlaces { get; } = new();
+                [Check.IsGreaterOrEqualTo(false, Path = "Value.Discovered")] public RelationMap<string, Pair> HidingPlaces { get; } = [];
             }
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
@@ -10102,7 +10102,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public DateTime FirstDeath { get; set; }
                 public double Quickening { get; set; }
-                [Check.IsGreaterOrEqualTo("MacLeod", Path = "---")] public RelationSet<Guid> Swords { get; } = new();
+                [Check.IsGreaterOrEqualTo("MacLeod", Path = "---")] public RelationSet<Guid> Swords { get; } = [];
                 public double Height { get; set; }
             }
 
@@ -10113,7 +10113,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ID { get; set; }
                 public Judaism Denomination { get; set; }
                 public ulong SquareFootage { get; set; }
-                [Check.IsGreaterOrEqualTo("%999u$", Path = "Synagogue.Denomination")] public RelationSet<string> Congregants { get; } = new();
+                [Check.IsGreaterOrEqualTo("%999u$", Path = "Synagogue.Denomination")] public RelationSet<string> Congregants { get; } = [];
                 public DateTime NeirTamidInstalled { get; set; }
                 public uint BneiMitzvot { get; set; }
                 public string SeniorRabbi { get; set; } = "";
@@ -10125,7 +10125,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public DateTime Delivered { get; set; }
                 public string Topic { get; set; } = "";
                 public bool Religious { get; set; }
-                [Check.IsGreaterOrEqualTo(68174)] public RelationMap<int, string> Lines { get; } = new();
+                [Check.IsGreaterOrEqualTo(68174)] public RelationMap<int, string> Lines { get; } = [];
                 public bool Recorded { get; set; }
             }
 
@@ -10438,7 +10438,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Language { get; set; } = "";
                 public DateTime? Created { get; set; }
                 public ulong WorldwideUsers { get; set; }
-                [Check.IsLessOrEqualTo('|', Path = "Value")] public RelationMap<char, char> IPA { get; } = new();
+                [Check.IsLessOrEqualTo('|', Path = "Value")] public RelationMap<char, char> IPA { get; } = [];
                 public bool IsAlphasyllabary { get; set; }
             }
 
@@ -10450,8 +10450,8 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public byte EpisodeNumber { get; set; }
                 public DateTime AirDate { get; set; }
                 public bool IsParody { get; set; }
-                public RelationMap<string, Role> Cast { get; } = new();
-                [Check.IsLessOrEqualTo("Robert", Path = "Value")] public RelationMap<string, Role> Crew { get; } = new();
+                public RelationMap<string, Role> Cast { get; } = [];
+                [Check.IsLessOrEqualTo("Robert", Path = "Value")] public RelationMap<string, Role> Crew { get; } = [];
                 public string Segment1Title { get; set; } = "";
                 public string Segment2Title { get; set; } = "";
                 public string Segment3Title { get; set; } = "";
@@ -10711,7 +10711,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ThumbWarID { get; set; }
                 public uint Player1 { get; set; }
                 public uint Player2 { get; set; }
-                [Check.IsLessOrEqualTo(105, Path = "---")] public RelationList<Play> PlayByPlay { get; } = new();
+                [Check.IsLessOrEqualTo(105, Path = "---")] public RelationList<Play> PlayByPlay { get; } = [];
                 public Result Outcome { get; set; }
             }
 
@@ -10722,7 +10722,7 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public Guid ID { get; set; }
                 public Stone Centerpiece { get; set; }
-                [Check.IsLessOrEqualTo(285712905UL, Path = "EngagementRing.Centerpiece")] public RelationMap<string, Measurement> Measurements { get; } = new();
+                [Check.IsLessOrEqualTo(285712905UL, Path = "EngagementRing.Centerpiece")] public RelationMap<string, Measurement> Measurements { get; } = [];
                 public decimal Price { get; set; }
                 public bool FamilyHeirloom { get; set; }
                 public string Wearer { get; set; } = "";
@@ -10734,7 +10734,7 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public Guid JokeID { get; set; }
                 public Joker ImpracticalJoker { get; set; }
-                [Check.IsLessOrEqualTo((short)7512)] public RelationSet<string> JokeTargets { get; } = new();
+                [Check.IsLessOrEqualTo((short)7512)] public RelationSet<string> JokeTargets { get; } = [];
                 public double ComedyRating { get; set; }
                 public double JokeLength { get; set; }
                 public bool IsPhysicalComedy { get; set; }
@@ -10996,7 +10996,7 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public string FirstName { get; set; } = "";
                 [PrimaryKey] public string LastName { get; set; } = "";
-                [Check.IsNot(Kind.Other, Path = "Item.Kind"), Check.IsNot(false, Path = "Item.NSFW")] public RelationList<Joke> Jokes { get; } = new();
+                [Check.IsNot(Kind.Other, Path = "Item.Kind"), Check.IsNot(false, Path = "Item.NSFW")] public RelationList<Joke> Jokes { get; } = [];
                 public DateTime FirstShow { get; set; }
                 public bool LateNightHost { get; set; }
                 public ulong TwitterFollowers { get; set; }
@@ -11004,7 +11004,7 @@ namespace UT.Kvasir.Translation {
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class Interview {
-                public struct Course {
+                public readonly struct Course {
                     public RelationMap<string, double> Questions { get; }
                 }
 
@@ -11285,9 +11285,9 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public DateTime Date { get; set; }
                 public string Sponsor { get; set; } = "";
                 public string Religion { get; set; } = "";
-                public RelationSet<string> BooksBurned { get; } = new();
-                public RelationSet<string> PeopleBurned { get; } = new();
-                [Check.IsNot("Mona Lisa", Path = "---")] public RelationSet<string> ArtworkBurned { get; } = new();
+                public RelationSet<string> BooksBurned { get; } = [];
+                public RelationSet<string> PeopleBurned { get; } = [];
+                [Check.IsNot("Mona Lisa", Path = "---")] public RelationSet<string> ArtworkBurned { get; } = [];
             }
 
             // Test Scenario: <Path> on Relation Refers to Non-Primary-Key Field of Anchor Entity (✗non-existent path✗)
@@ -11298,7 +11298,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public DateTime DateOfDream { get; set; }
                 [PrimaryKey] public uint SequenceNumber { get; set; }
                 public sbyte Length { get; set; }
-                [Check.IsNot("Hercules", Path = "Dream.REM")] public RelationList<string> Cameos { get; } = new();
+                [Check.IsNot("Hercules", Path = "Dream.REM")] public RelationList<string> Cameos { get; } = [];
                 public bool REM { get; set; }
             }
 
@@ -11310,7 +11310,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Bachelor { get; set; } = "";
                 [PrimaryKey] public DateTime Date { get; set; }
                 public sbyte Attendees { get; set; }
-                [Check.IsNot((byte)121)] public RelationList<Destination> Destinations { get; } = new();
+                [Check.IsNot((byte)121)] public RelationList<Destination> Destinations { get; } = [];
                 public bool FianceeSanctioned { get; set; }
                 public DateTime WeddingDay { get; set; }
             }
@@ -11422,7 +11422,7 @@ namespace UT.Kvasir.Translation {
             public class Fudge {
                 [PrimaryKey] public Guid ID { get; set; }
                 [Check.IsNonEmpty] public DateOnly Baked { get; set; }
-                public string Flavor { get; set; }
+                public string Flavor { get; set; } = "";
                 public double CaloriesPerGram { get; set; }
                 public decimal PricePerPound { get; set; }
                 public bool IsEaten { get; set; }
@@ -11666,7 +11666,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime Started { get; set; }
                 public DateTime? Ended { get; set; }
                 public ulong Participants { get; set; }
-                [Check.IsNonEmpty(Path = "Item")] public RelationSet<string> Sponsors { get; } = new();
+                [Check.IsNonEmpty(Path = "Item")] public RelationSet<string> Sponsors { get; } = [];
                 public bool BDS { get; set; }
                 public decimal Damage { get; set; }
             }
@@ -11686,7 +11686,7 @@ namespace UT.Kvasir.Translation {
                 public string FirstName { get; set; } = "";
                 public char MiddleInitial { get; set; }
                 public string LastName { get; set; } = "";
-                [Check.IsNonEmpty(Path = "Value.MallID")] public RelationMap<ushort, Mall> Jobs { get; } = new();
+                [Check.IsNonEmpty(Path = "Value.MallID")] public RelationMap<ushort, Mall> Jobs { get; } = [];
                 public ulong TotalKids { get; set; }
                 public bool NaturalBeard { get; set; }
             }
@@ -11834,7 +11834,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string EnglishName { get; set; } = "";
                 public string GreekName { get; set; } = "";
                 public Variety Category { get; set; }
-                [Check.IsNonEmpty(Path = "---")] public RelationSet<sbyte> MetamorphosesAppearances { get; } = new();
+                [Check.IsNonEmpty(Path = "---")] public RelationSet<sbyte> MetamorphosesAppearances { get; } = [];
                 public bool Virgin { get; set; }
                 public string? TurnedInto { get; set; }
             }
@@ -11847,7 +11847,7 @@ namespace UT.Kvasir.Translation {
                 public string CEO { get; set; } = "";
                 public DateTime Launched { get; set; }
                 public ulong Users { get; set; }
-                [Check.IsNonEmpty(Path = "DatingApp.CEO")] public RelationList<Pair> CouplesFormed { get; } = new();
+                [Check.IsNonEmpty(Path = "DatingApp.CEO")] public RelationList<Pair> CouplesFormed { get; } = [];
                 public bool SwipeBased { get; set; }
                 public decimal? MonthlyFee { get; set; }
             }
@@ -11859,7 +11859,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public ulong Downloads { get; set; }
                 public bool Free { get; set; }
-                [Check.IsNonEmpty] public RelationSet<AdType> EffectiveAgainst { get; } = new();
+                [Check.IsNonEmpty] public RelationSet<AdType> EffectiveAgainst { get; } = [];
                 public bool Mobile { get; set; }
             }
 
@@ -12184,15 +12184,15 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public DateTime TermBegin { get; set; }
                 public DateTime? TermEnd { get; set; }
-                [Check.LengthIsAtLeast(6, Path = "Item.Title")] public RelationList<Resolution> ResolutionsPassed { get; } = new();
-                [Check.LengthIsAtLeast(17, Path = "UNSecretaryGeneral.Name")] public RelationSet<string> CountriesAdmitted { get; } = new();
+                [Check.LengthIsAtLeast(6, Path = "Item.Title")] public RelationList<Resolution> ResolutionsPassed { get; } = [];
+                [Check.LengthIsAtLeast(17, Path = "UNSecretaryGeneral.Name")] public RelationSet<string> CountriesAdmitted { get; } = [];
             }
 
             // Test Scenario: Applied to Relation-Nested Non-String Scalar (✗impermissible✗)
             public class MemoryBuffer {
                 [PrimaryKey] public ulong StartAddress { get; set; }
                 [PrimaryKey] public ulong EndAddress { get; set; }
-                [Check.LengthIsAtLeast(489, Path = "MemoryBuffer.EndAddress")] public RelationList<bool> Bits { get; } = new();
+                [Check.LengthIsAtLeast(489, Path = "MemoryBuffer.EndAddress")] public RelationList<bool> Bits { get; } = [];
                 public string IntendedType { get; set; } = "";
                 public bool HeapAllocated { get; set; }
             }
@@ -12364,7 +12364,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid CigarID { get; set; }
                 public float Length { get; set; }
                 public bool IsCuban { get; set; }
-                [Check.LengthIsAtLeast(52, Path = "---")] public RelationMap<Tobacco, double> Contents { get; } = new();
+                [Check.LengthIsAtLeast(52, Path = "---")] public RelationMap<Tobacco, double> Contents { get; } = [];
             }
 
             // Test Scenario: <Path> on Relation Refers to Non-Primary-Key Field of Anchor Entity (✗non-existent path✗)
@@ -12379,7 +12379,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid StrainID { get; set; }
                 public string StrainName { get; set; } = "";
                 public DateTime Created { get; set; }
-                [Check.LengthIsAtLeast(4, Path = "MarijuanaStrain.StrainName")] public RelationSet<Dispensary> SoldAt { get; } = new();
+                [Check.LengthIsAtLeast(4, Path = "MarijuanaStrain.StrainName")] public RelationSet<Dispensary> SoldAt { get; } = [];
                 public double Addictiveness { get; set; }
             }
 
@@ -12390,7 +12390,7 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public string Name { get; set; } = "";
                 public Guid? FBINumber { get; set; }
-                [Check.LengthIsAtLeast(87)] public RelationList<Robbery> Robberies { get; } = new();
+                [Check.LengthIsAtLeast(87)] public RelationList<Robbery> Robberies { get; } = [];
                 public ushort MurdersCommitted { get; set; }
                 public bool Incarcerated { get; set; }
             }
@@ -12739,7 +12739,7 @@ namespace UT.Kvasir.Translation {
             public class Golem {
                 [PrimaryKey] public Guid ID { get; set; }
                 public DateTime Created { get; set; }
-                [Check.LengthIsAtMost(26, Path = "Item")] public RelationSet<string> Materials { get; } = new();
+                [Check.LengthIsAtMost(26, Path = "Item")] public RelationSet<string> Materials { get; } = [];
                 public float ShemSize { get; set; }
                 public string OwningRabbi { get; set; } = "";
                 public ulong Weight { get; set; }
@@ -12755,14 +12755,14 @@ namespace UT.Kvasir.Translation {
                 public string Flavor { get; set; } = "";
                 public double Volume { get; set; }
                 public DateTime ExpirationDate { get; set; }
-                [Check.LengthIsAtMost(255, Path = "Item.Grams")] public RelationSet<Ingredient> Ingredients { get; } = new();
+                [Check.LengthIsAtMost(255, Path = "Item.Grams")] public RelationSet<Ingredient> Ingredients { get; } = [];
                 public Color BalsamicColor { get; set; }
                 public bool DOP { get; set; }
             }
 
             // Test Scenario: Applied to Nested Relation (✗impermissible✗)
             public class TerroristOrganization {
-                public struct Record {
+                public readonly struct Record {
                     public RelationMap<string, DateTime> Entities { get; }
                 }
 
@@ -12923,7 +12923,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime TermBegin { get; set; }
                 public DateTime TermEnd { get; set; }
                 public string RuledFrom { get; set; } = "";
-                [Check.LengthIsAtMost(30, Path = "---")] public RelationList<string> CardinalsCreated { get; } = new();
+                [Check.LengthIsAtMost(30, Path = "---")] public RelationList<string> CardinalsCreated { get; } = [];
                 public bool Excommunicated { get; set; }
             }
 
@@ -12935,7 +12935,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid CabaretID { get; set; }
                 public DateTime Date { get; set; }
                 public Loc Venue { get; set; }
-                [Check.LengthIsAtMost(102, Path = "Cabaret.Venue.Name")] public RelationMap<string, string> Performers { get; } = new();
+                [Check.LengthIsAtMost(102, Path = "Cabaret.Venue.Name")] public RelationMap<string, string> Performers { get; } = [];
                 public bool Drag { get; set; }
                 public bool Burlesque { get; set; }
             }
@@ -12948,7 +12948,7 @@ namespace UT.Kvasir.Translation {
                 public string Creator { get; set; } = "";
                 public ushort Length { get; set; }
                 public bool Viral { get; set; }
-                [Check.LengthIsAtMost(100000)] public RelationMap<string, ulong> Views { get; } = new();
+                [Check.LengthIsAtMost(100000)] public RelationMap<string, ulong> Views { get; } = [];
                 public Kind Category { get; set; }
             }
 
@@ -13189,7 +13189,7 @@ namespace UT.Kvasir.Translation {
                     [PrimaryKey] public ulong Integral { get; set; }
                     [PrimaryKey] public double Decimal { get; set; }
                 }
-                public record struct Date(Number Year, Number Month, Number day);
+                public record struct Date(Number Year, Number Month, Number Day);
 
                 [PrimaryKey] public Guid SumoID { get; set; }
                 public string Name { get; set; } = "";
@@ -13283,7 +13283,7 @@ namespace UT.Kvasir.Translation {
                 public string Series { get; set; } = "";
                 public Pub Publisher { get; set; }
                 public DateTime Published { get; set; }
-                [Check.LengthIsBetween(4, 37, Path = "Item"), Check.LengthIsBetween(8, 19, Path = "ComicBook.Title")] public RelationSet<string> Characters { get; } = new();
+                [Check.LengthIsBetween(4, 37, Path = "Item"), Check.LengthIsBetween(8, 19, Path = "ComicBook.Title")] public RelationSet<string> Characters { get; } = [];
                 public decimal Price { get; set; }
                 public bool Vintage { get; set; }
             }
@@ -13295,7 +13295,7 @@ namespace UT.Kvasir.Translation {
 
                 [PrimaryKey] public Guid ID { get; set; }
                 public Kind Variety { get; set; }
-                [Check.LengthIsBetween(14, 99, Path = "Item.Z")] public RelationSet<Location> ConnectedLocations { get; } = new();
+                [Check.LengthIsBetween(14, 99, Path = "Item.Z")] public RelationSet<Location> ConnectedLocations { get; } = [];
                 public double Radius { get; set; }
                 public ulong Density { get; set; }
             }
@@ -13476,7 +13476,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime Launched { get; set; }
                 public decimal Budget { get; set; }
                 public string SpaceAgency { get; set; } = "";
-                [Check.LengthIsBetween(177, 179, Path = "---")] public RelationList<Specimen> SpecimensCollected { get; } = new();
+                [Check.LengthIsBetween(177, 179, Path = "---")] public RelationList<Specimen> SpecimensCollected { get; } = [];
                 public double Height { get; set; }
                 public double Length { get; set; }
                 public double Width { get; set; }
@@ -13491,7 +13491,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Name { get; set; } = "";
                 public string Country { get; set; } = "";
                 public Branch MilitaryBranch { get; set; }
-                [Check.LengthIsBetween(6, 29, Path = "BlackOp.Country")] public RelationSet<string> Participants { get; } = new();
+                [Check.LengthIsBetween(6, 29, Path = "BlackOp.Country")] public RelationSet<string> Participants { get; } = [];
                 public DateTime Executed { get; set; }
                 public DateTime Declassified { get; set; }
                 public ushort Casualites { get; set; }
@@ -13503,7 +13503,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public string Victim { get; set; } = "";
                 [PrimaryKey] public DateTime Occurrence { get; set; }
                 public bool Fatal { get; set; }
-                [Check.LengthIsBetween(4, 67)] public RelationSet<string> Symptoms { get; } = new();
+                [Check.LengthIsBetween(4, 67)] public RelationSet<string> Symptoms { get; } = [];
             }
 
             // Test Scenario: <Path> on Localization Does Not Exist (✗non-existent path✗)
@@ -13775,7 +13775,7 @@ namespace UT.Kvasir.Translation {
                 public Period MesozoicPeriod { get; set; }
                 public Hips Clade { get; set; }
                 public Diet FoodPreference { get; set; }
-                [Check.IsOneOf("Americas", "Eurasia", "Middle East", "Africa", "Australia", "Pacific Islands", "Arctic", "Antarctica", "Oceans", Path = "Item")] public RelationSet<string> FossilLocations { get; } = new();
+                [Check.IsOneOf("Americas", "Eurasia", "Middle East", "Africa", "Australia", "Pacific Islands", "Arctic", "Antarctica", "Oceans", Path = "Item")] public RelationSet<string> FossilLocations { get; } = [];
                 public int FacialHorns { get; set; }
                 public int NumTeeth { get; set; }
             }
@@ -14084,11 +14084,11 @@ namespace UT.Kvasir.Translation {
                 public record struct Object(string Name, Status Status, decimal Appraisal, DateTime Acquired);
 
                 [PrimaryKey] public string ShopName { get; set; } = "";
-                public RelationList<string> Employees { get; } = new();
+                public RelationList<string> Employees { get; } = [];
                 public sbyte Floors { get; set; }
                 public DateTime Opened { get; set; }
                 public Guid License { get; set; }
-                [Check.IsOneOf('A', '7', '_', '/', '=', '~', Path = "---")] public RelationList<Object> Inventory { get; } = new();
+                [Check.IsOneOf('A', '7', '_', '/', '=', '~', Path = "---")] public RelationList<Object> Inventory { get; } = [];
                 public decimal Revenue { get; set; }
             }
 
@@ -14100,7 +14100,7 @@ namespace UT.Kvasir.Translation {
                 public bool EcoFriendly { get; set; }
                 public double WaterPressure { get; set; }
                 public ulong VolumeDispensed { get; set; }
-                [Check.IsOneOf(37.6, 1158.44, 0.919, 63.6666, Path = "DrinkingFountain.WaterPressure")] public RelationSet<DateTime> Inspections { get; } = new();
+                [Check.IsOneOf(37.6, 1158.44, 0.919, 63.6666, Path = "DrinkingFountain.WaterPressure")] public RelationSet<DateTime> Inspections { get; } = [];
                 public bool MotionSensored { get; set; }
             }
 
@@ -14111,7 +14111,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ID { get; set; }
                 public string Name { get; set; } = "";
                 public string Description { get; set; } = "";
-                [Check.IsOneOf(true, false)] public RelationMap<Guid, bool> Certifications { get; } = new();
+                [Check.IsOneOf(true, false)] public RelationMap<Guid, bool> Certifications { get; } = [];
                 public DateTime? FirstDocumented { get; set; }
                 public string? Culture { get; set; } = "";
                 public Gender AppropriateFor { get; set; }
@@ -14387,7 +14387,7 @@ namespace UT.Kvasir.Translation {
             public class Infomercial {
                 [PrimaryKey] public Guid ID { get; set; }
                 public string Product { get; set; } = "";
-                [Check.IsNotOneOf("2022-03-17", "1965-11-14", "1333-01-02", Path = "Value")] public RelationMap<uint, DateTime> Broadcasts { get; } = new();
+                [Check.IsNotOneOf("2022-03-17", "1965-11-14", "1333-01-02", Path = "Value")] public RelationMap<uint, DateTime> Broadcasts { get; } = [];
                 public string Hawker { get; set; } = "";
                 public double Discount { get; set; }
                 public double CommercialLength { get; set; }
@@ -14705,7 +14705,7 @@ namespace UT.Kvasir.Translation {
                 public DateTime Published { get; set; }
                 public string Region { get; set; } = "";
                 public ulong PageCount { get; set; }
-                [Check.IsNotOneOf(8471294811, 2056178955, 8005882340, Path = "---")] public RelationMap<string, ulong> PhoneNumbers { get; } = new();
+                [Check.IsNotOneOf(8471294811, 2056178955, 8005882340, Path = "---")] public RelationMap<string, ulong> PhoneNumbers { get; } = [];
                 public double Weight { get; set; }
             }
 
@@ -14716,7 +14716,7 @@ namespace UT.Kvasir.Translation {
                 [PrimaryKey] public Guid ID { get; set; }
                 public string BakuganName { get; set; } = "";
                 public Attribute BakuganAttribute { get; set; }
-                [Check.IsNotOneOf("Counterspell", "Basic Island", "Lightning Bolt", Path = "Bakugan.BakuganName")] public RelationSet<string> AbilityCards { get; } = new();
+                [Check.IsNotOneOf("Counterspell", "Basic Island", "Lightning Bolt", Path = "Bakugan.BakuganName")] public RelationSet<string> AbilityCards { get; } = [];
                 public bool InAnime { get; set; }
             }
 
@@ -14724,8 +14724,8 @@ namespace UT.Kvasir.Translation {
             public class QRCode {
                 [PrimaryKey] public Guid ID { get; set; }
                 public string URL { get; set; } = "";
-                public RelationList<bool> Horizontal { get; } = new();
-                [Check.IsNotOneOf(false)] public RelationList<bool> Vertical { get; } = new();
+                public RelationList<bool> Horizontal { get; } = [];
+                [Check.IsNotOneOf(false)] public RelationList<bool> Vertical { get; } = [];
                 public double Version { get; set; }
                 public char ErrorCorrection { get; set; }
             }
@@ -14928,7 +14928,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Bear { get; set; } = "";
             public string Color { get; set; } = "";
             public char TummySymbol { get; set; }
-            [Check<CustomCheck>(Path = "Item")] public RelationSet<string> MediaAppearances { get; } = new();
+            [Check<CustomCheck>(Path = "Item")] public RelationSet<string> MediaAppearances { get; } = [];
             public string LeadDesigner { get; set; } = "";
         }
 
@@ -15156,7 +15156,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public string Name { get; set; } = "";
             public Kind Classification { get; set; }
-            [Check<CustomCheck>(Path = "---")] public RelationList<City> Cities { get; } = new();
+            [Check<CustomCheck>(Path = "---")] public RelationList<City> Cities { get; } = [];
             public string PostalCode { get; set; } = "";
             public Language OfficialLanguages { get; set; }
             public Reps Representation { get; set; }
@@ -15170,14 +15170,14 @@ namespace UT.Kvasir.Translation {
             public string Name { get; set; } = "";
             public double Height { get; set; }
             public double Weight { get; set; }
-            [Check<CustomCheck>(Path = "Skydiver.Height")] public RelationMap<DateTime, long> Dives { get; } = new();
+            [Check<CustomCheck>(Path = "Skydiver.Height")] public RelationMap<DateTime, long> Dives { get; } = [];
             public Vehicle HasJumpedFrom { get; set; }
         }
 
         // Test Scenario: <Path> on Relation Not Specified (✗missing path✗)
         public class Spring {
             [PrimaryKey] public Guid ID { get; set; }
-            [Check<CustomCheck>] public RelationSet<string> ConstituentMetals { get; } = new();
+            [Check<CustomCheck>] public RelationSet<string> ConstituentMetals { get; } = [];
             public double SpringConstant { get; set; }
             public ushort NumCoils { get; set; }
         }
@@ -15185,7 +15185,7 @@ namespace UT.Kvasir.Translation {
 
     internal static class ComplexCheckConstraints {
         // Test Scenario: No Constructor Arguments (✓constrained✓)
-        [Check.Complex<CustomCheck>(new[] { "FirstLine" })]
+        [Check.Complex<CustomCheck>(["FirstLine"])]
         public class CanterburyTale {
             [PrimaryKey] public int Index { get; set; }
             public string Whose { get; set; } = "";
@@ -15194,7 +15194,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Constructor Arguments (✓constrained✓)
-        [Check.Complex<CustomCheck>(new[] { "ConclaveRounds" }, -93, true, 'X')]
+        [Check.Complex<CustomCheck>(["ConclaveRounds"], -93, true, 'X')]
         public class Pope {
             [PrimaryKey] public string PapalName { get; set; } = "";
             [PrimaryKey] public uint PapalNumber { get; set; }
@@ -15205,7 +15205,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Covers Zero Fields (✗illegal✗)
-        [Check.Complex<CustomCheck>(new string[] {})]
+        [Check.Complex<CustomCheck>([])]
         public class Terminator {
             [PrimaryKey] public string Model { get; set; } = "";
             [PrimaryKey] public ushort Number { get; set; }
@@ -15215,7 +15215,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Covers Multiple Distinct Fields (✓constrained✓)
-        [Check.Complex<CustomCheck>(new[] { "Major", "Minor", "Patch" })]
+        [Check.Complex<CustomCheck>(["Major", "Minor", "Patch"])]
         public class LinuxDistribution {
             [PrimaryKey] public string Name { get; set; } = "";
             [PrimaryKey] public ulong Major { get; set; }
@@ -15227,7 +15227,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Covers Single Field Multiple Times (✓constrained✓)
-        [Check.Complex<CustomCheck>(new[] { "Name", "Name", "Name", "Name" })]
+        [Check.Complex<CustomCheck>(["Name", "Name", "Name", "Name"])]
         public class Muppet {
             [PrimaryKey] public string Name { get; set; } = "";
             public DateTime Debut { get; set; }
@@ -15237,7 +15237,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Covers Name-Swapped Fields (✓constrained✓)
-        [Check.Complex<CustomCheck>(new[] { "Cuisine", "ContainsTomatoes" })]
+        [Check.Complex<CustomCheck>(["Cuisine", "ContainsTomatoes"])]
         public class PastaSauce {
             [PrimaryKey] public string Name { get; set; } = "";
             public bool IsMotherSauce { get; set; }
@@ -15249,7 +15249,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Covers Name-Changed Field with Original Name (✗illegal✗)
-        [Check.Complex<CustomCheck>(new string[] { "Width" })]
+        [Check.Complex<CustomCheck>(["Width"])]
         public class Dam {
             [PrimaryKey] public Guid ID { get; set; }
             public string Name { get; set; } = "";
@@ -15261,7 +15261,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Covers Unrecognized Field (✗illegal✗)
-        [Check.Complex<CustomCheck>(new string[] { "Belligerents" })]
+        [Check.Complex<CustomCheck>(["Belligerents"])]
         public class PeaceTreaty {
             [PrimaryKey] public string TreatyName { get; set; } = "";
             public DateTime Signed { get; set; }
@@ -15271,7 +15271,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Covers Data-Converted Field (✓constrained✓)
-        [Check.Complex<CustomCheck>(new[] { "When", "Casualties", "When" })]
+        [Check.Complex<CustomCheck>(["When", "Casualties", "When"])]
         public class Massacre {
             [PrimaryKey] public string Name { get; set; } = "";
             public ulong Casualties { get; set; }
@@ -15280,9 +15280,9 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Applied to Single Entity Type Multiple Times (✓constrained✓)
-        [Check.Complex<CustomCheck>(new[] { "LengthMinutes" })]
-        [Check.Complex<CustomCheck>(new[] { "SungThrough" })]
-        [Check.Complex<CustomCheck>(new[] { "SungThrough" })]
+        [Check.Complex<CustomCheck>(["LengthMinutes"])]
+        [Check.Complex<CustomCheck>(["SungThrough"])]
+        [Check.Complex<CustomCheck>(["SungThrough"])]
         public class Musical {
             [PrimaryKey] public string Title { get; set; } = "";
             public bool SungThrough { get; set; }
@@ -15292,7 +15292,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Constraint Generator Cannot Be Constructed (✗illegal✗)
-        [Check.Complex<PrivateCheck>(new[] { "Omega3s", "Omega6s" }, 'O', 'I', 'L', '!')]
+        [Check.Complex<PrivateCheck>(["Omega3s", "Omega6s"], 'O', 'I', 'L', '!')]
         public class CookingOil {
             [PrimaryKey] public string Type { get; set; } = "";
             public decimal SmokePoint { get; set; }
@@ -15302,7 +15302,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Constraint Generator Throws Error upon Construction (✗propagated✗)
-        [Check.Complex<UnconstructibleCheck>(new[] { "Born", "Died" }, "Lifespan", 2918.01f, true)]
+        [Check.Complex<UnconstructibleCheck>(["Born", "Died"], "Lifespan", 2918.01f, true)]
         public class Pirate {
             [PrimaryKey] public string PirateName { get; set; } = "";
             [PrimaryKey] public string LandName { get; set; } = "";
@@ -15314,7 +15314,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Constraint Generator Throws Error when Creating Constraint (✗propagated✗)
-        [Check.Complex<UnusableCheck>(new[] { "Namespace", "ClassName" })]
+        [Check.Complex<UnusableCheck>(["Namespace", "ClassName"])]
         public class Attribute {
             [PrimaryKey] public string Namespace { get; set; } = "";
             [PrimaryKey] public string ClassName { get; set; } = "";
@@ -15323,7 +15323,7 @@ namespace UT.Kvasir.Translation {
         }
 
         // Test Scenario: Applied to Localization (✓constrained✓)
-        [Check.Complex<CustomCheck>(new[] { "Key", "Locale", "Value" })]
+        [Check.Complex<CustomCheck>(["Key", "Locale", "Value"])]
         public class MahjongTile : Localization<int, Language, string> {
             public MahjongTile(int key) : base(key) {}
         }
@@ -15877,9 +15877,9 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public string Hash { get; set; } = "";
             public string Name { get; set; } = "";
             public string Version { get; set; } = "";
-            public RelationMap<string, bool> Flags { get; } = new();
-            public RelationSet<SoftwarePackage> BuildDependencies { get; } = new();
-            public RelationSet<SoftwarePackage> RunDependencies { get; } = new();
+            public RelationMap<string, bool> Flags { get; } = [];
+            public RelationSet<SoftwarePackage> BuildDependencies { get; } = [];
+            public RelationSet<SoftwarePackage> RunDependencies { get; } = [];
             public bool Secure { get; set; }
         }
 
@@ -15892,7 +15892,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public ulong IndictmentNumber { get; set; }
             [PrimaryKey] public string Defendant { get; set; } = "";
             public DateTime Issued { get; set; }
-            public RelationList<Charge> Charges { get; } = new();
+            public RelationList<Charge> Charges { get; } = [];
             public Level Government { get; set; }
             public bool? Conviction { get; set; }
         }
@@ -15908,7 +15908,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey] public Guid ID { get; set; }
             public sbyte FrameNumber { get; set; }
-            public RelationList<Breakpoint> Breakpoints { get; } = new();
+            public RelationList<Breakpoint> Breakpoints { get; } = [];
             public string Debugger { get; set; } = "";
             public double Memory { get; set; }
         }
@@ -15918,7 +15918,7 @@ namespace UT.Kvasir.Translation {
             public class Politician {
                 [PrimaryKey] public string FullName { get; set; } = "";
                 public DateTime FirstElected { get; set; }
-                public RelationSet<Filibuster> FilibustersBroken { get; } = new();
+                public RelationSet<Filibuster> FilibustersBroken { get; } = [];
             }
 
             [PrimaryKey] public Guid FilibusterID { get; set; }
@@ -16336,7 +16336,7 @@ namespace UT.Kvasir.Translation {
         public class Pretzel {
             [PrimaryKey, Column(0)] public Guid PretzelID { get; set; }
             [Column(1)] public string Name { get; set; } = "";
-            public RelationSet<string> Toppings { get; init;  } = new();
+            public RelationSet<string> Toppings { get; init; } = [];
             [Column(2)] public decimal RetailPrice { get; set; }
             [Column(3)] public string DoughSource { get; set; } = "";
         }
@@ -16345,8 +16345,8 @@ namespace UT.Kvasir.Translation {
         public class Teppanyaki {
             [PrimaryKey, Column(0)] public Guid GrillID { get; set; }
             [Column(1)] public double GrillSurfaceArea { get; set; }
-            public RelationSet<string> AuthorizedChefs { get; init; } = new();
-            public RelationList<string> SupportedFoods { get; init; } = new();
+            public RelationSet<string> AuthorizedChefs { get; init; } = [];
+            public RelationList<string> SupportedFoods { get; init; } = [];
             [Column(2)] public float MaxTemperature { get; set; }
             [Column(3)] public string? Restaurant { get; set; }
             [Column(4)] public bool IsHibachi { get; set; }
@@ -16357,7 +16357,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public ushort Year { get; set; }
             [Column(1)] public byte NumRounds { get; set; }
             [Column(2)] public string Champion { get; set; } = "";
-            public RelationMap<uint, string> EliminationWords { get; init; } = new();
+            public RelationMap<uint, string> EliminationWords { get; init; } = [];
         }
 
         // Scenario: Non-Null Ordered List Relation Property with Only New Elements (✓values extracted per element✓)
@@ -16365,7 +16365,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
             [Column(1)] public DateTime Created { get; set; }
             [Column(2)] public uint NumShows { get; set; }
-            public RelationOrderedList<string> Lineup { get; init; } = new();
+            public RelationOrderedList<string> Lineup { get; init; } = [];
             [Column(3)] public string Location { get; set; } = "";
             [Column(4)] public string URL { get; set; } = "";
         }
@@ -16375,13 +16375,13 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public Guid ID { get; set; }
             public string Category { get; set; } = "";
             public string Tip { get; set; } = "";
-            public RelationSet<string> For { get; init; } = new();
+            public RelationSet<string> For { get; init; } = [];
         }
 
         // Scenario: Non-Null Relation Property with At Least One Modified Element (✓values extracted per element✓)
         public class PendragonTerritory {
             [PrimaryKey] public string Name { get; set; } = "";
-            public RelationOrderedList<string> Travellers { get; init; } = new();
+            public RelationOrderedList<string> Travellers { get; init; } = [];
             public string FirstAppearance { get; set; } = "";
             public string Capital { get; set; } = "";
         }
@@ -16393,7 +16393,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public ushort Year { get; set; }
             [PrimaryKey] public PoliticalParty Party { get; set; }
             public DateTime Date { get; set; }
-            public RelationMap<string, double> DelegatesEarned { get; init; } = new();
+            public RelationMap<string, double> DelegatesEarned { get; init; } = [];
             public bool Bellwether { get; set; }
         }
 
@@ -16406,7 +16406,7 @@ namespace UT.Kvasir.Translation {
             }
 
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
-            public RelationOrderedList<Thesis> DoctoralTheses { get; init; }
+            public RelationOrderedList<Thesis> DoctoralTheses { get; init; } = new();
             [Column(1)] public DateTime DateOfBirth { get; set; }
             [Column(2)] public DateTime? DateOfDeath { get; set; }
             [Column(3)] public string ExistentialSchool { get; set; } = "";
@@ -16425,7 +16425,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public string BoonName { get; set; } = "";
             [Column(1)] public Deity Benefactor { get; set; }
             [Column(2)] public Ability AbilityAffected { get; set; }
-            public RelationOrderedList<Benefit> Progressions { get; init; } = new();
+            public RelationOrderedList<Benefit> Progressions { get; init; } = [];
             [Column(3)] public double Likelihood { get; set; }
         }
 
@@ -16446,7 +16446,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public string Official { get; set; } = "";
             [Column(1)] public string Position { get; set; } = "";
             [PrimaryKey, Column(2)] public DateTime Commenced { get; set; }
-            public RelationList<Count> Counts { get; init; } = new();
+            public RelationList<Count> Counts { get; init; } = [];
             [Calculated, Column(3)] public bool Convicted => Counts.Any(c => c.Guilty);
         }
 
@@ -16456,7 +16456,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
             [Column(1)] public string Domain { get; set; } = "";
-            public RelationMap<MaoriGod, Relation> Family { get; init; } = new();
+            public RelationMap<MaoriGod, Relation> Family { get; init; } = [];
             [Column(2)] public bool IsAtua { get; set; }
             [Column(3)] public bool EncounteredMaui { get; set; }
         }
@@ -16496,9 +16496,10 @@ namespace UT.Kvasir.Translation {
             [Calculated] public RelationOrderedList<Eye> Eyes { get; init; }
 
             public Chameleon() {
-                Eyes = new RelationOrderedList<Eye>();
-                Eyes.Add(new Eye() { ConeDensity = 8571, RodDensity = 4409, VisionRange = 360 });
-                Eyes.Add(new Eye() { ConeDensity = 12099, RodDensity = 6776, VisionRange = 360 });
+                Eyes = [
+                    new Eye() { ConeDensity = 8571, RodDensity = 4409, VisionRange = 360 },
+                    new Eye() { ConeDensity = 12099, RodDensity = 6776, VisionRange = 360 }
+                ];
             }
         }
 
@@ -16515,7 +16516,7 @@ namespace UT.Kvasir.Translation {
             }
 
             [PrimaryKey, Column(0)] public Zodiac Sign { get; set; }
-            public RelationMap<DateTime, Listing> Readings { get; init; } = new();
+            public RelationMap<DateTime, Listing> Readings { get; init; } = [];
             [Column(1)] public DateTime RangeLower { get; set; }
             [Column(2)] public DateTime RangeUpper { get; set; }
         }
@@ -16603,7 +16604,7 @@ namespace UT.Kvasir.Translation {
             [Column(2)] public string Challenge { get; set; } = "";
             [Column(3)] public string WinningBaker { get; set; } = "";
             [Column(4)] public string WorstBaker { get; set; } = "";
-            public RelationSet<LocalizedText> Ingredients { get; init; } = new();
+            public RelationSet<LocalizedText> Ingredients { get; init; } = [];
         }
 
         // Scenario: Localization as Key of Map Relation (✓key extracted into Relation Table✓)
@@ -16623,7 +16624,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public ushort Year { get; set; }
             [Column(1)] public DateTime StartDate { get; set; }
             [Column(2)] public DateTime EndDate { get; set; }
-            public RelationMap<string, LocalizedMeasure> RaceTimes { get; init; } = new();
+            public RelationMap<string, LocalizedMeasure> RaceTimes { get; init; } = [];
             [Column(3)] public uint TotalSledDogs { get; set; }
             [Column(4)] public decimal PrizeMoney { get; set; }
         }
@@ -16632,7 +16633,7 @@ namespace UT.Kvasir.Translation {
         public class Festigal {
             [PrimaryKey, Column(0)] public ushort Year { get; set; }
             [Column(1)] public string HostCity { get; set; } = "";
-            public RelationOrderedList<LocalizedText> Songs { get; init; } = new();
+            public RelationOrderedList<LocalizedText> Songs { get; init; } = [];
             [Column(2)] public DateOnly Opening { get; set; }
             [Column(3)] public string? Theme { get; set; }
             [Column(4)] public ushort NumPerformers { get; set; }
@@ -16843,13 +16844,13 @@ namespace UT.Kvasir.Translation {
             [Column(2)] public string Spouse2 { get; set; } = "";
             [Calculated] public RelationSet<DateTime> VestingSchedule {
                 get {
-                    return new RelationSet<DateTime>() {
+                    return [
                         new DateTime(2035, 1, 1),
                         new DateTime(2036, 1, 1),
                         new DateTime(2037, 1, 1),
                         new DateTime(2038, 1, 1),
                         new DateTime(2039, 1, 1),
-                    };
+                    ];
                 }
             }
             [Column(3)] public decimal TotalNetWorth { get; set; }
@@ -17050,7 +17051,7 @@ namespace UT.Kvasir.Translation {
         public class Empanada {
             public struct Filling {
                 [Column(0)] public string Contents { get; set; }
-                [Calculated, Column(1)] public double Percentage => 100.0;
+                [Calculated, Column(1)] public readonly double Percentage => 100.0;
             }
 
             [PrimaryKey, Column(0)] public Guid EmpanadaID { get; set; }
@@ -17176,18 +17177,18 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public Guid ID { get; set; }
             [Column(1)] public string BoardMaterial { get; set; } = "";
             [Column(2)] public double BoardArea { get; set; }
-            public RelationList<string> Cheeses { get; } = new();
-            public RelationSet<string> Meats { get; } = new();
-            public RelationOrderedList<string> Sauces { get; } = new();
-            public RelationMap<DateTime, uint> Usages { get; } = new();
+            public RelationList<string> Cheeses { get; } = [];
+            public RelationSet<string> Meats { get; } = [];
+            public RelationOrderedList<string> Sauces { get; } = [];
+            public RelationMap<DateTime, uint> Usages { get; } = [];
         }
 
         // Scenario: List/Set Relation Elements (✓values reconstituted per element✓)
         public class Mutant {
             [PrimaryKey, Column(0)] public string CodeName { get; set; } = "";
             [Column(1)] public string BirthName { get; set; } = "";
-            public RelationList<string> Powers { get; } = new();
-            public RelationSet<DateTime> Appearances { get; } = new();
+            public RelationList<string> Powers { get; } = [];
+            public RelationSet<DateTime> Appearances { get; } = [];
             [Column(2)] public bool InXMenMovies { get; set; }
         }
 
@@ -17197,17 +17198,17 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey, Column(0)] public Guid WaterParkID { get; set; }
             [Column(1)] public string Name { get; set; } = "";
-            public RelationMap<string, double> WaterSlides { get; } = new();
+            public RelationMap<string, double> WaterSlides { get; } = [];
             [Column(2)] public bool LazyRiver { get; set; }
             [Column(3)] public ulong GallonsWater { get; set; }
-            public RelationMap<Customer, decimal> AdmissionPrices { get; } = new();
+            public RelationMap<Customer, decimal> AdmissionPrices { get; } = [];
         }
 
         // Scenario: Ordered List Relation Elements (✓values reconstituted per element✓)
         public class Seance {
             [PrimaryKey, Column(0)] public DateTime Timestamp { get; set; }
             [PrimaryKey, Column(1)] public string Medium { get; set; } = "";
-            public RelationOrderedList<string> SpiritsContacted { get; } = new();
+            public RelationOrderedList<string> SpiritsContacted { get; } = [];
             [Column(2)] public decimal PriceTag { get; set; }
             [Column(3)] public ushort NumCandles { get; set; }
         }
@@ -17252,7 +17253,7 @@ namespace UT.Kvasir.Translation {
                 [Column(2)] public string? DecalMaker { get; set; }
 
                 public Personnel() {
-                    LicensedDrivers = new RelationSet<string>();
+                    LicensedDrivers = [];
                 }
             }
 
@@ -17289,7 +17290,7 @@ namespace UT.Kvasir.Translation {
             [Column(1)] public string Author { get; set; } = "";
             [Column(2)] public DateTime Published { get; set; }
             [Column(3)] public uint StanzaCount { get; set; }
-            public RelationOrderedList<Section> Sections { get; } = new();
+            public RelationOrderedList<Section> Sections { get; } = [];
             [Column(4)] public string Language { get; set; } = "";
         }
 
@@ -17304,7 +17305,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey, Column(0)] public DateTime Timestamp { get; set; }
             [Column(1)] public string Driver { get; set; } = "";
-            public RelationList<PoliceOfficer> Officers { get; } = new();
+            public RelationList<PoliceOfficer> Officers { get; } = [];
             [Column(2)] public bool TicketIssued { get; set; }
             [Column(3)] public bool ArrestMade { get; set; }
         }
@@ -17317,7 +17318,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public string Name { get; set; } = "";
             [Column(1)] public Continent ActiveLocations { get; set; }
             [Column(2)] public AnimalType Targets { get; set; }
-            public RelationSet<Poacher> PoachingGroup { get; } = new();
+            public RelationSet<Poacher> PoachingGroup { get; } = [];
             [Column(3)] public decimal Income { get; set; }
         }
 
@@ -17330,7 +17331,7 @@ namespace UT.Kvasir.Translation {
 
             [PrimaryKey, Column(0)] public ushort Year { get; set; }
             [Column(1)] public uint PageCount { get; set; }
-            public RelationMap<string, Rating> Restaurants { get; } = new();
+            public RelationMap<string, Rating> Restaurants { get; } = [];
             [Column(2)] public bool IsGreenGuide { get; set; }
         }
 
@@ -17695,7 +17696,7 @@ namespace UT.Kvasir.Translation {
         public class GPU {
             public enum Field { Gaming, CloudGaming, Workstation, CloudWorkstation, AI, DriverlessCars, Other }
 
-            public struct Spec {
+            public readonly struct Spec {
                 [Column(0)] public Field PrimaryField { get; }
                 [Column(1)] public ushort MegaHertz { get; }
                 [Column(2)] public ushort GigaBytes { get; }
@@ -17771,7 +17772,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey, Column(0)] public string PowerName { get; set; } = "";
             [Column(1)] public Act ActUnlocked { get; set; }
             [Column(2)] public Kind KindOfPower { get; set; }
-            public RelationList<Feature> Features { get; } = new RelationList<Feature>();
+            public RelationList<Feature> Features { get; } = [];
         }
 
         // Scenario: No Viable Constructor for Aggregate Type Backing only [Calculated] Properties (✓reconstituted✓)
@@ -18224,7 +18225,7 @@ namespace UT.Kvasir.Translation {
             [Column(2)] public Kind Variety { get; set; }
             [Column(3)] public bool WasProsecuted { get; set; }
             [Column(4)] public bool IsOngoing { get; set; }
-            public RelationList<LocalizedText> Perpetrators { get; init; } = new();
+            public RelationList<LocalizedText> Perpetrators { get; init; } = [];
             [Column(5)] public bool WasNazi { get; set; }
         }
 

--- a/test/UnitTests/Kvasir/Translation/_Globals.cs
+++ b/test/UnitTests/Kvasir/Translation/_Globals.cs
@@ -3,6 +3,6 @@ using System.Collections.Generic;
 
 namespace UT.Kvasir.Translation {
     internal static class Globals {
-        public static Func<Type, IEnumerable<object>> NO_ENTITIES => _ => Array.Empty<object>();
+        public static Func<Type, IEnumerable<object>> NO_ENTITIES = _ => [];
     }
 }

--- a/test/UnitTests/_FluentExtensions/RelationAssertions.cs
+++ b/test/UnitTests/_FluentExtensions/RelationAssertions.cs
@@ -39,7 +39,7 @@ namespace FluentAssertions {
                 : base(subject) {
 
                 Subject = subject;
-                SubjectList = new List<(object Item, Status status)>();
+                SubjectList = [];
 
                 var iter = subject.GetEnumerator();
                 while (iter.MoveNext()) {
@@ -89,7 +89,7 @@ namespace FluentAssertions {
                 var flags = BindingFlags.Static | BindingFlags.NonPublic;
                 var name = nameof(IRelation.ConnectionType);
                 var reader = Subject.GetType().GetProperties(flags).First(p => p.Name.Contains(name))!.GetMethod!;
-                var connectionType = (Type)reader.Invoke(null, new object?[] {})!;
+                var connectionType = (Type)reader.Invoke(null, [])!;
 
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)

--- a/test/UnitTests/_FluentExtensions/TableAssertions.cs
+++ b/test/UnitTests/_FluentExtensions/TableAssertions.cs
@@ -20,10 +20,10 @@ namespace FluentAssertions {
                 : base(subject)
             {
                 Subject = subject;
-                checkedFields_ = new();
-                checkedKeys_ = new();
-                checkedConstraints_ = new();
-                checkedForeignKeys_ = new();
+                checkedFields_ = [];
+                checkedKeys_ = [];
+                checkedConstraints_ = [];
+                checkedForeignKeys_ = [];
             }
             protected override string Identifier => "Table";
 


### PR DESCRIPTION
  * add `readonly` keyword to a number of structs/fields
  * use new [bracket] syntax for collection initialization
  * remove interpolation $prefix from strings with no interpolation
  * make types of some fields concrete rather than interfaces
  * use .Be<T> rather than .Be(typeof(T)) in unit tests
  * a few other things