### PR TITLE
Introduce ConnectionPool for Ad-Hoc Connections in Transactor

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -1854,6 +1854,31 @@
         <member name="M:Kvasir.Providers.MySQL.CommandsFactory.CreateCommands(Kvasir.Schema.ITable,System.Boolean)">
             <inheritdoc/>
         </member>
+        <member name="T:Kvasir.Providers.MySQL.ConnectionPool">
+            <summary>
+              The <see cref="T:Kvasir.Transaction.IConnectionPool"/> implementation for the MySQL provider.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Providers.MySQL.ConnectionPool.#ctor(System.String,System.String,System.String,System.String)">
+            <summary>
+              Creates a new MySQL <see cref="T:Kvasir.Providers.MySQL.ConnectionPool"/>.
+            </summary>
+            <param name="server">
+              The database server.
+            </param>
+            <param name="database">
+              The database name.
+            </param>
+            <param name="username">
+              The connection username.
+            </param>
+            <param name="password">
+              The connection password.
+            </param>
+        </member>
+        <member name="M:Kvasir.Providers.MySQL.ConnectionPool.MakeConnection">
+            <see cref="M:Kvasir.Transaction.IConnectionPool.MakeConnection"/>
+        </member>
         <member name="T:Kvasir.Providers.MySQL.IConstraintDecl">
             <summary>
               A type tag to be used as the return value for a MySQL <see cref="T:Kvasir.Transcription.IConstraintDeclBuilder`1"/>
@@ -7530,6 +7555,25 @@
               An <see cref="T:Kvasir.Transaction.ICommands"/> instance that can be used to manipulate and query <paramref name="table"/>.
             </returns>
         </member>
+        <member name="T:Kvasir.Transaction.IConnectionPool">
+            <summary>
+              The interface that abstracts the creation of <see cref="T:System.Data.IDbConnection">database connections</see> without
+              exposing details about the connection or the back-end provider.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Transaction.IConnectionPool.MakeConnection">
+            <summary>
+              Creates a connection.
+            </summary>
+            <remarks>
+              It is recommended that clients leverage connection within a <c>using</c> statement so that it
+              automatically closes when it is no longer being used. The connection returned is guaranteed to be open,
+              and it *may* be the same object as returned on previous invocations, though that is not requried.
+            </remarks>
+            <returns>
+              An open <see cref="T:System.Data.IDbConnection">database connection</see>.
+            </returns>
+        </member>
         <member name="T:Kvasir.Transaction.Topology">
             <summary>
               Some utility functions for performing topological queries needed by the Transaction Layer.
@@ -7562,7 +7606,7 @@
               entities and a particular back-end provider/system.
             </summary>
         </member>
-        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},System.Data.IDbConnection,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Microsoft.Extensions.Logging.ILogger)">
+        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},Kvasir.Transaction.IConnectionPool,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Microsoft.Extensions.Logging.ILogger)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.Translator"/> that uses default <see cref="T:Kvasir.Core.Settings"/>.
             </summary>
@@ -7574,8 +7618,8 @@
               The set of <see cref="T:Kvasir.Translation.LocalizationTranslation">translations</see> for Localization types that define the
               schema of the back-end database on which the new <see cref="T:Kvasir.Transaction.Transactor"/> will operate.
             </param>
-            <param name="connection">
-              The database connection through which all commands and queries will be executed.
+            <param name="connectionPool">
+              The <see cref="T:Kvasir.Transaction.IConnectionPool">connection pool</see> with which to create database connections as needed.
             </param>
             <param name="commandsFactory">
               The <see cref="T:Kvasir.Transaction.ICommandsFactory"/> with which to create the necessary commands and queries to interact
@@ -7588,7 +7632,7 @@
               The <see cref="T:Microsoft.Extensions.Logging.ILogger">logger</see> with which to issue diagnostics.
             </param>
         </member>
-        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},System.Data.IDbConnection,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Kvasir.Core.Settings,Microsoft.Extensions.Logging.ILogger)">
+        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},Kvasir.Transaction.IConnectionPool,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Kvasir.Core.Settings,Microsoft.Extensions.Logging.ILogger)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.Translator"/> that uses custom <see cref="T:Kvasir.Core.Settings"/>.
             </summary>
@@ -7600,8 +7644,8 @@
               The set of <see cref="T:Kvasir.Translation.LocalizationTranslation">translations</see> for Localization types that define the
               schema of the back-end database on which the new <see cref="T:Kvasir.Transaction.Transactor"/> will operate.
             </param>
-            <param name="connection">
-              The database connection through which all commands and queries will be executed.
+            <param name="connectionPool">
+              The <see cref="T:Kvasir.Transaction.IConnectionPool">connection pool</see> with which to create database connections as needed.
             </param>
             <param name="commandsFactory">
               The <see cref="T:Kvasir.Transaction.ICommandsFactory"/> with which to create the necessary commands and queries to interact

--- a/src/Kvasir/Providers/MySQL/Connection.cs
+++ b/src/Kvasir/Providers/MySQL/Connection.cs
@@ -1,0 +1,50 @@
+﻿using Kvasir.Transaction;
+using MySql.Data.MySqlClient;
+using System.Data;
+using System.Diagnostics;
+
+namespace Kvasir.Providers.MySQL {
+    /// <summary>
+    ///   The <see cref="IConnectionPool"/> implementation for the MySQL provider.
+    /// </summary>
+    internal sealed class ConnectionPool : IConnectionPool {
+        /// <summary>
+        ///   Creates a new MySQL <see cref="ConnectionPool"/>.
+        /// </summary>
+        /// <param name="server">
+        ///   The database server.
+        /// </param>
+        /// <param name="database">
+        ///   The database name.
+        /// </param>
+        /// <param name="username">
+        ///   The connection username.
+        /// </param>
+        /// <param name="password">
+        ///   The connection password.
+        /// </param>
+        public ConnectionPool(string server, string database, string username, string password) {
+            Debug.Assert(server is not null && server != "");
+            Debug.Assert(database is not null && database != "");
+            Debug.Assert(username is not null && username != "");
+            Debug.Assert(password is not null && password != "");
+
+            connectionString_ = new MySqlConnectionStringBuilder() {
+                Server = server,
+                Database = database,
+                UserID = username,
+                Password = password
+            }.ConnectionString;
+        }
+
+        /// <see cref="IConnectionPool.MakeConnection"/>
+        public IDbConnection MakeConnection() {
+            var connection = new MySqlConnection(connectionString_);
+            connection.Open();
+            return connection;
+        }
+
+
+        private readonly string connectionString_;
+    }
+}

--- a/src/Kvasir/Transaction/IConnectionPool.cs
+++ b/src/Kvasir/Transaction/IConnectionPool.cs
@@ -1,0 +1,22 @@
+﻿using System.Data;
+
+namespace Kvasir.Transaction {
+    /// <summary>
+    ///   The interface that abstracts the creation of <see cref="IDbConnection">database connections</see> without
+    ///   exposing details about the connection or the back-end provider.
+    /// </summary>
+    internal interface IConnectionPool {
+        /// <summary>
+        ///   Creates a connection.
+        /// </summary>
+        /// <remarks>
+        ///   It is recommended that clients leverage connection within a <c>using</c> statement so that it
+        ///   automatically closes when it is no longer being used. The connection returned is guaranteed to be open,
+        ///   and it *may* be the same object as returned on previous invocations, though that is not requried.
+        /// </remarks>
+        /// <returns>
+        ///   An open <see cref="IDbConnection">database connection</see>.
+        /// </returns>
+        IDbConnection MakeConnection();
+    }
+}

--- a/src/Kvasir/Transaction/Transactor.cs
+++ b/src/Kvasir/Transaction/Transactor.cs
@@ -8,10 +8,8 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
-using System.Transactions;
 
 namespace Kvasir.Transaction {
     /// <summary>
@@ -30,8 +28,8 @@ namespace Kvasir.Transaction {
         ///   The set of <see cref="LocalizationTranslation">translations</see> for Localization types that define the
         ///   schema of the back-end database on which the new <see cref="Transactor"/> will operate.
         /// </param>
-        /// <param name="connection">
-        ///   The database connection through which all commands and queries will be executed.
+        /// <param name="connectionPool">
+        ///   The <see cref="IConnectionPool">connection pool</see> with which to create database connections as needed.
         /// </param>
         /// <param name="commandsFactory">
         ///   The <see cref="ICommandsFactory"/> with which to create the necessary commands and queries to interact
@@ -46,12 +44,12 @@ namespace Kvasir.Transaction {
         public Transactor(
             IEnumerable<EntityTranslation> entityTranslations,
             IEnumerable<LocalizationTranslation> localizationTranslations,
-            IDbConnection connection,
+            IConnectionPool connectionPool,
             ICommandsFactory commandsFactory,
             Action<object> entityStorage,
             ILogger logger
         )
-            : this(entityTranslations, localizationTranslations, connection, commandsFactory, entityStorage, Settings.Default, logger) {}
+            : this(entityTranslations, localizationTranslations, connectionPool, commandsFactory, entityStorage, Settings.Default, logger) {}
 
         /// <summary>
         ///   Constructs a new <see cref="Translator"/> that uses custom <see cref="Settings"/>.
@@ -64,8 +62,8 @@ namespace Kvasir.Transaction {
         ///   The set of <see cref="LocalizationTranslation">translations</see> for Localization types that define the
         ///   schema of the back-end database on which the new <see cref="Transactor"/> will operate.
         /// </param>
-        /// <param name="connection">
-        ///   The database connection through which all commands and queries will be executed.
+        /// <param name="connectionPool">
+        ///   The <see cref="IConnectionPool">connection pool</see> with which to create database connections as needed.
         /// </param>
         /// <param name="commandsFactory">
         ///   The <see cref="ICommandsFactory"/> with which to create the necessary commands and queries to interact
@@ -88,7 +86,7 @@ namespace Kvasir.Transaction {
         public Transactor(
             IEnumerable<EntityTranslation> entityTranslations,
             IEnumerable<LocalizationTranslation> localizationTranslations,
-            IDbConnection connection,
+            IConnectionPool connectionPool,
             ICommandsFactory commandsFactory,
             Action<object> entityStorage,
             Settings settings,
@@ -97,7 +95,7 @@ namespace Kvasir.Transaction {
             Debug.Assert(entityTranslations is not null);
             Debug.Assert(localizationTranslations is not null);
             Debug.Assert(!entityTranslations.IsEmpty() || !localizationTranslations.IsEmpty());
-            Debug.Assert(connection is not null && connection.State == ConnectionState.Open);
+            Debug.Assert(connectionPool is not null);
             Debug.Assert(commandsFactory is not null);
             Debug.Assert(entityStorage is not null);
             Debug.Assert(settings is not null);
@@ -106,7 +104,7 @@ namespace Kvasir.Transaction {
             settings_ = settings;
             entityTranslations_ = entityTranslations.ToDictionary(t => t.CLRSource, t => t);
             localizationTranslations_ = localizationTranslations.ToDictionary(t => t.CLRSource, t => t);
-            connection_ = connection;
+            connectionPool_ = connectionPool;
             commandsFactory_ = commandsFactory;
             entityStorage_ = entityStorage;
             logger_ = logger;
@@ -170,9 +168,10 @@ namespace Kvasir.Transaction {
         ///   fails.
         /// </exception>
         public void CreateTables() {
-            using var transaction = connection_.BeginTransaction();
+            using var connection = connectionPool_.MakeConnection();
+            using var transaction = connection.BeginTransaction();
             foreach (var command in commands_.Select(c => c.CreateTableCommand)) {
-                command.Connection = connection_;
+                command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
@@ -192,6 +191,8 @@ namespace Kvasir.Transaction {
         ///   Selects all of the data out of the back-end database and creates corresponding CLR objects.
         /// </summary>
         public void SelectAll() {
+            using var connection = connectionPool_.MakeConnection();
+
             var entityTranslations = entityTranslations_.Values.OrderBy(t => tables_[t.Principal.Table]).ToList();
             var localizationTranslations = localizationTranslations_.Values.ToList();
             int numEntityTypes = entityTranslations_.Count;
@@ -204,7 +205,7 @@ namespace Kvasir.Transaction {
             for (int idx = 0; idx < numLocalizationTypes; ++idx) {
                 var query = commands_[idx + localizationStartIdx_].SelectAllQuery;
                 logger_.LogDebug("Executing SQL: {}", query.CommandText);
-                query.Connection = connection_;
+                query.Connection = connection;
                 var reader = query.ExecuteReader();
 
                 var rows = new Dictionary<DBValue, List<List<DBValue>>>();
@@ -235,7 +236,7 @@ namespace Kvasir.Transaction {
             for (int idx = 0; idx < numEntityTypes; ++idx) {
                 var query = commands_[idx].SelectAllQuery;
                 logger_.LogDebug("Executing SQL: {}", query.CommandText);
-                query.Connection = connection_;
+                query.Connection = connection;
                 var reader = query.ExecuteReader();
 
                 var creations = new List<object>();
@@ -259,7 +260,7 @@ namespace Kvasir.Transaction {
                 foreach (var relation in translation.Relations) {
                     var query = commands_[tables_[relation.Table]].SelectAllQuery;
                     logger_.LogDebug("Executing SQL: {}", query.CommandText);
-                    query.Connection = connection_;
+                    query.Connection = connection;
                     var reader = query.ExecuteReader();
 
                     var rows = options.ToDictionary(e => e, _ => new List<IReadOnlyList<DBValue>>());
@@ -307,7 +308,8 @@ namespace Kvasir.Transaction {
             var entityTranslations = mapping.Keys.Where(t => !Translator.IsLocalizationType(t)).Select(k => entityTranslations_[k]).OrderBy(t => tables_[t.Principal.Table]).ToList();
             var localizationTranslations = mapping.Keys.Where(t => Translator.IsLocalizationType(t)).Select(k => localizationTranslations_[k]).ToList();
 
-            using var transaction = connection_.BeginTransaction();
+            using var connection = connectionPool_.MakeConnection();
+            using var transaction = connection.BeginTransaction();
 
             // Insert all the data into Principal Tables first
             foreach (var translation in entityTranslations) {
@@ -317,7 +319,7 @@ namespace Kvasir.Transaction {
                 }
 
                 var command = commands_[tables_[translation.Principal.Table]].InsertCommand(rows);
-                command.Connection = connection_;
+                command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
@@ -341,7 +343,7 @@ namespace Kvasir.Transaction {
                     }
 
                     var command = commands_[tables_[relation.Table]].InsertCommand(rows);
-                    command.Connection = connection_;
+                    command.Connection = connection;
                     command.Transaction = transaction;
                     logger_.LogDebug("Executing SQL: {}", command.CommandText);
                     command.ExecuteNonQuery();
@@ -363,7 +365,7 @@ namespace Kvasir.Transaction {
                 }
 
                 var command = commands_[tables_[translation.Principal.Table]].InsertCommand(rows);
-                command.Connection = connection_;
+                command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
@@ -399,7 +401,8 @@ namespace Kvasir.Transaction {
             var entityTranslations = mapping.Keys.Where(t => !Translator.IsLocalizationType(t)).Select(k => entityTranslations_[k]).OrderBy(t => tables_[t.Principal.Table]).ToList();
             var localizationTranslations = mapping.Keys.Where(t => Translator.IsLocalizationType(t)).Select(k => localizationTranslations_[k]).ToList();
 
-            using var transaction = connection_.BeginTransaction();
+            using var connection = connectionPool_.MakeConnection();
+            using var transaction = connection.BeginTransaction();
 
             // Update all the data in Principal Tables first
             foreach (var translation in entityTranslations) {
@@ -409,7 +412,7 @@ namespace Kvasir.Transaction {
                 }
 
                 var command = commands_[tables_[translation.Principal.Table]].UpdateCommand(rows);
-                command.Connection = connection_;
+                command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
@@ -439,7 +442,7 @@ namespace Kvasir.Transaction {
                     var insertCommand = (insertRows.IsEmpty(), commands_[tables_[relation.Table]].InsertCommand(insertRows));
                     foreach (var (isEmpty, command) in new[] { deleteCommand, updateCommand, insertCommand }) {
                         if (!isEmpty) {
-                            command.Connection = connection_;
+                            command.Connection = connection;
                             command.Transaction = transaction;
                             logger_.LogDebug("Executing SQL: {}", command.CommandText);
                             command.ExecuteNonQuery();
@@ -470,7 +473,7 @@ namespace Kvasir.Transaction {
                 var insertCommand = (insertRows.IsEmpty(), commands_[tables_[translation.Principal.Table]].InsertCommand(insertRows));
                 foreach (var (isEmpty, command) in new[] { deleteCommand, insertCommand }) {
                     if (!isEmpty) {
-                        command.Connection = connection_;
+                        command.Connection = connection;
                         command.Transaction = transaction;
                         logger_.LogDebug("Executing SQL: {}", command.CommandText);
                         command.ExecuteNonQuery();
@@ -508,7 +511,8 @@ namespace Kvasir.Transaction {
             var entityTranslations = mapping.Keys.Where(t => !Translator.IsLocalizationType(t)).Select(k => entityTranslations_[k]).OrderBy(t => tables_[t.Principal.Table]).ToList();
             var localizationTranslations = mapping.Keys.Where(t => Translator.IsLocalizationType(t)).Select(k => localizationTranslations_[k]).ToList();
 
-            using var transaction = connection_.BeginTransaction();
+            using var connection = connectionPool_.MakeConnection();
+            using var transaction = connection.BeginTransaction();
 
             // Delete all the data from Localization Tables first
             foreach (var translation in localizationTranslations) {
@@ -522,7 +526,7 @@ namespace Kvasir.Transaction {
                     rows.Add(translation.Principal.KeyExtractor.ExtractFrom(entity));
                 }
                 var command = commands_[tables_[translation.Principal.Table]].DeleteCommand(rows);
-                command.Connection = connection_;
+                command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
@@ -543,7 +547,7 @@ namespace Kvasir.Transaction {
                     }
 
                     var command = commands_[tables_[relation.Table]].DeleteCommand(rows);
-                    command.Connection = connection_;
+                    command.Connection = connection;
                     command.Transaction = transaction;
                     logger_.LogDebug("Executing SQL: {}", command.CommandText);
                     command.ExecuteNonQuery();
@@ -558,7 +562,7 @@ namespace Kvasir.Transaction {
                 }
 
                 var command = commands_[tables_[translation.Principal.Table]].DeleteCommand(rows);
-                command.Connection = connection_;
+                command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
                 command.ExecuteNonQuery();
@@ -598,7 +602,7 @@ namespace Kvasir.Transaction {
 
             // We need a translation of the `TableHash` administrative type in order to create a Transactor.
             var translation = translator[typeof(TableHash)];
-            var transactor = new Transactor([translation], [], connection_, commandsFactory_, hashStorage, logger_);
+            var transactor = new Transactor([translation], [], connectionPool_, commandsFactory_, hashStorage, logger_);
 
             // First, create the tables; this will create the administrative table if it does not yet exist. Then,
             // select all the data; this will load all existing administrative hashes into the `hashes` dictionary.
@@ -674,7 +678,7 @@ namespace Kvasir.Transaction {
         private readonly IReadOnlyDictionary<Type, LocalizationTranslation> localizationTranslations_;
         private readonly IReadOnlyDictionary<ITable, int> tables_;          // maps to index in `commands_` list
         private readonly Dictionary<ITable, Type> sourceTypes_;
-        private readonly IDbConnection connection_;
+        private readonly IConnectionPool connectionPool_;
         private readonly ICommandsFactory commandsFactory_;
         private readonly Action<object> entityStorage_;
         private readonly ILogger logger_;

--- a/test/UnitTests/Kvasir/Providers/MySQL.cs
+++ b/test/UnitTests/Kvasir/Providers/MySQL.cs
@@ -3758,5 +3758,5 @@ namespace UT.Kvasir.Providers {
             return (string)converter.Convert(enumerator)!;
         }
         private readonly static Func<Type, IEnumerable<object>> NO_ENTITIES = _ => [];
-    }    
+    }
 }

--- a/test/UnitTests/Kvasir/Transaction/_Fixture.cs
+++ b/test/UnitTests/Kvasir/Transaction/_Fixture.cs
@@ -19,7 +19,7 @@ using Rows = System.Collections.Generic.IEnumerable<System.Collections.Generic.I
 namespace UT.Kvasir.Transaction {
     internal sealed class TestFixture {
         public IReadOnlyDictionary<ITable, ICommands> Commands => commands_;
-        public IDbConnection Connection { get; }
+        public IDbConnection Connection { get; } = Substitute.For<IDbConnection>();
         public IDbTransaction Transaction { get; }
         public Dictionary<Type, List<object>> Depot { get; }
         public Transactor Transactor {
@@ -34,6 +34,7 @@ namespace UT.Kvasir.Transaction {
         public TestFixture(params Type[] types) {
             commands_ = [];
             dbRows_ = [];
+            connectionPool_ = Substitute.For<IConnectionPool>();
             commandsFactory_ = Substitute.For<ICommandsFactory>();
             Connection = Substitute.For<IDbConnection>();
             Transaction = Connection.BeginTransaction();
@@ -42,7 +43,7 @@ namespace UT.Kvasir.Transaction {
             ordering_ = [];
             invocationArgs_ = [];
 
-            Connection.State.Returns(ConnectionState.Open);
+            connectionPool_.MakeConnection().Returns(Connection);
 
             var adminTypes = new Type[] { typeof(TableHash) };
 
@@ -98,7 +99,7 @@ namespace UT.Kvasir.Transaction {
             }
 
             transactor_ = null!;
-            transactorInitializer_ = () => transactor_ = new Transactor(entityTranslations, localizationTranslations, Connection, commandsFactory_, e => Depot[e.GetType()].Add(e), NullLogger.Instance);            
+            transactorInitializer_ = () => transactor_ = new Transactor(entityTranslations, localizationTranslations, connectionPool_, commandsFactory_, e => Depot[e.GetType()].Add(e), NullLogger.Instance);            
         }
         public TestFixture WithCommitError() {
             Transaction.When(x => x.Commit()).Throw<InvalidOperationException>();
@@ -240,6 +241,7 @@ namespace UT.Kvasir.Transaction {
         }
 
 
+        private readonly IConnectionPool connectionPool_;
         private readonly ICommandsFactory commandsFactory_;
         private readonly Translator translator_;
         private readonly Dictionary<ITable, ICommands> commands_;


### PR DESCRIPTION
This commit fixes an issue in the Transactor where the database connection was kept open indefinitely, which is not ideal. Now, there is a new IConnectionPool interface available that exposes a function to produce a connection (new or reused). The MySQL provider defines an implementation that produces a new connection on each invocation, and the Transactor now creates a new connection before executing its functions.