### PR TITLE
Make Transaction Code Support Asynchronous Operations

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -1876,8 +1876,8 @@
               The connection password.
             </param>
         </member>
-        <member name="M:Kvasir.Providers.MySQL.ConnectionPool.MakeConnection">
-            <see cref="M:Kvasir.Transaction.IConnectionPool.MakeConnection"/>
+        <member name="M:Kvasir.Providers.MySQL.ConnectionPool.MakeConnectionAsync">
+            <see cref="M:Kvasir.Transaction.IConnectionPool.MakeConnectionAsync"/>
         </member>
         <member name="T:Kvasir.Providers.MySQL.IConstraintDecl">
             <summary>
@@ -7557,11 +7557,11 @@
         </member>
         <member name="T:Kvasir.Transaction.IConnectionPool">
             <summary>
-              The interface that abstracts the creation of <see cref="T:System.Data.IDbConnection">database connections</see> without
+              The interface that abstracts the creation of <see cref="T:System.Data.Common.DbConnection">database connections</see> without
               exposing details about the connection or the back-end provider.
             </summary>
         </member>
-        <member name="M:Kvasir.Transaction.IConnectionPool.MakeConnection">
+        <member name="M:Kvasir.Transaction.IConnectionPool.MakeConnectionAsync">
             <summary>
               Creates a connection.
             </summary>
@@ -7571,7 +7571,7 @@
               and it *may* be the same object as returned on previous invocations, though that is not requried.
             </remarks>
             <returns>
-              An open <see cref="T:System.Data.IDbConnection">database connection</see>.
+              A task that, when `await`ed, resolves to an open <see cref="T:System.Data.Common.DbConnection">database connection</see>.
             </returns>
         </member>
         <member name="T:Kvasir.Transaction.Topology">
@@ -7606,9 +7606,9 @@
               entities and a particular back-end provider/system.
             </summary>
         </member>
-        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},Kvasir.Transaction.IConnectionPool,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Microsoft.Extensions.Logging.ILogger)">
+        <member name="M:Kvasir.Transaction.Transactor.New(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},Kvasir.Transaction.IConnectionPool,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Microsoft.Extensions.Logging.ILogger)">
             <summary>
-              Constructs a new <see cref="T:Kvasir.Translation.Translator"/> that uses default <see cref="T:Kvasir.Core.Settings"/>.
+              Creates a new <see cref="T:Kvasir.Translation.Translator"/> that uses default <see cref="T:Kvasir.Core.Settings"/>.
             </summary>
             <param name="entityTranslations">
               The set of <see cref="T:Kvasir.Translation.EntityTranslation">translations</see> for non-Localization types that define the
@@ -7631,8 +7631,12 @@
             <param name="logger">
               The <see cref="T:Microsoft.Extensions.Logging.ILogger">logger</see> with which to issue diagnostics.
             </param>
+            <returns>
+              An <see langword="await"/>able <see cref="T:System.Threading.Tasks.Task"/> that, upon completion, yields a new
+              <see cref="T:Kvasir.Transaction.Transactor"/>.
+            </returns>
         </member>
-        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},Kvasir.Transaction.IConnectionPool,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Kvasir.Core.Settings,Microsoft.Extensions.Logging.ILogger)">
+        <member name="M:Kvasir.Transaction.Transactor.New(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},Kvasir.Transaction.IConnectionPool,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Kvasir.Core.Settings,Microsoft.Extensions.Logging.ILogger)">
             <summary>
               Constructs a new <see cref="T:Kvasir.Translation.Translator"/> that uses custom <see cref="T:Kvasir.Core.Settings"/>.
             </summary>
@@ -7660,6 +7664,10 @@
             <param name="logger">
               The <see cref="T:Microsoft.Extensions.Logging.ILogger">logger</see> with which to issue diagnostics.
             </param>
+            <returns>
+              An <see langword="await"/>able <see cref="T:System.Threading.Tasks.Task"/> that, upon completion, yields a new
+              <see cref="T:Kvasir.Transaction.Transactor"/>.
+            </returns>
             <remarks>
               Note that the settings are not currently used for anything; in fact, there are no traits available in the
               <see cref="T:Kvasir.Core.Settings"/> class. Instead, the settings serve as a forward compatibility mechanism that allows
@@ -7732,6 +7740,40 @@
               fails.
             </exception>
         </member>
+        <member name="M:Kvasir.Transaction.Transactor.#ctor(System.Collections.Generic.IEnumerable{Kvasir.Translation.EntityTranslation},System.Collections.Generic.IEnumerable{Kvasir.Translation.LocalizationTranslation},Kvasir.Transaction.IConnectionPool,Kvasir.Transaction.ICommandsFactory,System.Action{System.Object},Kvasir.Core.Settings,Microsoft.Extensions.Logging.ILogger)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.Translator"/> that uses specific <see cref="T:Kvasir.Core.Settings"/>.
+            </summary>
+            <param name="entityTranslations">
+              The set of <see cref="T:Kvasir.Translation.EntityTranslation">translations</see> for non-Localization types that define the
+              schema of the back-end database on which the new <see cref="T:Kvasir.Transaction.Transactor"/> will operate.
+            </param>
+            <param name="localizationTranslations">
+              The set of <see cref="T:Kvasir.Translation.LocalizationTranslation">translations</see> for Localization types that define the
+              schema of the back-end database on which the new <see cref="T:Kvasir.Transaction.Transactor"/> will operate.
+            </param>
+            <param name="connectionPool">
+              The <see cref="T:Kvasir.Transaction.IConnectionPool">connection pool</see> with which to create database connections as needed.
+            </param>
+            <param name="commandsFactory">
+              The <see cref="T:Kvasir.Transaction.ICommandsFactory"/> with which to create the necessary commands and queries to interact
+              with the tables for <paramref name="entityTranslations"/> and <paramref name="localizationTranslations"/>.
+            </param>
+            <param name="entityStorage">
+              The functor through which reconstituted Entities will be stored for later look-up.
+            </param>
+            <param name="settings">
+              The <see cref="T:Kvasir.Core.Settings"/> according to which to perform the transaction activity.
+            </param>
+            <param name="logger">
+              The <see cref="T:Microsoft.Extensions.Logging.ILogger">logger</see> with which to issue diagnostics.
+            </param>
+            <remarks>
+              Note that the settings are not currently used for anything; in fact, there are no traits available in the
+              <see cref="T:Kvasir.Core.Settings"/> class. Instead, the settings serve as a forward compatibility mechanism that allows
+              us to provide customization of behaviors in the future without necessitating a significant redesign.
+            </remarks>
+        </member>
         <member name="M:Kvasir.Transaction.Transactor.ManageAdministration">
             <summary>
               Executes all of the administrative business logic.
@@ -7746,7 +7788,7 @@
               The <see cref="T:Kvasir.Translation.Translator"/> with which to translate any administrative Entity types.
             </param>
         </member>
-        <member name="M:Kvasir.Transaction.Transactor.TryCommitTransaction(System.Data.IDbTransaction)">
+        <member name="M:Kvasir.Transaction.Transactor.TryCommitTransaction(System.Data.Common.DbTransaction)">
             <summary>
               Attempts to commit a <see cref="T:System.Data.IDbTransaction">database transaction</see>. If the commit operation fails,
               an attempt to roll the transaction back is made.

--- a/src/Kvasir/Providers/MySQL/Commands.cs
+++ b/src/Kvasir/Providers/MySQL/Commands.cs
@@ -1,7 +1,7 @@
 ﻿using Kvasir.Schema;
 using Kvasir.Transaction;
 using MySql.Data.MySqlClient;
-using System.Data;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,14 +12,14 @@ namespace Kvasir.Providers.MySQL {
     /// </summary>
     internal sealed class Commands : ICommands {
         /// <inheritdoc/>
-        public IDbCommand CreateTableCommand {
+        public DbCommand CreateTableCommand {
             get {
                 return new MySqlCommand(createCmdText_);
             }
         }
 
         /// <inheritdoc/>
-        public IDbCommand SelectAllQuery {
+        public DbCommand SelectAllQuery {
             get {
                 return new MySqlCommand(selectAllQueryText_);
             }
@@ -104,7 +104,7 @@ namespace Kvasir.Providers.MySQL {
         }
 
         /// <inheritdoc/>
-        public IDbCommand InsertCommand(IEnumerable<IReadOnlyList<DBValue>> rows) {
+        public DbCommand InsertCommand(IEnumerable<IReadOnlyList<DBValue>> rows) {
             var command = new MySqlCommand();
             string paramName() => $"@v{command.Parameters.Count}";
 
@@ -130,7 +130,7 @@ namespace Kvasir.Providers.MySQL {
         }
 
         /// <inheritdoc/>
-        public IDbCommand UpdateCommand(IEnumerable<IReadOnlyList<DBValue>> rows) {
+        public DbCommand UpdateCommand(IEnumerable<IReadOnlyList<DBValue>> rows) {
             var command = new MySqlCommand();
             string paramName() => $"@v{command.Parameters.Count}";
 
@@ -162,7 +162,7 @@ namespace Kvasir.Providers.MySQL {
         }
 
         /// <inheritdoc/>
-        public IDbCommand DeleteCommand(IEnumerable<IReadOnlyList<DBValue>> keys) {
+        public DbCommand DeleteCommand(IEnumerable<IReadOnlyList<DBValue>> keys) {
             int longMatchCount = table_.PrimaryKey.Fields.Count;
 
             var command = new MySqlCommand();

--- a/src/Kvasir/Providers/MySQL/Connection.cs
+++ b/src/Kvasir/Providers/MySQL/Connection.cs
@@ -1,7 +1,8 @@
 ﻿using Kvasir.Transaction;
 using MySql.Data.MySqlClient;
-using System.Data;
+using System.Data.Common;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Kvasir.Providers.MySQL {
     /// <summary>
@@ -37,10 +38,10 @@ namespace Kvasir.Providers.MySQL {
             }.ConnectionString;
         }
 
-        /// <see cref="IConnectionPool.MakeConnection"/>
-        public IDbConnection MakeConnection() {
+        /// <see cref="IConnectionPool.MakeConnectionAsync"/>
+        public async Task<DbConnection> MakeConnectionAsync() {
             var connection = new MySqlConnection(connectionString_);
-            connection.Open();
+            await connection.OpenAsync();
             return connection;
         }
 

--- a/src/Kvasir/Transaction/ICommands.cs
+++ b/src/Kvasir/Transaction/ICommands.cs
@@ -1,6 +1,6 @@
 ﻿using Kvasir.Schema;
 using System.Collections.Generic;
-using System.Data;
+using System.Data.Common;
 
 namespace Kvasir.Transaction {
     /// <summary>
@@ -10,13 +10,13 @@ namespace Kvasir.Transaction {
         /// <summary>
         ///   The command that creates the target <see cref="Table"/> in the back-end database.
         /// </summary>
-        IDbCommand CreateTableCommand { get; }
+        DbCommand CreateTableCommand { get; }
 
         /// <summary>
         ///   The command that selects all data from the target <see cref="Table"/>. The rows should be returned in
         ///   key-sorted order, which for Relation Tables guarantees that the rows are grouped by "owning Entity."
         /// </summary>
-        IDbCommand SelectAllQuery { get; }
+        DbCommand SelectAllQuery { get; }
 
         /// <summary>
         ///   Produce a command that, when executed against a back-end database and committed, inserts one or more rows
@@ -25,7 +25,7 @@ namespace Kvasir.Transaction {
         /// <param name="rows">
         ///   The rows of data to be inserted.
         /// </param>
-        IDbCommand InsertCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
+        DbCommand InsertCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
 
         /// <summary>
         ///   Produce a command that, when executed against a back-end database and committed, updates the values of one
@@ -41,7 +41,7 @@ namespace Kvasir.Transaction {
         /// <param name="rows">
         ///   The full rows of data that should exist in the back-end database after the update.
         /// </param>
-        IDbCommand UpdateCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
+        DbCommand UpdateCommand(IEnumerable<IReadOnlyList<DBValue>> rows);
 
         /// <summary>
         ///   Produce a command that, when executed against a back-end database and committed, deleted one or more rows
@@ -72,6 +72,6 @@ namespace Kvasir.Transaction {
         ///   Fields are of the same type). If the Primary Key is, in fact, the full row, then obviously the full row
         ///   can be provided, though the Fields must be present in the order matching that of the Primary Key.
         /// </note>
-        IDbCommand DeleteCommand(IEnumerable<IReadOnlyList<DBValue>> keys);
+        DbCommand DeleteCommand(IEnumerable<IReadOnlyList<DBValue>> keys);
     }
 }

--- a/src/Kvasir/Transaction/IConnectionPool.cs
+++ b/src/Kvasir/Transaction/IConnectionPool.cs
@@ -1,8 +1,9 @@
-﻿using System.Data;
+﻿using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace Kvasir.Transaction {
     /// <summary>
-    ///   The interface that abstracts the creation of <see cref="IDbConnection">database connections</see> without
+    ///   The interface that abstracts the creation of <see cref="DbConnection">database connections</see> without
     ///   exposing details about the connection or the back-end provider.
     /// </summary>
     internal interface IConnectionPool {
@@ -15,8 +16,8 @@ namespace Kvasir.Transaction {
         ///   and it *may* be the same object as returned on previous invocations, though that is not requried.
         /// </remarks>
         /// <returns>
-        ///   An open <see cref="IDbConnection">database connection</see>.
+        ///   A task that, when `await`ed, resolves to an open <see cref="DbConnection">database connection</see>.
         /// </returns>
-        IDbConnection MakeConnection();
+        Task<DbConnection> MakeConnectionAsync();
     }
 }

--- a/src/Kvasir/Transaction/Transactor.cs
+++ b/src/Kvasir/Transaction/Transactor.cs
@@ -8,8 +8,10 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Kvasir.Transaction {
     /// <summary>
@@ -18,7 +20,7 @@ namespace Kvasir.Transaction {
     /// </summary>
     internal sealed class Transactor {
         /// <summary>
-        ///   Constructs a new <see cref="Translator"/> that uses default <see cref="Settings"/>.
+        ///   Creates a new <see cref="Translator"/> that uses default <see cref="Settings"/>.
         /// </summary>
         /// <param name="entityTranslations">
         ///   The set of <see cref="EntityTranslation">translations</see> for non-Localization types that define the
@@ -41,15 +43,20 @@ namespace Kvasir.Transaction {
         /// <param name="logger">
         ///   The <see cref="ILogger">logger</see> with which to issue diagnostics.
         /// </param>
-        public Transactor(
+        /// <returns>
+        ///   An <see langword="await"/>able <see cref="Task"/> that, upon completion, yields a new
+        ///   <see cref="Transactor"/>.
+        /// </returns>
+        public static async Task<Transactor> New(
             IEnumerable<EntityTranslation> entityTranslations,
             IEnumerable<LocalizationTranslation> localizationTranslations,
             IConnectionPool connectionPool,
             ICommandsFactory commandsFactory,
             Action<object> entityStorage,
             ILogger logger
-        )
-            : this(entityTranslations, localizationTranslations, connectionPool, commandsFactory, entityStorage, Settings.Default, logger) {}
+        ) {
+            return await New(entityTranslations, localizationTranslations, connectionPool, commandsFactory, entityStorage, Settings.Default, logger);
+        }
 
         /// <summary>
         ///   Constructs a new <see cref="Translator"/> that uses custom <see cref="Settings"/>.
@@ -78,12 +85,16 @@ namespace Kvasir.Transaction {
         /// <param name="logger">
         ///   The <see cref="ILogger">logger</see> with which to issue diagnostics.
         /// </param>
+        /// <returns>
+        ///   An <see langword="await"/>able <see cref="Task"/> that, upon completion, yields a new
+        ///   <see cref="Transactor"/>.
+        /// </returns>
         /// <remarks>
         ///   Note that the settings are not currently used for anything; in fact, there are no traits available in the
         ///   <see cref="Settings"/> class. Instead, the settings serve as a forward compatibility mechanism that allows
         ///   us to provide customization of behaviors in the future without necessitating a significant redesign.
         /// </remarks>
-        public Transactor(
+        public static async Task<Transactor> New(
             IEnumerable<EntityTranslation> entityTranslations,
             IEnumerable<LocalizationTranslation> localizationTranslations,
             IConnectionPool connectionPool,
@@ -92,68 +103,17 @@ namespace Kvasir.Transaction {
             Settings settings,
             ILogger logger
         ) {
-            Debug.Assert(entityTranslations is not null);
-            Debug.Assert(localizationTranslations is not null);
-            Debug.Assert(!entityTranslations.IsEmpty() || !localizationTranslations.IsEmpty());
-            Debug.Assert(connectionPool is not null);
-            Debug.Assert(commandsFactory is not null);
-            Debug.Assert(entityStorage is not null);
-            Debug.Assert(settings is not null);
-            Debug.Assert(logger is not null);
-
-            settings_ = settings;
-            entityTranslations_ = entityTranslations.ToDictionary(t => t.CLRSource, t => t);
-            localizationTranslations_ = localizationTranslations.ToDictionary(t => t.CLRSource, t => t);
-            connectionPool_ = connectionPool;
-            commandsFactory_ = commandsFactory;
-            entityStorage_ = entityStorage;
-            logger_ = logger;
-
-            logger_.LogDebug("Transactor created for {} regular Entities and {} Localizations", entityTranslations_.Count, localizationTranslations_.Count);
-
-            var principalCommands = new List<ICommands>();
-            var relationCommands = new List<ICommands>();
-            var localizationCommands = new List<ICommands>();
-            var tables = new Dictionary<ITable, int>();
-            var sourceTypes = new Dictionary<ITable, Type>();
-            foreach (var principal in Topology.OrderEntities([..entityTranslations])) {
-                tables[principal.Table] = principalCommands.Count;
-                sourceTypes[principal.Table] = principal.Extractor.SourceType;
-                principalCommands.Add(commandsFactory_.CreateCommands(principal.Table, isPrincipalTable: true));
-                logger_.LogDebug("Entity #{} is `{}`", principalCommands.Count, principal.Extractor.SourceType.Name);
-
-                // using `Extractor.SourceType` is a little awkward here, but it's the best we have
-                foreach (var relation in entityTranslations_[principal.Extractor.SourceType].Relations) {
-                    tables[relation.Table] = entityTranslations_.Count + relationCommands.Count;
-                    sourceTypes[relation.Table] = relation.Extractor.SourceType;
-                    relationCommands.Add(commandsFactory_.CreateCommands(relation.Table, isPrincipalTable: false));
-                    logger_.LogDebug("Relation #{} is for table {}", relationCommands.Count, relation.Table.Name);
-                }
-            }
-            foreach (var principal in localizationTranslations.Select(x => x.Principal)) {
-                tables[principal.Table] = principalCommands.Count + relationCommands.Count + localizationCommands.Count;
-                sourceTypes[principal.Table] = principal.Extractor.SourceType;
-                localizationCommands.Add(commandsFactory_.CreateCommands(principal.Table, isPrincipalTable: true));
-                logger_.LogDebug("Entity #{} is `{}`", principalCommands.Count + localizationCommands.Count, principal.Extractor.SourceType.Name);
-            }
-
-            // The order here is Regular Entities -> Relations -> Localizations, with the former in topological order.
-            // Nothing ever references a Localization Table (we omit foreign keys to support "empty" Localizations), so
-            // they can safely go last. For the same reason, the Localizations can be arbitrarily ordered relative to
-            // one another. The relative order of the Relation Tables is likewise not relevant because they cannot
-            // reference each other, either.
-            localizationStartIdx_ = principalCommands.Count + relationCommands.Count;
-            commands_ = [..principalCommands.Concat(relationCommands).Concat(localizationCommands)];
-            tables_ = tables;
-            sourceTypes_ = sourceTypes;
+            Transactor transactor = new Transactor(entityTranslations, localizationTranslations, connectionPool, commandsFactory, entityStorage, settings, logger);
 
             // There is administrative work that has to be done before any other queries can be executed. This work
             // involves tables reserved by the framework. However, if any of the types being transacted upon is itself
             // an administrative type, then we're already in the process of managing administration and don't want to
             // get ourselves into an infinite loop.
             if (entityTranslations.Select(t => t.Principal.Extractor.SourceType).All(t => !t.TranslationCategory().Equals(TypeCategory.Administrative))) {
-                ManageAdministration();
+                await transactor.ManageAdministration();
             }
+
+            return transactor;
         }
 
         /// <summary>
@@ -167,31 +127,31 @@ namespace Kvasir.Transaction {
         ///   if the transaction creating the necessary tables fails, and the attempt to roll the transaction back also
         ///   fails.
         /// </exception>
-        public void CreateTables() {
-            using var connection = connectionPool_.MakeConnection();
-            using var transaction = connection.BeginTransaction();
+        public async Task CreateTables() {
+            await using var connection = await connectionPool_.MakeConnectionAsync();
+            await using var transaction = await connection.BeginTransactionAsync();
             foreach (var command in commands_.Select(c => c.CreateTableCommand)) {
                 command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
-                command.ExecuteNonQuery();
+                await command.ExecuteNonQueryAsync();
             }
-            TryCommitTransaction(transaction);
+            await TryCommitTransaction(transaction);
 
             // Rather than do the ordering ourselves here, just let the insertion function handle it. This will also
             // make everything one transaction, though that's not really super important.
             var preDefineds = entityTranslations_.Values.SelectMany(translation => translation.Principal.PreDefinedInstances);
             preDefineds = preDefineds.Concat(localizationTranslations_.Values.SelectMany(translation => translation.Principal.PreDefinedInstances));
             if (!preDefineds.IsEmpty()) {
-                Insert([..preDefineds]);
+                await Insert([..preDefineds]);
             }
         }
 
         /// <summary>
         ///   Selects all of the data out of the back-end database and creates corresponding CLR objects.
         /// </summary>
-        public void SelectAll() {
-            using var connection = connectionPool_.MakeConnection();
+        public async Task SelectAll() {
+            await using var connection = await connectionPool_.MakeConnectionAsync();
 
             var entityTranslations = entityTranslations_.Values.OrderBy(t => tables_[t.Principal.Table]).ToList();
             var localizationTranslations = localizationTranslations_.Values.ToList();
@@ -206,7 +166,7 @@ namespace Kvasir.Transaction {
                 var query = commands_[idx + localizationStartIdx_].SelectAllQuery;
                 logger_.LogDebug("Executing SQL: {}", query.CommandText);
                 query.Connection = connection;
-                var reader = query.ExecuteReader();
+                var reader = await query.ExecuteReaderAsync();
 
                 var rows = new Dictionary<DBValue, List<List<DBValue>>>();
                 var instances = new Dictionary<DBValue, object>();
@@ -237,7 +197,7 @@ namespace Kvasir.Transaction {
                 var query = commands_[idx].SelectAllQuery;
                 logger_.LogDebug("Executing SQL: {}", query.CommandText);
                 query.Connection = connection;
-                var reader = query.ExecuteReader();
+                var reader = await query.ExecuteReaderAsync();
 
                 var creations = new List<object>();
                 while (reader.Read()) {
@@ -261,7 +221,7 @@ namespace Kvasir.Transaction {
                     var query = commands_[tables_[relation.Table]].SelectAllQuery;
                     logger_.LogDebug("Executing SQL: {}", query.CommandText);
                     query.Connection = connection;
-                    var reader = query.ExecuteReader();
+                    var reader = await query.ExecuteReaderAsync();
 
                     var rows = options.ToDictionary(e => e, _ => new List<IReadOnlyList<DBValue>>());
                     while (reader.Read()) {
@@ -300,7 +260,7 @@ namespace Kvasir.Transaction {
         ///   if the transaction creating the necessary tables fails, and the attempt to roll the transaction back also
         ///   fails.
         /// </exception>
-        public void Insert(IEnumerable<object> entities) {
+        public async Task Insert(IEnumerable<object> entities) {
             Debug.Assert(entities is not null);
             Debug.Assert(!entities.IsEmpty());
 
@@ -308,8 +268,8 @@ namespace Kvasir.Transaction {
             var entityTranslations = mapping.Keys.Where(t => !Translator.IsLocalizationType(t)).Select(k => entityTranslations_[k]).OrderBy(t => tables_[t.Principal.Table]).ToList();
             var localizationTranslations = mapping.Keys.Where(t => Translator.IsLocalizationType(t)).Select(k => localizationTranslations_[k]).ToList();
 
-            using var connection = connectionPool_.MakeConnection();
-            using var transaction = connection.BeginTransaction();
+            await using var connection = await connectionPool_.MakeConnectionAsync();
+            await using var transaction = await connection.BeginTransactionAsync();
 
             // Insert all the data into Principal Tables first
             foreach (var translation in entityTranslations) {
@@ -322,7 +282,7 @@ namespace Kvasir.Transaction {
                 command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
-                command.ExecuteNonQuery();
+                await command.ExecuteNonQueryAsync();
             }
 
             // Insert all the data into Relation Tables second
@@ -346,7 +306,7 @@ namespace Kvasir.Transaction {
                     command.Connection = connection;
                     command.Transaction = transaction;
                     logger_.LogDebug("Executing SQL: {}", command.CommandText);
-                    command.ExecuteNonQuery();
+                    await command.ExecuteNonQueryAsync();
                 }
             }
 
@@ -368,12 +328,12 @@ namespace Kvasir.Transaction {
                 command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
-                command.ExecuteNonQuery();
+                await command.ExecuteNonQueryAsync();
             }
 
             // Commit the transaction; if it succeeds (failure is indicated by a `throw`), then we run all of the
             // canonicalization functions
-            TryCommitTransaction(transaction);
+            await TryCommitTransaction(transaction);
             foreach (var canonicalize in canonicalizations) {
                 canonicalize();
             }
@@ -393,7 +353,7 @@ namespace Kvasir.Transaction {
         ///   if the transaction updating the necessary data fails, and the attempt to roll the transaction back also
         ///   fails.
         /// </exception>
-        public void Update(IEnumerable<object> entities) {
+        public async Task Update(IEnumerable<object> entities) {
             Debug.Assert(entities is not null);
             Debug.Assert(!entities.IsEmpty());
 
@@ -401,8 +361,8 @@ namespace Kvasir.Transaction {
             var entityTranslations = mapping.Keys.Where(t => !Translator.IsLocalizationType(t)).Select(k => entityTranslations_[k]).OrderBy(t => tables_[t.Principal.Table]).ToList();
             var localizationTranslations = mapping.Keys.Where(t => Translator.IsLocalizationType(t)).Select(k => localizationTranslations_[k]).ToList();
 
-            using var connection = connectionPool_.MakeConnection();
-            using var transaction = connection.BeginTransaction();
+            await using var connection = await connectionPool_.MakeConnectionAsync();
+            await using var transaction = await connection.BeginTransactionAsync();
 
             // Update all the data in Principal Tables first
             foreach (var translation in entityTranslations) {
@@ -415,7 +375,7 @@ namespace Kvasir.Transaction {
                 command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
-                command.ExecuteNonQuery();
+                await command.ExecuteNonQueryAsync();
             }
 
             // Update all the data in Relation Tables second: deletes, then updates, then inserts
@@ -445,7 +405,7 @@ namespace Kvasir.Transaction {
                             command.Connection = connection;
                             command.Transaction = transaction;
                             logger_.LogDebug("Executing SQL: {}", command.CommandText);
-                            command.ExecuteNonQuery();
+                            await command.ExecuteNonQueryAsync();
                         }
                     }
                 }
@@ -476,14 +436,14 @@ namespace Kvasir.Transaction {
                         command.Connection = connection;
                         command.Transaction = transaction;
                         logger_.LogDebug("Executing SQL: {}", command.CommandText);
-                        command.ExecuteNonQuery();
+                        await command.ExecuteNonQueryAsync();
                     }
                 }
             }
 
             // Commit the transaction; if it succeeds (failure is indicated by a `throw`), then we run all of the
             // canonicalization functions
-            TryCommitTransaction(transaction);
+            await TryCommitTransaction(transaction);
             foreach (var canonicalize in canonicalizations) {
                 canonicalize();
             }
@@ -503,7 +463,7 @@ namespace Kvasir.Transaction {
         ///   if the transaction deleting the necessary data fails, and the attempt to roll the transaction back also
         ///   fails.
         /// </exception>
-        public void Delete(IEnumerable<object> entities) {
+        public async Task Delete(IEnumerable<object> entities) {
             Debug.Assert(entities is not null);
             Debug.Assert(!entities.IsEmpty());
 
@@ -511,8 +471,8 @@ namespace Kvasir.Transaction {
             var entityTranslations = mapping.Keys.Where(t => !Translator.IsLocalizationType(t)).Select(k => entityTranslations_[k]).OrderBy(t => tables_[t.Principal.Table]).ToList();
             var localizationTranslations = mapping.Keys.Where(t => Translator.IsLocalizationType(t)).Select(k => localizationTranslations_[k]).ToList();
 
-            using var connection = connectionPool_.MakeConnection();
-            using var transaction = connection.BeginTransaction();
+            await using var connection = await connectionPool_.MakeConnectionAsync();
+            await using var transaction = await connection.BeginTransactionAsync();
 
             // Delete all the data from Localization Tables first
             foreach (var translation in localizationTranslations) {
@@ -529,7 +489,7 @@ namespace Kvasir.Transaction {
                 command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
-                command.ExecuteNonQuery();
+                await command.ExecuteNonQueryAsync();
             }
 
             // Delete all the data from Relation Tables second
@@ -550,7 +510,7 @@ namespace Kvasir.Transaction {
                     command.Connection = connection;
                     command.Transaction = transaction;
                     logger_.LogDebug("Executing SQL: {}", command.CommandText);
-                    command.ExecuteNonQuery();
+                    await command.ExecuteNonQueryAsync();
                 }
             }
 
@@ -565,25 +525,122 @@ namespace Kvasir.Transaction {
                 command.Connection = connection;
                 command.Transaction = transaction;
                 logger_.LogDebug("Executing SQL: {}", command.CommandText);
-                command.ExecuteNonQuery();
+                await command.ExecuteNonQueryAsync();
             }
 
             // Commit the transaction; since we're doing deletes, we don't need to canonicalize anything - it's on the
             // caller to throw away their objects and create new ones
-            TryCommitTransaction(transaction);
+            await TryCommitTransaction(transaction);
+        }
+
+        /// <summary>
+        ///   Constructs a new <see cref="Translator"/> that uses specific <see cref="Settings"/>.
+        /// </summary>
+        /// <param name="entityTranslations">
+        ///   The set of <see cref="EntityTranslation">translations</see> for non-Localization types that define the
+        ///   schema of the back-end database on which the new <see cref="Transactor"/> will operate.
+        /// </param>
+        /// <param name="localizationTranslations">
+        ///   The set of <see cref="LocalizationTranslation">translations</see> for Localization types that define the
+        ///   schema of the back-end database on which the new <see cref="Transactor"/> will operate.
+        /// </param>
+        /// <param name="connectionPool">
+        ///   The <see cref="IConnectionPool">connection pool</see> with which to create database connections as needed.
+        /// </param>
+        /// <param name="commandsFactory">
+        ///   The <see cref="ICommandsFactory"/> with which to create the necessary commands and queries to interact
+        ///   with the tables for <paramref name="entityTranslations"/> and <paramref name="localizationTranslations"/>.
+        /// </param>
+        /// <param name="entityStorage">
+        ///   The functor through which reconstituted Entities will be stored for later look-up.
+        /// </param>
+        /// <param name="settings">
+        ///   The <see cref="Settings"/> according to which to perform the transaction activity.
+        /// </param>
+        /// <param name="logger">
+        ///   The <see cref="ILogger">logger</see> with which to issue diagnostics.
+        /// </param>
+        /// <remarks>
+        ///   Note that the settings are not currently used for anything; in fact, there are no traits available in the
+        ///   <see cref="Settings"/> class. Instead, the settings serve as a forward compatibility mechanism that allows
+        ///   us to provide customization of behaviors in the future without necessitating a significant redesign.
+        /// </remarks>
+        private Transactor(
+            IEnumerable<EntityTranslation> entityTranslations,
+            IEnumerable<LocalizationTranslation> localizationTranslations,
+            IConnectionPool connectionPool,
+            ICommandsFactory commandsFactory,
+            Action<object> entityStorage,
+            Settings settings,
+            ILogger logger
+        ) {
+            Debug.Assert(entityTranslations is not null);
+            Debug.Assert(localizationTranslations is not null);
+            Debug.Assert(!entityTranslations.IsEmpty() || !localizationTranslations.IsEmpty());
+            Debug.Assert(connectionPool is not null);
+            Debug.Assert(commandsFactory is not null);
+            Debug.Assert(entityStorage is not null);
+            Debug.Assert(settings is not null);
+            Debug.Assert(logger is not null);
+
+            settings_ = settings;
+            entityTranslations_ = entityTranslations.ToDictionary(t => t.CLRSource, t => t);
+            localizationTranslations_ = localizationTranslations.ToDictionary(t => t.CLRSource, t => t);
+            connectionPool_ = connectionPool;
+            commandsFactory_ = commandsFactory;
+            entityStorage_ = entityStorage;
+            logger_ = logger;
+
+            logger_.LogDebug("Transactor created for {} regular Entities and {} Localizations", entityTranslations_.Count, localizationTranslations_.Count);
+
+            var principalCommands = new List<ICommands>();
+            var relationCommands = new List<ICommands>();
+            var localizationCommands = new List<ICommands>();
+            var tables = new Dictionary<ITable, int>();
+            var sourceTypes = new Dictionary<ITable, Type>();
+            foreach (var principal in Topology.OrderEntities([.. entityTranslations])) {
+                tables[principal.Table] = principalCommands.Count;
+                sourceTypes[principal.Table] = principal.Extractor.SourceType;
+                principalCommands.Add(commandsFactory_.CreateCommands(principal.Table, isPrincipalTable: true));
+                logger_.LogDebug("Entity #{} is `{}`", principalCommands.Count, principal.Extractor.SourceType.Name);
+
+                // using `Extractor.SourceType` is a little awkward here, but it's the best we have
+                foreach (var relation in entityTranslations_[principal.Extractor.SourceType].Relations) {
+                    tables[relation.Table] = entityTranslations_.Count + relationCommands.Count;
+                    sourceTypes[relation.Table] = relation.Extractor.SourceType;
+                    relationCommands.Add(commandsFactory_.CreateCommands(relation.Table, isPrincipalTable: false));
+                    logger_.LogDebug("Relation #{} is for table {}", relationCommands.Count, relation.Table.Name);
+                }
+            }
+            foreach (var principal in localizationTranslations.Select(x => x.Principal)) {
+                tables[principal.Table] = principalCommands.Count + relationCommands.Count + localizationCommands.Count;
+                sourceTypes[principal.Table] = principal.Extractor.SourceType;
+                localizationCommands.Add(commandsFactory_.CreateCommands(principal.Table, isPrincipalTable: true));
+                logger_.LogDebug("Entity #{} is `{}`", principalCommands.Count + localizationCommands.Count, principal.Extractor.SourceType.Name);
+            }
+
+            // The order here is Regular Entities -> Relations -> Localizations, with the former in topological order.
+            // Nothing ever references a Localization Table (we omit foreign keys to support "empty" Localizations), so
+            // they can safely go last. For the same reason, the Localizations can be arbitrarily ordered relative to
+            // one another. The relative order of the Relation Tables is likewise not relevant because they cannot
+            // reference each other, either.
+            localizationStartIdx_ = principalCommands.Count + relationCommands.Count;
+            commands_ = [.. principalCommands.Concat(relationCommands).Concat(localizationCommands)];
+            tables_ = tables;
+            sourceTypes_ = sourceTypes;
         }
 
         /// <summary>
         ///   Executes all of the administrative business logic.
         /// </summary>
-        private void ManageAdministration() {
+        private async Task ManageAdministration() {
             // I don't love that we have to create our own Translator here, but the administrative CLR types are not
             // provided on construction and we need to translate them. We'll use default settings since we're only
             // dealing with framework-controlled Tables anyway, and we know that the table names are reserved. There
             // also won't be any referential fields, so we don't have to worry about the Entity lookup.
             var translator = new Translator(t => [], logger_);
 
-            ManageSchemaMigration(translator);
+            await ManageSchemaMigration(translator);
         }
 
         /// <summary>
@@ -593,7 +650,7 @@ namespace Kvasir.Transaction {
         /// <param name="translator">
         ///   The <see cref="Translator"/> with which to translate any administrative Entity types.
         /// </param>
-        private void ManageSchemaMigration(Translator translator) {
+        private async Task ManageSchemaMigration(Translator translator) {
             // We are going to need direct access to the reconstituted `TableHash` instances to perform the migration
             // check. The `entityStorage_` functor that *this* Transactor is using is opaque to us, so we'll use an
             // entirely different one.
@@ -602,12 +659,12 @@ namespace Kvasir.Transaction {
 
             // We need a translation of the `TableHash` administrative type in order to create a Transactor.
             var translation = translator[typeof(TableHash)];
-            var transactor = new Transactor([translation], [], connectionPool_, commandsFactory_, hashStorage, logger_);
+            var transactor = await New([translation], [], connectionPool_, commandsFactory_, hashStorage, logger_);
 
             // First, create the tables; this will create the administrative table if it does not yet exist. Then,
             // select all the data; this will load all existing administrative hashes into the `hashes` dictionary.
-            transactor.CreateTables();
-            transactor.SelectAll();
+            await transactor.CreateTables();
+            await transactor.SelectAll();
 
             // For each table that *this* Transactor is responsible for, we have to look up its expected hash in the
             // existing data. It's okay for a table to not exist in the administrative data yet: that just means it is
@@ -633,7 +690,7 @@ namespace Kvasir.Transaction {
                 throw new SchemaMigrationException(hashes.Keys.First());
             }
             if (!tablesToRecord.IsEmpty()) {
-                transactor.Insert(tablesToRecord);
+                await transactor.Insert(tablesToRecord);
             }
         }
 
@@ -650,15 +707,15 @@ namespace Kvasir.Transaction {
         /// <exception cref="AggregateException">
         ///   if the attempt to commit <paramref name="transaction"/> fails, and the attempt to roll it back also fails.
         /// </exception>
-        private void TryCommitTransaction(IDbTransaction transaction) {
+        private async Task TryCommitTransaction(DbTransaction transaction) {
             try {
                 logger_.LogDebug("Committing Transaction");
-                transaction.Commit();
+                await transaction.CommitAsync();
             }
             catch (InvalidOperationException commitEx) {
                 try {
                     logger_.LogError("Rolling Back Transaction (cause: {})", commitEx.Message);
-                    transaction.Rollback();
+                    await transaction.RollbackAsync();
                 }
                 catch (InvalidOperationException rollbackEx) {
                     logger_.LogError("Roll Back Failed (cause: {})", rollbackEx.Message);

--- a/test/UnitTests/Kvasir/Transaction/Administration.cs
+++ b/test/UnitTests/Kvasir/Transaction/Administration.cs
@@ -4,16 +4,17 @@ using Kvasir.Schema;
 using Kvasir.Translation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading.Tasks;
 
 using static UT.Kvasir.Transaction.Administration;
 
 namespace UT.Kvasir.Transaction {
     [TestClass, TestCategory("Administration")]
     public class AdministrationTests {
-        [TestMethod] public void SchemaManagement_TableCreatedOnConstruction() {
+        [TestMethod] public async Task SchemaManagement_TableCreatedOnConstruction() {
             // Arrange
             var fixture = new TestFixture(typeof(DogWalker));
+            await fixture.InitializeSchema();
 
             // Act
             var adminCmd = fixture.PrincipalCommands<TableHash>().CreateTableCommand;
@@ -25,9 +26,10 @@ namespace UT.Kvasir.Transaction {
             fixture.AdminCommits.Should().Be(2);
         }
 
-        [TestMethod] public void SchemaManagement_Unpopulated() {
+        [TestMethod] public async Task SchemaManagement_Unpopulated() {
             // Arrange
             var fixture = new TestFixture(typeof(MapProjection), typeof(Hymn));
+            await fixture.InitializeSchema();
 
             // Act
             var creationCmd = fixture.PrincipalCommands<TableHash>().CreateTableCommand;
@@ -50,7 +52,7 @@ namespace UT.Kvasir.Transaction {
             fixture.AdminCommits.Should().Be(2);
         }
 
-        [TestMethod] public void SchemaManagement_FullyPopulated() {
+        [TestMethod] public async Task SchemaManagement_FullyPopulated() {
             // Arrange
             var fixture = new TestFixture(typeof(Amulet), typeof(Outlier), typeof(Shaman));
             var amuletTable = fixture.PrincipalTableOf<Amulet>();
@@ -60,6 +62,7 @@ namespace UT.Kvasir.Transaction {
             var shamanTable = fixture.PrincipalTableOf<Shaman>();
             var shamanMetadata = new object[] {shamanTable.Name.ToString(), shamanTable.GetHashCode() };
             fixture = fixture.WithEntityRow<TableHash>(amuletMetadata).WithEntityRow<TableHash>(outlierMetadata).WithEntityRow<TableHash>(shamanMetadata);
+            await fixture.InitializeSchema();
 
             // Act
             var creationCmd = fixture.PrincipalCommands<TableHash>().CreateTableCommand;
@@ -74,12 +77,13 @@ namespace UT.Kvasir.Transaction {
             fixture.AdminCommits.Should().Be(1);
         }
 
-        [TestMethod] public void SchemaManagement_PrincipalTableUnpopulated() {
+        [TestMethod] public async Task SchemaManagement_PrincipalTableUnpopulated() {
             // Arrange
             var fixture = new TestFixture(typeof(IndenturedServant), typeof(Oatmeal));
             var servantTable = fixture.PrincipalTableOf<IndenturedServant>();
             var servantMetadata = new object[] { servantTable.Name.ToString(), servantTable.GetHashCode() };
             fixture = fixture.WithEntityRow<TableHash>(servantMetadata);
+            await fixture.InitializeSchema();
 
             // Act
             var creationCmd = fixture.PrincipalCommands<TableHash>().CreateTableCommand;
@@ -98,12 +102,13 @@ namespace UT.Kvasir.Transaction {
             fixture.AdminCommits.Should().Be(2);
         }
 
-        [TestMethod] public void SchemaManagement_RelationTableUnpopulated() {
+        [TestMethod] public async Task SchemaManagement_RelationTableUnpopulated() {
             // Arrange
             var fixture = new TestFixture(typeof(LorcanaCharacter));
             var characterTable = fixture.PrincipalTableOf<LorcanaCharacter>();
             var characterMetadata = new object[] { characterTable.Name.ToString(), characterTable.GetHashCode() };
             fixture = fixture.WithEntityRow<TableHash>(characterMetadata);
+            await fixture.InitializeSchema();
 
             // Act
             var creationCmd = fixture.PrincipalCommands<TableHash>().CreateTableCommand;
@@ -122,7 +127,7 @@ namespace UT.Kvasir.Transaction {
             fixture.AdminCommits.Should().Be(2);
         }
 
-        [TestMethod] public void SchemaManagement_PrincipalTableMismatch_IsError() {
+        [TestMethod] public async Task SchemaManagement_PrincipalTableMismatch_IsError() {
             // Arrange
             var fixture = new TestFixture(typeof(GrandRelic));
             var relicTable = fixture.PrincipalTableOf<GrandRelic>();
@@ -130,15 +135,15 @@ namespace UT.Kvasir.Transaction {
             fixture = fixture.WithEntityRow<TableHash>(relicMetadata);
 
             // Act
-            var action = () => fixture.Transactor;
+            var action = async () => await fixture.InitializeSchema();
 
             // Assert
-            action.Should().FailWith<SchemaMigrationException>()
-                .WithLocation("`GrandRelic`")
-                .WithProblem($"the schema of table {relicTable.Name} has migrated since it was created in the database");
+            await action.Should().ThrowExactlyAsync<SchemaMigrationException>()
+                .WithMessage("*\n  • Location: `GrandRelic\n*")
+                .WithMessage($"*\n  • Problem: *the schema of table {relicTable.Name} has migrated since it was created in the database*\n*");
         }
 
-        [TestMethod] public void SchemaManagement_RelationTableMismatch_IsError() {
+        [TestMethod] public async Task SchemaManagement_RelationTableMismatch_IsError() {
             // Arrange
             var fixture = new TestFixture(typeof(Metazooa));
             var scientificTable = fixture.RelationTableOf<Metazooa>(0);
@@ -146,27 +151,27 @@ namespace UT.Kvasir.Transaction {
             fixture = fixture.WithEntityRow<TableHash>(scientificMetadata);
 
             // Act
-            var action = () => fixture.Transactor;
+            var action = async () => await fixture.InitializeSchema();
 
             // Assert
-            action.Should().FailWith<SchemaMigrationException>()
-                .WithLocation("`Metazooa`")
-                .WithProblem($"the schema of table {scientificTable.Name} has migrated since it was created in the database");
+            await action.Should().ThrowExactlyAsync<SchemaMigrationException>()
+                .WithMessage("*\n  • Location: `Metazooa\n*")
+                .WithMessage($"*\n  • Problem: *the schema of table {scientificTable.Name} has migrated since it was created in the database*\n*");
         }
 
-        [TestMethod] public void SchemaManagement_TableHasBeenDeleted() {
+        [TestMethod] public async Task SchemaManagement_TableHasBeenDeleted() {
             // Arrange
             var fixture = new TestFixture(typeof(PillPocket));
             var nonexistentMetadata = new object[] { "NonExistentEntityTable", 871725 };
             fixture = fixture.WithEntityRow<TableHash>(nonexistentMetadata);
 
             // Act
-            var action = () => fixture.Transactor;
+            var action = async () => await fixture.InitializeSchema();
 
             // Assert
-            action.Should().FailWith<SchemaMigrationException>()
-                .WithLocation("<back-end database>")
-                .WithProblem($"the CLR source of table {nonexistentMetadata[0]} no longer exists");
+            await action.Should().ThrowExactlyAsync<SchemaMigrationException>()
+                .WithMessage("*\n  • Location: <back-end database>\n*")
+                .WithMessage($"*\n  • Problem: *the CLR source of table {nonexistentMetadata[0]} no longer exists*\n*");
         }
 
 

--- a/test/UnitTests/Kvasir/Transaction/Deletion.cs
+++ b/test/UnitTests/Kvasir/Transaction/Deletion.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading.Tasks;
 
 using static UT.Kvasir.Transaction.Deletion;
 using static UT.Kvasir.Translation.TestLocalizations;
@@ -14,7 +14,7 @@ using static UT.Kvasir.Translation.TestLocalizations;
 namespace UT.Kvasir.Transaction {
     [TestClass, TestCategory("Deletion")]
     public class DeletionTests {
-        [TestMethod] public void SingleInstanceSingleEntityNoRelationsSingleFieldPrimaryKey() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNoRelationsSingleFieldPrimaryKey() {
             // Arrange
             var pinata = new Pinata() {
                 PinataID = Guid.NewGuid(),
@@ -26,7 +26,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Pinata));
 
             // Act
-            fixture.Transactor.Delete([pinata]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([pinata]);
             var pinataCmd = fixture.PrincipalCommands<Pinata>().DeleteCommand(ANY_ROWS);
             var pinataDeletions = fixture.DeletionsFor(pinataCmd);
 
@@ -36,10 +37,10 @@ namespace UT.Kvasir.Transaction {
             pinataDeletions.Should().HaveCount(1);
             pinataDeletions.Should().ContainRow(pinata.PinataID);
             fixture.ShouldBeOrdered(pinataCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNoRelationsMultiFieldPrimaryKey() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNoRelationsMultiFieldPrimaryKey() {
             // Arrange
             var choir = new Choir() {
                 GroupName = "The LaLaLambourghinis",
@@ -53,7 +54,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Choir));
 
             // Act
-            fixture.Transactor.Delete([choir]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([choir]);
             var choirCmd = fixture.PrincipalCommands<Choir>().DeleteCommand(ANY_ROWS);
             var choirDeletions = fixture.DeletionsFor(choirCmd);
 
@@ -63,10 +65,10 @@ namespace UT.Kvasir.Transaction {
             choirDeletions.Should().HaveCount(1);
             choirDeletions.Should().ContainRow(choir.GroupName, choir.Level, choir.Established);
             fixture.ShouldBeOrdered(choirCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleInstancesSingleEntityNoRelations() {
+        [TestMethod] public async Task MultipleInstancesSingleEntityNoRelations() {
             // Arrange
             var microsoft = new EquityOption() {
                 Underlying = "MSFT",
@@ -98,7 +100,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(EquityOption));
 
             // Act
-            fixture.Transactor.Delete([microsoft, nvidia, disney]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([microsoft, nvidia, disney]);
             var optionCmd = fixture.PrincipalCommands<EquityOption>().DeleteCommand(ANY_ROWS);
             var optionDeletions = fixture.DeletionsFor(optionCmd);
 
@@ -110,10 +113,10 @@ namespace UT.Kvasir.Transaction {
             optionDeletions.Should().ContainRow(nvidia.Underlying, nvidia.Expiration, nvidia.Strike, ConversionOf(nvidia.Side));
             optionDeletions.Should().ContainRow(disney.Underlying, disney.Expiration, disney.Strike, ConversionOf(disney.Side));
             fixture.ShouldBeOrdered(optionCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarRelationsSavedElements() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarRelationsSavedElements() {
             // Arrange
             var k401 = new K401() {
                 AccountID = Guid.NewGuid(),
@@ -134,7 +137,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(K401));
 
             // Act
-            fixture.Transactor.Delete([k401]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([k401]);
             var k401Cmd = fixture.PrincipalCommands<K401>().DeleteCommand(ANY_ROWS);
             var k401Deletions = fixture.DeletionsFor(k401Cmd);
             var depositsCmd = fixture.RelationCommands<K401>(0).DeleteCommand(ANY_ROWS);
@@ -150,10 +154,10 @@ namespace UT.Kvasir.Transaction {
             depositsDeletions.Should().HaveCount(1);
             depositsDeletions.Should().ContainRow(k401.AccountID);
             fixture.ShouldBeOrdered(depositsCmd, k401Cmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarRelationsDeletedElements() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarRelationsDeletedElements() {
             // Arrange
             var jumpBall = new JumpBall() {
                 GameID = Guid.NewGuid(),
@@ -170,7 +174,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(JumpBall));
 
             // Act
-            fixture.Transactor.Delete([jumpBall]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([jumpBall]);
             var jumpBallCmd = fixture.PrincipalCommands<JumpBall>().DeleteCommand(ANY_ROWS);
             var jumpBallDeletions = fixture.DeletionsFor(jumpBallCmd);
             var participantsCmd = fixture.RelationCommands<JumpBall>(0).DeleteCommand(ANY_ROWS);
@@ -186,10 +191,10 @@ namespace UT.Kvasir.Transaction {
             participantsDeletions.Should().HaveCount(1);
             participantsDeletions.Should().ContainRow(jumpBall.GameID, jumpBall.Instance);
             fixture.ShouldBeOrdered(participantsCmd, jumpBallCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarRelationsNewElements() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarRelationsNewElements() {
             // Arrange
             var vault = new BankVault() {
                 BankID = Guid.NewGuid(),
@@ -211,7 +216,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(BankVault));
 
             // Act
-            fixture.Transactor.Delete([vault]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([vault]);
             var vaultCmd = fixture.PrincipalCommands<BankVault>().DeleteCommand(ANY_ROWS);
             var vaultDeletions = fixture.DeletionsFor(vaultCmd);
             var combinationCmd = fixture.RelationCommands<BankVault>(0).DeleteCommand(ANY_ROWS);
@@ -229,10 +235,10 @@ namespace UT.Kvasir.Transaction {
             storageDeletions.Should().HaveCount(1);
             storageDeletions.Should().ContainRow(vault.BankID, vault.Branch, vault.VaultNumber);
             fixture.ShouldBeOrdered(vaultCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarRelationsMixedElements() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarRelationsMixedElements() {
             // Arrange
             var sushi = new SushiRoll() {
                 RollType = "Dragon",
@@ -253,7 +259,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(SushiRoll));
 
             // Act
-            fixture.Transactor.Delete([sushi]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([sushi]);
             var sushiCmd = fixture.PrincipalCommands<SushiRoll>().DeleteCommand(ANY_ROWS);
             var sushiDeletions = fixture.DeletionsFor(sushiCmd);
             var ingredientsCmd = fixture.RelationCommands<SushiRoll>(0).DeleteCommand(ANY_ROWS);
@@ -269,10 +276,10 @@ namespace UT.Kvasir.Transaction {
             ingredientsDeletions.Should().HaveCount(1);
             ingredientsDeletions.Should().ContainRow(sushi.RollType, sushi.Restaurant);
             fixture.ShouldBeOrdered(ingredientsCmd, sushiCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
         
-        [TestMethod] public void SingleInstanceSingleEntityEmptyScalarRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityEmptyScalarRelations() {
             // Arrange
             var woodshop = new Woodshop() {
                 WoodshopID = Guid.NewGuid(),
@@ -285,7 +292,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Woodshop));
 
             // Act
-            fixture.Transactor.Delete([woodshop]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([woodshop]);
             var woodshopCmd = fixture.PrincipalCommands<Woodshop>().DeleteCommand(ANY_ROWS);
             var woodshopDeletions = fixture.DeletionsFor(woodshopCmd);
             var toolsCmd = fixture.RelationCommands<Woodshop>(0).DeleteCommand(ANY_ROWS);
@@ -303,10 +311,10 @@ namespace UT.Kvasir.Transaction {
             woodsDeletions.Should().HaveCount(1);
             woodsDeletions.Should().ContainRow(woodshop.WoodshopID);
             fixture.ShouldBeOrdered(woodshopCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleInstancesSingleEntityScalarRelations() {
+        [TestMethod] public async Task MultipleInstancesSingleEntityScalarRelations() {
             // Arrange
             var store0 = new ConvenienceStore() {
                 StoreBrand = "7-Eleven",
@@ -345,7 +353,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(ConvenienceStore));
 
             // Act
-            fixture.Transactor.Delete([store0, store1]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([store0, store1]);
             var storeCmd = fixture.PrincipalCommands<ConvenienceStore>().DeleteCommand(ANY_ROWS);
             var storeDeletions = fixture.DeletionsFor(storeCmd);
             var employeesCmd = fixture.RelationCommands<ConvenienceStore>(0).DeleteCommand(ANY_ROWS);
@@ -370,10 +379,10 @@ namespace UT.Kvasir.Transaction {
             productsDeletions.Should().ContainRow(store0.StoreBrand, store0.StoreNumber);
             productsDeletions.Should().ContainRow(store1.StoreBrand, store1.StoreNumber);
             fixture.ShouldBeOrdered((employeesCmd, productsCmd), storeCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleLocalizationSavedValues() {
+        [TestMethod] public async Task SingleInstanceSingleLocalizationSavedValues() {
             // Arrange
             var showtime = new Showtime("LOC_SPAMALOT_SHOWTIME");
             showtime["US_CENTRAL"] = 1900;
@@ -383,7 +392,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Showtime));
 
             // Act
-            fixture.Transactor.Delete([showtime]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([showtime]);
             var showtimeCmd = fixture.PrincipalCommands<Showtime>().DeleteCommand(ANY_ROWS);
             var showtimeDeletions = fixture.DeletionsFor(showtimeCmd);
 
@@ -393,10 +403,10 @@ namespace UT.Kvasir.Transaction {
             showtimeDeletions.Should().HaveCount(1);
             showtimeDeletions.Should().ContainRow(showtime.Key);
             fixture.ShouldBeOrdered(showtimeCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleLocalizationDeletedValues() {
+        [TestMethod] public async Task SingleInstanceSingleLocalizationDeletedValues() {
             // Arrange
             var termOfEndearment = new TermOfEndearment("LOC_SWEETHEART");
             termOfEndearment[Language.English] = "Sweetheart";
@@ -405,7 +415,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(TermOfEndearment));
 
             // Act
-            fixture.Transactor.Delete([termOfEndearment]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([termOfEndearment]);
             var termOfEndearmentCmd = fixture.PrincipalCommands<TermOfEndearment>().DeleteCommand(ANY_ROWS);
             var termOfEndearmentDeletions = fixture.DeletionsFor(termOfEndearmentCmd);
 
@@ -415,10 +426,10 @@ namespace UT.Kvasir.Transaction {
             termOfEndearmentDeletions.Should().HaveCount(1);
             termOfEndearmentDeletions.Should().ContainRow(termOfEndearment.Key);
             fixture.ShouldBeOrdered(termOfEndearmentCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleLocalizationNewValues() {
+        [TestMethod] public async Task SingleInstanceSingleLocalizationNewValues() {
             // Arrange
             var label = new Label(81929125024);
             label['E'] = "Fragile but Unimportant Airborne Cargo";
@@ -427,7 +438,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Label));
 
             // Act
-            fixture.Transactor.Delete([label]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([label]);
             var labelCmd = fixture.PrincipalCommands<Label>().DeleteCommand(ANY_ROWS);
             var labelDeletions = fixture.DeletionsFor(labelCmd);
 
@@ -437,10 +449,10 @@ namespace UT.Kvasir.Transaction {
             labelDeletions.Should().HaveCount(1);
             labelDeletions.Should().ContainRow(label.Key);
             fixture.ShouldBeOrdered(labelCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleLocalizationMixedValues() {
+        [TestMethod] public async Task SingleInstanceSingleLocalizationMixedValues() {
             // Arrange
             var verb = new ConjugatedVerb(-19033);
             verb[1.10] = "(yo) tengo";
@@ -454,7 +466,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(ConjugatedVerb));
 
             // Act
-            fixture.Transactor.Delete([verb]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([verb]);
             var conjugationCmd = fixture.PrincipalCommands<ConjugatedVerb>().DeleteCommand(ANY_ROWS);
             var conjugationDeletions = fixture.DeletionsFor(conjugationCmd);
 
@@ -464,10 +477,10 @@ namespace UT.Kvasir.Transaction {
             conjugationDeletions.Should().HaveCount(1);
             conjugationDeletions.Should().ContainRow(verb.Key);
             fixture.ShouldBeOrdered(conjugationCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleInstancesSingleLocalization() {
+        [TestMethod] public async Task MultipleInstancesSingleLocalization() {
             // Arrange
             var coordinate0 = new Coordinate(Guid.NewGuid());
             var coordinate1 = new Coordinate(Guid.NewGuid());
@@ -475,7 +488,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Coordinate));
 
             // Act
-            fixture.Transactor.Delete([coordinate0, coordinate1, coordinate2]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([coordinate0, coordinate1, coordinate2]);
             var coordinateCmd = fixture.PrincipalCommands<Coordinate>().DeleteCommand(ANY_ROWS);
             var coordinateDeletions = fixture.DeletionsFor(coordinateCmd);
 
@@ -487,10 +501,10 @@ namespace UT.Kvasir.Transaction {
             coordinateDeletions.Should().ContainRow(coordinate1.Key);
             coordinateDeletions.Should().ContainRow(coordinate2.Key);
             fixture.ShouldBeOrdered(coordinateCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleUnrelatedEntities() {
+        [TestMethod] public async Task MultipleUnrelatedEntities() {
             // Arrange
             var shanty = new SeaShanty() {
                 Title = "Spanish Ladies",
@@ -514,7 +528,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(SeaShanty), typeof(ElginMarble), typeof(CepheidVariable));
 
             // Act
-            fixture.Transactor.Delete([shanty, marble, cepheid]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([shanty, marble, cepheid]);
             var shantyCmd = fixture.PrincipalCommands<SeaShanty>().DeleteCommand(ANY_ROWS);
             var shantyDeletions = fixture.DeletionsFor(shantyCmd);
             var marbleCmd = fixture.PrincipalCommands<ElginMarble>().DeleteCommand(ANY_ROWS);
@@ -536,10 +551,10 @@ namespace UT.Kvasir.Transaction {
             cepheidDeletions.Should().HaveCount(1);
             cepheidDeletions.Should().ContainRow(cepheid.Name);
             fixture.ShouldBeOrdered((shantyCmd, marbleCmd, cepheidCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleUnrelatedLocalizations() {
+        [TestMethod] public async Task MultipleUnrelatedLocalizations() {
             // Arrange
             var sunset = new Sunset(new DateOnly(1983, 4, 19));
             sunset["CHICAGO"] = 2013;
@@ -558,7 +573,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Sunset), typeof(Wingding), typeof(Sprite));
 
             // Act
-            fixture.Transactor.Delete([sunset, wingding, sprite]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([sunset, wingding, sprite]);
             var sunsetCmd = fixture.PrincipalCommands<Sunset>().DeleteCommand(ANY_ROWS);
             var sunsetDeletions = fixture.DeletionsFor(sunsetCmd);
             var wingdingCmd = fixture.PrincipalCommands<Wingding>().DeleteCommand(ANY_ROWS);
@@ -580,10 +596,10 @@ namespace UT.Kvasir.Transaction {
             spriteDeletions.Should().HaveCount(1);
             spriteDeletions.Should().ContainRow(sprite.Key);
             fixture.ShouldBeOrdered((sunsetCmd, wingdingCmd, spriteCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceChain() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceChain() {
             // Arrange
             var costume = new CostumeParty.Costume() {
                 CostumeID = Guid.NewGuid(),
@@ -606,7 +622,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(CostumeParty), typeof(CostumeParty.Partygoer), typeof(CostumeParty.Costume));
 
             // Act
-            fixture.Transactor.Delete([costume, party, partygoer]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([costume, party, partygoer]);
             var costumeCmd = fixture.PrincipalCommands<CostumeParty.Costume>().DeleteCommand(ANY_ROWS);
             var costumeDeletios = fixture.DeletionsFor(costumeCmd);
             var partygoerCmd = fixture.PrincipalCommands<CostumeParty.Partygoer>().DeleteCommand(ANY_ROWS);
@@ -628,10 +645,10 @@ namespace UT.Kvasir.Transaction {
             partyDeletios.Should().HaveCount(1);
             partyDeletios.Should().ContainRow(party.PartyID);
             fixture.ShouldBeOrdered(costumeCmd, partygoerCmd, partyCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceTree() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceTree() {
             // Arrange
             var album = new WeirdAlParody.Album() {
                 Title = "Straight Outta Lynwood",
@@ -654,7 +671,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(WeirdAlParody), typeof(WeirdAlParody.Song), typeof(WeirdAlParody.Album));
 
             // Act
-            fixture.Transactor.Delete([album, beatIt, eatIt]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([album, beatIt, eatIt]);
             var albumCmd = fixture.PrincipalCommands<WeirdAlParody.Album>().DeleteCommand(ANY_ROWS);
             var albumDeletions = fixture.DeletionsFor(albumCmd);
             var songCmd = fixture.PrincipalCommands<WeirdAlParody.Song>().DeleteCommand(ANY_ROWS);
@@ -676,10 +694,10 @@ namespace UT.Kvasir.Transaction {
             parodyDeletions.Should().HaveCount(1);
             parodyDeletions.Should().ContainRow(eatIt.Title);
             fixture.ShouldBeOrdered((songCmd, albumCmd), parodyCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByRelation() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByRelation() {
             // Arrange
             var lawyer0 = new Affidavit.Lawyer() {
                 BarNumber = Guid.NewGuid(),
@@ -712,7 +730,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Affidavit), typeof(Affidavit.Lawyer));
 
             // Act
-            fixture.Transactor.Delete([affidavit, lawyer0, lawyer1, lawyer2]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([affidavit, lawyer0, lawyer1, lawyer2]);
             var affidavitCmd = fixture.PrincipalCommands<Affidavit>().DeleteCommand(ANY_ROWS);
             var affidavitDeletions = fixture.DeletionsFor(affidavitCmd);
             var lawyerCmd = fixture.PrincipalCommands<Affidavit.Lawyer>().DeleteCommand(ANY_ROWS);
@@ -736,10 +755,10 @@ namespace UT.Kvasir.Transaction {
             involvementDeletions.Should().HaveCount(1);
             involvementDeletions.Should().ContainRow(affidavit.ID);
             fixture.ShouldBeOrdered(involvementCmd, (lawyerCmd, affidavitCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByScalarLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByScalarLocalization() {
             // Arrange
             var bandeirante = new Bandeirante() {
                 ID = Guid.NewGuid(),
@@ -752,7 +771,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Bandeirante), typeof(LocalizedText), typeof(LocalizedCurrency));
 
             // Act
-            fixture.Transactor.Delete([bandeirante, bandeirante.HomeState, bandeirante.TotalLooted]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([bandeirante, bandeirante.HomeState, bandeirante.TotalLooted]);
             var bandeiranteCmd = fixture.PrincipalCommands<Bandeirante>().DeleteCommand(ANY_ROWS);
             var bandeiranteDeletions = fixture.DeletionsFor(bandeiranteCmd);
             var textCmd = fixture.PrincipalCommands<LocalizedText>().DeleteCommand(ANY_ROWS);
@@ -774,10 +794,10 @@ namespace UT.Kvasir.Transaction {
             currencyDeletions.Should().HaveCount(1);
             currencyDeletions.Should().ContainRow(bandeirante.TotalLooted.Key);
             fixture.ShouldBeOrdered((bandeiranteCmd, textCmd, currencyCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceLocalization() {
             // Arrange
             var yyyymmdd = new BirthdayParty.YearMonthDay() {
                 Year = 1873,
@@ -807,7 +827,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(BirthdayParty), typeof(BirthdayParty.YearMonthDay), typeof(BirthdayParty.LocalizedYearMonthDay));
 
             // Act
-            fixture.Transactor.Delete([yyyymmdd, wordyDate, party, party.Date]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([yyyymmdd, wordyDate, party, party.Date]);
             var partyCmd = fixture.PrincipalCommands<BirthdayParty>().DeleteCommand(ANY_ROWS);
             var partyDeletions = fixture.DeletionsFor(partyCmd);
             var dateCmd = fixture.PrincipalCommands<BirthdayParty.YearMonthDay>().DeleteCommand(ANY_ROWS);
@@ -833,7 +854,7 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered(localizationCmd, dateCmd);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByRelationLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByRelationLocalization() {
             // Arrange
             var text0 = new LocalizedNullableText("LOC_SCANDERRA");
             var text1 = new LocalizedNullableText("LOC_TA_FLUMIN");
@@ -854,7 +875,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Lawyer), typeof(LocalizedNullableText));
 
             // Act
-            fixture.Transactor.Delete([text0, text1, lawyer]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([text0, text1, lawyer]);
             var lawyerCmd = fixture.PrincipalCommands<Lawyer>().DeleteCommand(ANY_ROWS);
             var lawyerDeletions = fixture.DeletionsFor(lawyerCmd);
             var textCmd = fixture.PrincipalCommands<LocalizedNullableText>().DeleteCommand(ANY_ROWS);
@@ -880,7 +902,7 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered((employersCmd, textCmd));
         }
 
-        [TestMethod] public void SelfReferentialEntityViaRelation() {
+        [TestMethod] public async Task SelfReferentialEntityViaRelation() {
             // Arrange
             var masseuse0 = new Masseuse() {
                 LicenseNumber = Guid.NewGuid(),
@@ -917,7 +939,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Masseuse));
 
             // Act
-            fixture.Transactor.Delete([masseuse0, masseuse1, masseuse2]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([masseuse0, masseuse1, masseuse2]);
             var masseuseCmd = fixture.PrincipalCommands<Masseuse>().DeleteCommand(ANY_ROWS);
             var masseuseDeletions = fixture.DeletionsFor(masseuseCmd);
             var teachersCmd = fixture.RelationCommands<Masseuse>(0).DeleteCommand(ANY_ROWS);
@@ -935,10 +958,10 @@ namespace UT.Kvasir.Transaction {
             teachersDeletions.Should().ContainRow(masseuse1.LicenseNumber, ConversionOf(masseuse1.Style));
             teachersDeletions.Should().ContainRow(masseuse2.LicenseNumber, ConversionOf(masseuse2.Style));
             fixture.ShouldBeOrdered(teachersCmd, masseuseCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SelfReferentialEntityViaLocalization() {
+        [TestMethod] public async Task SelfReferentialEntityViaLocalization() {
             // Arrange
             var radiologist0 = new Radiologist() {
                 MedicalID = Guid.NewGuid(),
@@ -972,7 +995,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Radiologist), typeof(Radiologist.OnCallEscalation));
 
             // Act
-            fixture.Transactor.Delete([radiologist0, radiologist1, radiologist2, radiologist0.Superior]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Delete([radiologist0, radiologist1, radiologist2, radiologist0.Superior]);
             var radiologistCmd = fixture.PrincipalCommands<Radiologist>().DeleteCommand(ANY_ROWS);
             var radiologistDeletions = fixture.DeletionsFor(radiologistCmd);
             var onCallCmd = fixture.PrincipalCommands<Radiologist.OnCallEscalation>().DeleteCommand(ANY_ROWS);
@@ -989,10 +1013,10 @@ namespace UT.Kvasir.Transaction {
             radiologistDeletions.Should().ContainRow(radiologist2.MedicalID);
             onCallDeletions.Should().ContainRow(radiologist0.Superior.Key);
             fixture.ShouldBeOrdered(onCallCmd, radiologistCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void TransactionRolledBack() {
+        [TestMethod] public async Task TransactionRolledBack() {
             // Arrange
             var gazebo = new Gazebo() {
                 GazeboID = Guid.NewGuid(),
@@ -1003,15 +1027,16 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Gazebo)).WithCommitError();
 
             // Act
-            var action = () => fixture.Transactor.Insert([gazebo]);
+            await fixture.InitializeSchema();
+            var action = async () => await fixture.Transactor.Delete([gazebo]);
 
             // Assert
-            action.Should().ThrowExactly<InvalidOperationException>();
-            fixture.Transaction.Received(1).Commit();
-            fixture.Transaction.Received(1).Rollback();
+            await action.Should().ThrowExactlyAsync<InvalidOperationException>();
+            await fixture.Transaction.Received(1).CommitAsync();
+            await fixture.Transaction.Received(1).RollbackAsync();
         }
 
-        [TestMethod] public void RollbackFails() {
+        [TestMethod] public async Task RollbackFails() {
             // Arrange
             var moai = new Moai() {
                 Site = "Ahu Tongariki",
@@ -1023,12 +1048,13 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Moai)).WithRollbackError();
 
             // Act
-            var action = () => fixture.Transactor.Delete([moai]);
+            await fixture.InitializeSchema();
+            var action = async () => await fixture.Transactor.Delete([moai]);
 
             // Assert
-            action.Should().ThrowExactly<AggregateException>();
-            fixture.Transaction.Received(1).Commit();
-            fixture.Transaction.Received(1).Rollback();
+            await action.Should().ThrowExactlyAsync<AggregateException>();
+            await fixture.Transaction.Received(1).CommitAsync();
+            await fixture.Transaction.Received(1).RollbackAsync();
         }
 
 

--- a/test/UnitTests/Kvasir/Transaction/Insertion.cs
+++ b/test/UnitTests/Kvasir/Transaction/Insertion.cs
@@ -3,11 +3,11 @@ using Kvasir.Core;
 using Kvasir.Relations;
 using Kvasir.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Mysqlx.Crud;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 using static UT.Kvasir.Transaction.Insertion;
 using static UT.Kvasir.Translation.TestLocalizations;
@@ -15,7 +15,7 @@ using static UT.Kvasir.Translation.TestLocalizations;
 namespace UT.Kvasir.Transaction {
     [TestClass, TestCategory("Insertion")]
     public class InsertionTests {
-        [TestMethod] public void SingleInstanceSingleEntityNoNullsNoRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNoNullsNoRelations() {
             // Arrange
             var crossbow = new Crossbow {
                 BowID = Guid.NewGuid(),
@@ -28,7 +28,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Crossbow));
 
             // Act
-            fixture.Transactor.Insert([crossbow]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([crossbow]);
             var crossbowCmd = fixture.PrincipalCommands<Crossbow>().InsertCommand(ANY_ROWS);
             var crossbowInserts = fixture.InsertionsFor(crossbowCmd);
 
@@ -38,10 +39,10 @@ namespace UT.Kvasir.Transaction {
             crossbowInserts.Should().HaveCount(1);
             crossbowInserts.Should().ContainRow(crossbow.BowID, crossbow.Brand, crossbow.Model, crossbow.Weight, crossbow.DrawWeight, crossbow.DrawLength);
             fixture.ShouldBeOrdered(crossbowCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNullsNoRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNullsNoRelations() {
             // Arrange
             var doodle = new GoogleDoodle {
                 Date = new DateTime(2015, 9, 7),
@@ -53,7 +54,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(GoogleDoodle));
 
             // Act
-            fixture.Transactor.Insert([doodle]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([doodle]);
             var doodleCmd = fixture.PrincipalCommands<GoogleDoodle>().InsertCommand(ANY_ROWS);
             var doodleInserts = fixture.InsertionsFor(doodleCmd);
 
@@ -63,10 +65,10 @@ namespace UT.Kvasir.Transaction {
             doodleInserts.Should().HaveCount(1);
             doodleInserts.Should().ContainRow(doodle.Date, doodle.Artist, doodle.IsForHoliday, doodle.IsAnimated, doodle.ArchiveURL);
             fixture.ShouldBeOrdered(doodleCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleInstancesSingleEntityNoRelations() {
+        [TestMethod] public async Task MultipleInstancesSingleEntityNoRelations() {
             // Arrange
             var funcoot = new CountOlafDisguise() {
                 Name = "Al Funcoot",
@@ -86,7 +88,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(CountOlafDisguise));
 
             // Act
-            fixture.Transactor.Insert([funcoot, genghis, sham]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([funcoot, genghis, sham]);
             var disguiseCmd = fixture.PrincipalCommands<CountOlafDisguise>().InsertCommand(ANY_ROWS);
             var disguiseInserts = fixture.InsertionsFor(disguiseCmd);
 
@@ -98,10 +101,10 @@ namespace UT.Kvasir.Transaction {
             disguiseInserts.Should().ContainRow(genghis.Name, ConversionOf(genghis.Appearances), genghis.FooledBaudelaires);
             disguiseInserts.Should().ContainRow(sham.Name, ConversionOf(sham.Appearances), sham.FooledBaudelaires);
             fixture.ShouldBeOrdered(disguiseCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarRelations() {
             // Arrange
             var fountain = new SodaFountain() {
                 ProductID = Guid.NewGuid(),
@@ -134,7 +137,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(SodaFountain));
 
             // Act
-            fixture.Transactor.Insert([fountain]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([fountain]);
             var fountainCmd = fixture.PrincipalCommands<SodaFountain>().InsertCommand(ANY_ROWS);
             var fountainInserts = fixture.InsertionsFor(fountainCmd);
             var inspectionsCmd = fixture.RelationCommands<SodaFountain>(0).InsertCommand(ANY_ROWS);
@@ -172,12 +176,12 @@ namespace UT.Kvasir.Transaction {
             sodasInserts.Should().ContainRow(fountain.ProductID, "Dr. Pepper", fountain.Sodas["Dr. Pepper"]);
             sodasInserts.Should().ContainRow(fountain.ProductID, "Barq's Root Beer", fountain.Sodas["Barq's Root Beer"]);
             fixture.ShouldBeOrdered(fountainCmd, (inspectionsCmd, sodasCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             fountain.Inspections.Should().HaveUnsavedEntryCount(0);
             fountain.Sodas.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityEmptyScalarRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityEmptyScalarRelations() {
             // Arrange
             var recLetter = new LetterOfRecommendation() {
                 Author = "Dr. Barry Sfagnoulo",
@@ -190,7 +194,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(LetterOfRecommendation));
 
             // Act
-            fixture.Transactor.Insert([recLetter]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([recLetter]);
             var letterCmd = fixture.PrincipalCommands<LetterOfRecommendation>().InsertCommand(ANY_ROWS);
             var letterInserts = fixture.InsertionsFor(letterCmd);
             var wordsCmd = fixture.RelationCommands<LetterOfRecommendation>(0).InsertCommand(ANY_ROWS);
@@ -203,10 +208,10 @@ namespace UT.Kvasir.Transaction {
             letterInserts.Should().ContainRow(recLetter.Author, recLetter.Recipient, recLetter.Year, recLetter.Purpose, recLetter.Compensation);
             wordsInserts.Should().HaveCount(0);
             fixture.ShouldBeOrdered(letterCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleInstancesSingleEntityScalarRelations() {
+        [TestMethod] public async Task MultipleInstancesSingleEntityScalarRelations() {
             // Arrange
             var fund0 = new MutualFund() {
                 FundID = Guid.NewGuid(),
@@ -246,7 +251,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(MutualFund));
 
             // Act
-            fixture.Transactor.Insert([fund0, fund1, fund2]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([fund0, fund1, fund2]);
             var fundCmd = fixture.PrincipalCommands<MutualFund>().InsertCommand(ANY_ROWS);
             var fundInserts = fixture.InsertionsFor(fundCmd);
             var investorsCmd = fixture.RelationCommands<MutualFund>(0).InsertCommand(ANY_ROWS);
@@ -271,13 +277,13 @@ namespace UT.Kvasir.Transaction {
             investorsInserts.Should().ContainRow(fund2.FundID, fund2.CompanyID, "Dorothea Thau", fund2.Investors["Dorothea Thau"]);
             investorsInserts.Should().ContainRow(fund2.FundID, fund2.CompanyID, "Gilbert Gaq", fund2.Investors["Gilbert Gaq"]);
             fixture.ShouldBeOrdered(fundCmd, investorsCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             fund0.Investors.Should().HaveUnsavedEntryCount(0);
             fund1.Investors.Should().HaveUnsavedEntryCount(0);
             fund2.Investors.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleLocalization() {
+        [TestMethod] public async Task SingleInstanceSingleLocalization() {
             // Arrange
             var password = new Password(Guid.NewGuid());
             password[false] = "Th!s_IS_my_P@sSw0rd1";
@@ -285,7 +291,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Password));
 
             // Act
-            fixture.Transactor.Insert([password]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([password]);
             var passwordCmd = fixture.PrincipalCommands<Password>().InsertCommand(ANY_ROWS);
             var passwordInserts = fixture.InsertionsFor(passwordCmd);
 
@@ -296,11 +303,11 @@ namespace UT.Kvasir.Transaction {
             passwordInserts.Should().ContainRow(password.Key, false, password[false]);
             passwordInserts.Should().ContainRow(password.Key, true, password[true]);
             fixture.ShouldBeOrdered(passwordCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             password.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleInstancesSingleLocalization() {
+        [TestMethod] public async Task MultipleInstancesSingleLocalization() {
             // Arrange
             var first = new Ordinal(1);
             first[OrdinalMode.Suffixed] = "1st";
@@ -315,7 +322,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Ordinal));
 
             // Act
-            fixture.Transactor.Insert([first, twentyThird, eightMillionth]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([first, twentyThird, eightMillionth]);
             var ordinalCmd = fixture.PrincipalCommands<Ordinal>().InsertCommand(ANY_ROWS);
             var ordinalInserts = fixture.InsertionsFor(ordinalCmd);
 
@@ -331,13 +339,13 @@ namespace UT.Kvasir.Transaction {
             ordinalInserts.Should().ContainRow(eightMillionth.Key, ConversionOf(OrdinalMode.Suffixed), eightMillionth[OrdinalMode.Suffixed]);
             ordinalInserts.Should().ContainRow(eightMillionth.Key, ConversionOf(OrdinalMode.FullySpelled), eightMillionth[OrdinalMode.FullySpelled]);
             fixture.ShouldBeOrdered(ordinalCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             first.Relation.Should().HaveUnsavedEntryCount(0);
             twentyThird.Relation.Should().HaveUnsavedEntryCount(0);
             eightMillionth.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleUnrelatedEntities() {
+        [TestMethod] public async Task MultipleUnrelatedEntities() {
             // Arrange
             var wheelchair = new Wheelchair() {
                 ProductID = Guid.NewGuid(),
@@ -373,7 +381,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Wheelchair), typeof(Haka), typeof(BetterKnowADistrict), typeof(Invoice));
 
             // Act
-            fixture.Transactor.Insert([wheelchair, haka, bkad, invoice]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([wheelchair, haka, bkad, invoice]);
             var wheelchairCmd = fixture.PrincipalCommands<Wheelchair>().InsertCommand(ANY_ROWS);
             var wheelchairInserts = fixture.InsertionsFor(wheelchairCmd);
             var hakaCmd = fixture.PrincipalCommands<Haka>().InsertCommand(ANY_ROWS);
@@ -401,10 +410,10 @@ namespace UT.Kvasir.Transaction {
             invoiceInserts.Should().HaveCount(1);
             invoiceInserts.Should().ContainRow(invoice.InvoiceNumber, invoice.Buyer, invoice.Seller, invoice.Amount, invoice.Date, invoice.IsElectronic);
             fixture.ShouldBeOrdered((wheelchairCmd, hakaCmd, bkadCmd, invoiceCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleUnrelatedLocalizations() {
+        [TestMethod] public async Task MultipleUnrelatedLocalizations() {
             // Arrange
             var disclaimer = new Disclaimer(Guid.NewGuid());
             disclaimer[Language.Italian] = "non ci assumiamo responsabilità per le ustioni";
@@ -421,7 +430,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Disclaimer), typeof(Tagline), typeof(Polynomial));
 
             // Act
-            fixture.Transactor.Insert([disclaimer, tagline, polynomial]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([disclaimer, tagline, polynomial]);
             var disclaimerCmd = fixture.PrincipalCommands<Disclaimer>().InsertCommand(ANY_ROWS);
             var disclaimerInserts = fixture.InsertionsFor(disclaimerCmd);
             var taglineCmd = fixture.PrincipalCommands<Tagline>().InsertCommand(ANY_ROWS);
@@ -449,13 +459,13 @@ namespace UT.Kvasir.Transaction {
             polynomialInserts.Should().ContainRow(polynomial.Key, (byte)2, polynomial[2]);
             polynomialInserts.Should().ContainRow(polynomial.Key, (byte)3, polynomial[3]);
             fixture.ShouldBeOrdered((disclaimerCmd, taglineCmd, polynomialCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             disclaimer.Relation.Should().HaveUnsavedEntryCount(0);
             tagline.Relation.Should().HaveUnsavedEntryCount(0);
             polynomial.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceChain() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceChain() {
             // Arrange
             var zookeeper = new Rhinoceros.Person() {
                 IntelligenceNumber = Guid.NewGuid(),
@@ -479,7 +489,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Rhinoceros), typeof(Rhinoceros.Zoo), typeof(Rhinoceros.Person));
 
             // Act
-            fixture.Transactor.Insert([rhino, zookeeper, zoo]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([rhino, zookeeper, zoo]);
             var zookeeperCmd = fixture.PrincipalCommands<Rhinoceros.Person>().InsertCommand(ANY_ROWS);
             var zookeeperInserts = fixture.InsertionsFor(zookeeperCmd);
             var zooCmd = fixture.PrincipalCommands<Rhinoceros.Zoo>().InsertCommand(ANY_ROWS);
@@ -501,10 +512,10 @@ namespace UT.Kvasir.Transaction {
             rhinoInserts.Should().HaveCount(1);
             rhinoInserts.Should().ContainRow(rhino.AnimalID, rhino.Genus, rhino.Species, rhino.Captivity?.ZooID, rhino.NumHorns);
             fixture.ShouldBeOrdered(zookeeperCmd, zooCmd, rhinoCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceTree() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceTree() {
             // Arrange
             var badge = new Sheriff.Badge() {
                 Number = 4516,
@@ -525,7 +536,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Sheriff), typeof(Sheriff.Badge), typeof(Sheriff.Election));
 
             // Act
-            fixture.Transactor.Insert([sheriff, election, badge]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([sheriff, election, badge]);
             var badgeCmd = fixture.PrincipalCommands<Sheriff.Badge>().InsertCommand(ANY_ROWS);
             var badgeInserts = fixture.InsertionsFor(badgeCmd);
             var electionCmd = fixture.PrincipalCommands<Sheriff.Election>().InsertCommand(ANY_ROWS);
@@ -547,10 +559,10 @@ namespace UT.Kvasir.Transaction {
             sheriffInserts.Should().HaveCount(1);
             sheriffInserts.Should().ContainRow(sheriff.SheriffsBadge.Number, sheriff.SheriffsBadge.Municipality, sheriff.Name, sheriff.Arrests, sheriff.FirstElected?.ElectionID);
             fixture.ShouldBeOrdered((badgeCmd, electionCmd), sheriffCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByRelation() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByRelation() {
             // Arrange
             var witch0 = new Coven.Witch() {
                 Name = "Selma Aftorii",
@@ -585,7 +597,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Coven), typeof(Coven.Witch));
 
             // Act
-            fixture.Transactor.Insert([witch0, coven, witch1, witch2, witch3]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([witch0, coven, witch1, witch2, witch3]);
             var covenCmd = fixture.PrincipalCommands<Coven>().InsertCommand(ANY_ROWS);
             var covenInserts = fixture.InsertionsFor(covenCmd);
             var witchCmd = fixture.PrincipalCommands<Coven.Witch>().InsertCommand(ANY_ROWS);
@@ -612,11 +625,11 @@ namespace UT.Kvasir.Transaction {
             membersInserts.Should().ContainRow(coven.CovenID, witch1.Name, witch1.SpellcasterNumber);
             membersInserts.Should().ContainRow(coven.CovenID, witch2.Name, witch2.SpellcasterNumber);
             fixture.ShouldBeOrdered((covenCmd, witchCmd), membersCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             coven.Witches.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByScalarLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByScalarLocalization() {
             // Arrange
             var measurement = new LocalizedMeasure(1825125444);
             measurement[Translation.TestLocalizations.System.Imperial] = new Measurement(108, "MiB");
@@ -633,7 +646,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(MemoryLeak), typeof(LocalizedMeasure), typeof(LocalizedDate));
 
             // Act
-            fixture.Transactor.Insert([date, measurement, leak]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([date, measurement, leak]);
             var dateCmd = fixture.PrincipalCommands<LocalizedDate>().InsertCommand(ANY_ROWS);
             var dateInserts = fixture.InsertionsFor(dateCmd);
             var measurementCmd = fixture.PrincipalCommands<LocalizedMeasure>().InsertCommand(ANY_ROWS);
@@ -655,12 +669,12 @@ namespace UT.Kvasir.Transaction {
             measurementInserts.Should().ContainRow(measurement.Key, ConversionOf(Translation.TestLocalizations.System.Metric), "MiB", 108.0);
             leakInserts.Should().HaveCount(1);
             leakInserts.Should().ContainRow(leak.Program, leak.RunNumber, leak.MemoryLeaked.Key, leak.DetectedBySanitizer, leak.IncidentDate.Key);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             measurement.Relation.Should().HaveUnsavedEntryCount(0);
             date.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceLocalization() {
             // Arrange
             var id0 = new PoliceChase.Identifier() {
                 Text = "A78192FF-q",
@@ -692,7 +706,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(PoliceChase), typeof(PoliceChase.Identifier), typeof(PoliceChase.LocalizedID));
 
             // Act
-            fixture.Transactor.Insert([chase, id0, id1, id2, localization]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([chase, id0, id1, id2, localization]);
             var chaseCmd = fixture.PrincipalCommands<PoliceChase>().InsertCommand(ANY_ROWS);
             var chases = fixture.InsertionsFor(chaseCmd);
             var identifierCmd = fixture.PrincipalCommands<PoliceChase.Identifier>().InsertCommand(ANY_ROWS);
@@ -719,11 +734,11 @@ namespace UT.Kvasir.Transaction {
             localizations.Should().ContainRow(localization.Key, "Qwevnuryl", localization["Qwevnuryl"].Text, localization["Qwevnuryl"].Numeric);
             fixture.ShouldBeOrdered((chaseCmd, identifierCmd));
             fixture.ShouldBeOrdered(identifierCmd, localizationCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             localization.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByRelationLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByRelationLocalization() {
             // Arrange
             var fiftyDollars = new LocalizedCurrency("$50");
             fiftyDollars["dollar"] = 50M;
@@ -754,7 +769,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(HostileTakeover), typeof(LocalizedCurrency));
 
             // Act
-            fixture.Transactor.Insert([takeover, fiftyDollars, sixtyDollars, seventyDollars]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([takeover, fiftyDollars, sixtyDollars, seventyDollars]);
             var takeoverCmd = fixture.PrincipalCommands<HostileTakeover>().InsertCommand(ANY_ROWS);
             var takeoverInserts = fixture.InsertionsFor(takeoverCmd);
             var currencyCmd = fixture.PrincipalCommands<LocalizedCurrency>().InsertCommand(ANY_ROWS);
@@ -788,13 +804,13 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered(takeoverCmd, pricesCmd);
             fixture.ShouldBeOrdered((takeoverCmd, currencyCmd));
             fixture.ShouldBeOrdered((pricesCmd, currencyCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             fiftyDollars.Relation.Should().HaveUnsavedEntryCount(0);
             sixtyDollars.Relation.Should().HaveUnsavedEntryCount(0);
             seventyDollars.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SelfReferentialEntityViaRelation() {
+        [TestMethod] public async Task SelfReferentialEntityViaRelation() {
             // Arrange
             var ixchel = new MayanGod() {
                 Name = "Ixchel",
@@ -820,7 +836,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(MayanGod));
 
             // Act
-            fixture.Transactor.Insert([ixchel, itzamna, yumKaax]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([ixchel, itzamna, yumKaax]);
             var godCmd = fixture.PrincipalCommands<MayanGod>().InsertCommand(ANY_ROWS);
             var godInserts = fixture.InsertionsFor(godCmd);
             var fathersCmd = fixture.RelationCommands<MayanGod>(0).InsertCommand(ANY_ROWS);
@@ -844,12 +861,12 @@ namespace UT.Kvasir.Transaction {
             mothersInserts.Should().HaveCount(1);
             mothersInserts.Should().ContainRow(yumKaax.Name, yumKaax.Mothers.First().Name);
             fixture.ShouldBeOrdered(godCmd, (fathersCmd, mothersCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             yumKaax.Mothers.Should().HaveUnsavedEntryCount(0);
             yumKaax.Fathers.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SelfReferentialEntityViaLocalization() {
+        [TestMethod] public async Task SelfReferentialEntityViaLocalization() {
             // Arrange
             var pizzeria = new Pizzeria() {
                 Franchise = "Olympian Pies",
@@ -865,7 +882,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Pizzeria), typeof(Pizzeria.LocalizedStore));
 
             // Act
-            fixture.Transactor.Insert([pizzeria, pizzeria.ParentStore]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Insert([pizzeria, pizzeria.ParentStore]);
             var pizzeriaCmd = fixture.PrincipalCommands<Pizzeria>().InsertCommand(ANY_ROWS);
             var pizzeriaInserts = fixture.InsertionsFor(pizzeriaCmd);
             var storeCmd = fixture.PrincipalCommands<Pizzeria.LocalizedStore>().InsertCommand(ANY_ROWS);
@@ -882,11 +900,11 @@ namespace UT.Kvasir.Transaction {
             storeInserts.Should().ContainRow(pizzeria.ParentStore.Key, "official", pizzeria.ParentStore["official"].Franchise, pizzeria.ParentStore["official"].StoreNumber);
             storeInserts.Should().ContainRow(pizzeria.ParentStore.Key, "unofficial", pizzeria.ParentStore["unofficial"].Franchise, pizzeria.ParentStore["unofficial"].StoreNumber);
             fixture.ShouldBeOrdered(pizzeriaCmd, storeCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             pizzeria.ParentStore.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void TransactionRolledBack() {
+        [TestMethod] public async Task TransactionRolledBack() {
             // Arrange
             var blister = new Blister() {
                 Person = "Casimir Natchowski",
@@ -897,15 +915,16 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Blister)).WithCommitError();
 
             // Act
-            var action = () => fixture.Transactor.Insert([blister]);
+            await fixture.InitializeSchema();
+            var action = async () => await fixture.Transactor.Insert([blister]);
 
             // Assert
-            action.Should().ThrowExactly<InvalidOperationException>();
-            fixture.Transaction.Received(1).Commit();
-            fixture.Transaction.Received(1).Rollback();
+            await action.Should().ThrowExactlyAsync<InvalidOperationException>();
+            await fixture.Transaction.Received(1).CommitAsync();
+            await fixture.Transaction.Received(1).RollbackAsync();
         }
 
-        [TestMethod] public void RollbackFails() {
+        [TestMethod] public async Task RollbackFails() {
             // Arrange
             var chainsaw = new Chainsaw() {
                 ProductID = Guid.NewGuid(),
@@ -917,12 +936,13 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Chainsaw)).WithRollbackError();
 
             // Act
-            var action = () => fixture.Transactor.Insert([chainsaw]);
+            await fixture.InitializeSchema();
+            var action = async () => await fixture.Transactor.Insert([chainsaw]);
 
             // Assert
-            action.Should().ThrowExactly<AggregateException>();
-            fixture.Transaction.Received(1).Commit();
-            fixture.Transaction.Received(1).Rollback();
+            await action.Should().ThrowExactlyAsync<AggregateException>();
+            await fixture.Transaction.Received(1).CommitAsync();
+            await fixture.Transaction.Received(1).RollbackAsync();
         }
 
 

--- a/test/UnitTests/Kvasir/Transaction/Selection.cs
+++ b/test/UnitTests/Kvasir/Transaction/Selection.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 using static UT.Kvasir.Transaction.Selection;
 using static UT.Kvasir.Translation.TestLocalizations;
@@ -11,33 +12,35 @@ using static UT.Kvasir.Translation.TestLocalizations;
 namespace UT.Kvasir.Transaction {
     [TestClass, TestCategory("Selection")]
     public class SelectionTests {
-        [TestMethod] public void ZeroInstances() {
+        [TestMethod] public async Task ZeroInstances() {
             var fixture = new TestFixture(typeof(Samurai));
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var samuraiQuery = fixture.PrincipalCommands<Samurai>().SelectAllQuery;
             var samurais = fixture.Depot[typeof(Samurai)].Cast<Samurai>().ToList();
 
             // Assert
             samuraiQuery.Connection.Should().Be(fixture.Connection);
-            samuraiQuery.Received(1).ExecuteReader();
+            await samuraiQuery.Received(1).ExecuteReaderAsync();
             samurais.Should().HaveCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNoNullsNoRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNoNullsNoRelations() {
             // Arrange
             var diaper = new object[] { Guid.NewGuid(), false, 12.5f, "Huggies", false };
             var fixture = new TestFixture(typeof(Diaper)).WithEntityRow<Diaper>(diaper);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var diaperQuery = fixture.PrincipalCommands<Diaper>().SelectAllQuery;
             var diapers = fixture.Depot[typeof(Diaper)].Cast<Diaper>().ToList();
 
             // Assert
             diaperQuery.Connection.Should().Be(fixture.Connection);
-            diaperQuery.Received(1).ExecuteReader();
+            await diaperQuery.Received(1).ExecuteReaderAsync();
             diapers.Should().HaveCount(1);
             diaper[0].Should().Be(diapers[0].DiaperID);
             diaper[1].Should().Be(diapers[0].IsUsed);
@@ -46,19 +49,20 @@ namespace UT.Kvasir.Transaction {
             diaper[4].Should().Be(diapers[0].ForAdults);
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNullsNoRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNullsNoRelations() {
             // Arrange
             var test = new object[] { "MBTI", 94U, DBNull.Value, (byte)16, false, DBNull.Value };
             var fixture = new TestFixture(typeof(PersonalityTest)).WithEntityRow<PersonalityTest>(test);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var testQuery = fixture.PrincipalCommands<PersonalityTest>().SelectAllQuery;
             var tests = fixture.Depot[typeof(PersonalityTest)].Cast<PersonalityTest>().ToList();
 
             // Assert
             testQuery.Connection.Should().Be(fixture.Connection);
-            testQuery.Received(1).ExecuteReader();
+            await testQuery.Received(1).ExecuteReaderAsync();
             tests.Should().HaveCount(1);
             test[0].Should().Be(tests[0].TestName);
             test[1].Should().Be(tests[0].NumQuestions);
@@ -68,7 +72,7 @@ namespace UT.Kvasir.Transaction {
             tests[0].DebutYear.Should().BeNull();
         }
 
-        [TestMethod] public void MultipleInstancesSingleEntityNoRelations() {
+        [TestMethod] public async Task MultipleInstancesSingleEntityNoRelations() {
             // Arrange
             var carotid = new object[] { "Carotid", (byte)2, 115U, "Internal Jugular" };
             var femoral = new object[] { "Femoral", (byte)2, 115U, "Femoral" };
@@ -79,13 +83,14 @@ namespace UT.Kvasir.Transaction {
                 .WithEntityRow<Artery>(aorta);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var arteryQuery = fixture.PrincipalCommands<Artery>().SelectAllQuery;
             var arteries = fixture.Depot[typeof(Artery)].Cast<Artery>().ToList();
 
             // Assert
             arteryQuery.Connection.Should().Be(fixture.Connection);
-            arteryQuery.Received(1).ExecuteReader();
+            await arteryQuery.Received(1).ExecuteReaderAsync();
             arteries.Should().HaveCount(3);
             carotid[0].Should().Be(arteries[0].Name);
             carotid[1].Should().Be(arteries[0].NumPerPerson);
@@ -101,7 +106,7 @@ namespace UT.Kvasir.Transaction {
             aorta[3].Should().Be(arteries[2].Vein);
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarRelations() {
             // Arrange
             var table = new object[] { "PLT1TR4", (ushort)2021, true };
             var femaleRow0 = new object[] { table[0], table[1], 82, .056911 };
@@ -116,7 +121,8 @@ namespace UT.Kvasir.Transaction {
                 .WithRelationRow<ActuarialTable>(1, maleRow2);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var tableQuery = fixture.PrincipalCommands<ActuarialTable>().SelectAllQuery;
             var femaleQuery = fixture.RelationCommands<ActuarialTable>(0).SelectAllQuery;
             var maleQuery = fixture.RelationCommands<ActuarialTable>(1).SelectAllQuery;
@@ -139,13 +145,14 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered(tableQuery, (femaleQuery, maleQuery));
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityEmptyScalarRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityEmptyScalarRelations() {
             // Arrange
             var quasar = new object[] { "3C 273", "Virgo", 0.158339, 2433000000UL };
             var fixture = new TestFixture(typeof(Quasar)).WithEntityRow<Quasar>(quasar);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var quasarQuery = fixture.PrincipalCommands<Quasar>().SelectAllQuery;
             var discoverersQuery = fixture.RelationCommands<Quasar>(0).SelectAllQuery;
             var quasars = fixture.Depot[typeof(Quasar)].Cast<Quasar>().ToList();
@@ -162,7 +169,7 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered(quasarQuery, discoverersQuery);
         }
 
-        [TestMethod] public void MultipleInstancesSingleEntityScalarRelations() {
+        [TestMethod] public async Task MultipleInstancesSingleEntityScalarRelations() {
             // Arrange
             var oldSpice = new object[] { Guid.NewGuid(), "Old Spice", 17.99M, false };
             var degreeUltra = new object[] { Guid.NewGuid(), "Degree Ultra", 24.99M, false };
@@ -185,7 +192,8 @@ namespace UT.Kvasir.Transaction {
                 .WithRelationRow<Deodorant>(0, mango);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var deodorantQuery = fixture.PrincipalCommands<Deodorant>().SelectAllQuery;
             var scentsQuery = fixture.RelationCommands<Deodorant>(0).SelectAllQuery;
             var deodorants = fixture.Depot[typeof(Deodorant)].Cast<Deodorant>().ToList();
@@ -218,7 +226,7 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered(deodorantQuery, scentsQuery);
         }
 
-        [TestMethod] public void SingleInstanceSingleLocalization() {
+        [TestMethod] public async Task SingleInstanceSingleLocalization() {
             // Arrange
             var vocalRange1 = new object[] { "LOC_ALTO", ConversionOf(Language.English), 37.9 };
             var vocalRange2 = new object[] { "LOC_ALTO", ConversionOf(Language.Spanish), -9.656 };
@@ -229,7 +237,8 @@ namespace UT.Kvasir.Transaction {
                 .WithLocalizationRow<VocalRange>(vocalRange3);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var vocalRangeQuery = fixture.PrincipalCommands<VocalRange>().SelectAllQuery;
             var vocalRanges = fixture.Depot[typeof(VocalRange)].Cast<VocalRange>().ToList();
 
@@ -243,7 +252,7 @@ namespace UT.Kvasir.Transaction {
             vocalRange3[2].Should().Be(vocalRanges[0][Language.Hindi]);
         }
 
-        [TestMethod] public void MultipleInstancesSingleLocalization() {
+        [TestMethod] public async Task MultipleInstancesSingleLocalization() {
             // Arrange
             var pleasantry1 = new object[] { "LOC_THANKS", 'q', "Thank You" };
             var pleasantry2 = new object[] { "LOC_THANKS", 'a', "Thank You Very Much" };
@@ -260,7 +269,8 @@ namespace UT.Kvasir.Transaction {
                 .WithLocalizationRow<Pleasantry>(pleasantry6);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var pleasantryQuery = fixture.PrincipalCommands<Pleasantry>().SelectAllQuery;
             var pleasantries = fixture.Depot[typeof(Pleasantry)].Cast<Pleasantry>().ToList();
 
@@ -281,7 +291,7 @@ namespace UT.Kvasir.Transaction {
             pleasantry3[2].Should().Be(pleasantries[2]['i']);
         }
 
-        [TestMethod] public void MultipleUnrelatedEntities() {
+        [TestMethod] public async Task MultipleUnrelatedEntities() {
             // Arrange
             var griselda = new object[] { (byte)3, (byte)2, "Griselda Blanco", "New Jersey", "Dan Harmon", new DateTime(2015, 9, 8) };
             var cooper = new object[] { (byte)5, (byte)7, "D.B. Cooper", "Drunk Mystery", "Kyle Mooney", new DateTime(2018, 3, 6) };
@@ -300,7 +310,8 @@ namespace UT.Kvasir.Transaction {
                 .WithEntityRow<Colonscopy>(colonoscopy);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var drunkHistoryQuery = fixture.PrincipalCommands<DrunkHistory>().SelectAllQuery;
             var allergenQuery = fixture.PrincipalCommands<Allergen>().SelectAllQuery;
             var colonoscopyQuery = fixture.PrincipalCommands<Colonscopy>().SelectAllQuery;
@@ -358,7 +369,7 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered((drunkHistoryQuery, allergenQuery, colonoscopyQuery));
         }
 
-        [TestMethod] public void MultipleUnrelatedLocalizations() {
+        [TestMethod] public async Task MultipleUnrelatedLocalizations() {
             // Arrange
             var wotd1 = new object[] { new DateOnly(2026, 5, 9), ConversionOf(Language.English), "antelope" };
             var wotd2 = new object[] { new DateOnly(2026, 5, 9), ConversionOf(Language.Spanish), "antílope" };
@@ -381,7 +392,8 @@ namespace UT.Kvasir.Transaction {
                 .WithLocalizationRow<IrrationalNumber>(irrationalNumber4);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var wotdQuery = fixture.PrincipalCommands<WordOfTheDay>().SelectAllQuery;
             var exclamationQuery = fixture.PrincipalCommands<Exclamation>().SelectAllQuery;
             var irrationalNumberQuery = fixture.PrincipalCommands<IrrationalNumber>().SelectAllQuery;
@@ -413,7 +425,7 @@ namespace UT.Kvasir.Transaction {
             irrationalNumber4[2].Should().Be(irrationalNumbers[0][18]);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceChain() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceChain() {
             // Arrange
             var male = new object[] { 'M', "male", 47.259 };
             var female = new object[] { 'F', "female", 46.8114 };
@@ -434,7 +446,8 @@ namespace UT.Kvasir.Transaction {
                 .WithEntityRow<Annuity.Gender>(female);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var genderQuery = fixture.PrincipalCommands<Annuity.Gender>().SelectAllQuery;
             var personQuery = fixture.PrincipalCommands<Annuity.Person>().SelectAllQuery;
             var companyQuery = fixture.PrincipalCommands<Annuity.Company>().SelectAllQuery;
@@ -490,7 +503,7 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered(genderQuery, personQuery, companyQuery, annuityQuery);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceTree() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceTree() {
             // Arrange
             var elvis = new object[] { Guid.NewGuid(), "Elvis", "Presley" };
             var taylor = new object[] { Guid.NewGuid(), "Taylor", "Swift" };
@@ -505,7 +518,8 @@ namespace UT.Kvasir.Transaction {
                 .WithEntityRow<ACapellaGroup>(group);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var songwriterQuery = fixture.PrincipalCommands<ACapellaGroup.Songwriter>().SelectAllQuery;
             var universityQuery = fixture.PrincipalCommands<ACapellaGroup.University>().SelectAllQuery;
             var songQuery = fixture.PrincipalCommands<ACapellaGroup.Song>().SelectAllQuery;
@@ -549,7 +563,7 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered(universityQuery, groupQuery);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByRelation() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByRelation() {
             // Arrange
             var aaron = new object[] { "GB", 12, "Aaron Rodgers", "QB" };
             var richard = new object[] { "GB", 82, "Richard Rodgers", "TE" };
@@ -562,7 +576,8 @@ namespace UT.Kvasir.Transaction {
                 .WithRelationRow<HailMary>(0, [miracle[0], miracle[1], richard[0], richard[1]]);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var hailMaryQuery = fixture.PrincipalCommands<HailMary>().SelectAllQuery;
             var playerQuery = fixture.PrincipalCommands<HailMary.FootballPlayer>().SelectAllQuery;
             var involvementQuery = fixture.RelationCommands<HailMary>(0).SelectAllQuery;
@@ -593,7 +608,7 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered((playerQuery, hailMaryQuery), involvementQuery);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByScalarLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByScalarLocalization() {
             // Arrange
             var currency0 = new object[] { "LOC_CURRENCY_0", "dollar", 38.00M };
             var currency1 = new object[] { "LOC_CURRENCY_1", "dollar", 0.003M };
@@ -608,7 +623,8 @@ namespace UT.Kvasir.Transaction {
                 .WithLocalizationRow<LocalizedNullableText>(text);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var contractQuery = fixture.PrincipalCommands<EventContract>().SelectAllQuery;
             var currencyQuery = fixture.PrincipalCommands<LocalizedCurrency>().SelectAllQuery;
             var dateQuery = fixture.PrincipalCommands<LocalizedDate>().SelectAllQuery;
@@ -647,7 +663,7 @@ namespace UT.Kvasir.Transaction {
             text[2].Should().Be(texts[0][Language.English]);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceLocalization() {
             // Arrange
             var cost = new object[] { Guid.NewGuid(), 3600, 500.0M };
             var localizedCost0 = new object[] { "LOC_VRANTZHAUS", ConversionOf(DJ.Event.Wedding), cost[0] };
@@ -660,7 +676,8 @@ namespace UT.Kvasir.Transaction {
                 .WithLocalizationRow<DJ.LocalizedCost>(localizedCost1);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var djQuery = fixture.PrincipalCommands<DJ>().SelectAllQuery;
             var costQuery = fixture.PrincipalCommands<DJ.Cost>().SelectAllQuery;
             var localizedCostQuery = fixture.PrincipalCommands<DJ.LocalizedCost>().SelectAllQuery;
@@ -690,7 +707,7 @@ namespace UT.Kvasir.Transaction {
             localizedCosts[0][DJ.Event.BneiMitzvah].Should().Be(costs[0]);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByRelationLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByRelationLocalization() {
             // Arrange
             var length0 = new object[] { 1825712UL, ConversionOf(Translation.TestLocalizations.System.Imperial), "feet", 13.9 };
             var length1 = new object[] { length0[0], ConversionOf(Translation.TestLocalizations.System.Metric), "meters", 4.25 };
@@ -710,7 +727,8 @@ namespace UT.Kvasir.Transaction {
                 .WithRelationRow<Whale>(0, [whale[0], ConversionOf(Whale.Dimension.GestationPeriod), gestation[0]]);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var whaleQuery = fixture.PrincipalCommands<Whale>().SelectAllQuery;
             var measureQuery = fixture.PrincipalCommands<LocalizedMeasure>().SelectAllQuery;
             var measurementsQuery = fixture.RelationCommands<Whale>(0).SelectAllQuery;
@@ -745,7 +763,7 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered((whaleQuery, measureQuery), measurementsQuery);
         }
 
-        [TestMethod] public void SelfReferentialEntityViaRelation() {
+        [TestMethod] public async Task SelfReferentialEntityViaRelation() {
             // Arrange
             var naderShah = new object[] { "Nader Shah", new DateTime(1736, 3, 8), new DateTime(1747, 6, 20), "Afsharid", "Tehran" };
             var abbas = new object[] { "Abbas III", new DateTime(1732, 4, 16), new DateTime(1736, 1, 22), "Safavid", "Tehran" };
@@ -758,7 +776,8 @@ namespace UT.Kvasir.Transaction {
                 .WithRelationRow<IranianShah>(0, [abbas[0], tahmasp[0]]);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var shahQuery = fixture.PrincipalCommands<IranianShah>().SelectAllQuery;
             var predecessorsQuery = fixture.RelationCommands<IranianShah>(0).SelectAllQuery;
             var shahs = fixture.Depot[typeof(IranianShah)].Cast<IranianShah>().ToList();
@@ -790,7 +809,7 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered(shahQuery, predecessorsQuery);
         }
 
-        [TestMethod] public void SelfReferentialEntityViaLocalization() {
+        [TestMethod] public async Task SelfReferentialEntityViaLocalization() {
             // Arrange
             var localizedCell = new object[] { '+', true, Guid.NewGuid() };
             var stemCell0 = new object[] { localizedCell[2], localizedCell[0], 0.00945f, true, "Samson Houlie" };
@@ -801,7 +820,8 @@ namespace UT.Kvasir.Transaction {
                 .WithLocalizationRow<StemCell.LocalizedCell>(localizedCell);
 
             // Act
-            fixture.Transactor.SelectAll();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
             var stemCellQuery = fixture.PrincipalCommands<StemCell>().SelectAllQuery;
             var localizedCellQuery = fixture.PrincipalCommands<StemCell.LocalizedCell>().SelectAllQuery;
             var stemCells = fixture.Depot[typeof(StemCell)].Cast<StemCell>().ToList();

--- a/test/UnitTests/Kvasir/Transaction/TableCreation.cs
+++ b/test/UnitTests/Kvasir/Transaction/TableCreation.cs
@@ -1,10 +1,8 @@
 ﻿using FluentAssertions;
-using Kvasir.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Threading.Tasks;
 
 using static UT.Kvasir.Transaction.TableCreation;
 using static UT.Kvasir.Translation.TestLocalizations;
@@ -12,27 +10,29 @@ using static UT.Kvasir.Translation.TestLocalizations;
 namespace UT.Kvasir.Transaction {
     [TestClass, TestCategory("Table Creation")]
     public class TableCreationTests {
-        [TestMethod] public void SingleEntityNoRelations() {
+        [TestMethod] public async Task SingleEntityNoRelations() {
             // Arrange
             var fixture = new TestFixture(typeof(PoliticalRally));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var rallyCmd = fixture.PrincipalCommands<PoliticalRally>().CreateTableCommand;
 
             // Assert
             rallyCmd.Connection.Should().Be(fixture.Connection);
             rallyCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered(rallyCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleEntityScalarRelations() {
+        [TestMethod] public async Task SingleEntityScalarRelations() {
             // Arrange
             var fixture = new TestFixture(typeof(Yogurt));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var yogurtCmd = fixture.PrincipalCommands<Yogurt>().CreateTableCommand;
             var nutritionCmd = fixture.RelationCommands<Yogurt>(0).CreateTableCommand;
             var traitsCmd = fixture.RelationCommands<Yogurt>(1).CreateTableCommand;
@@ -45,30 +45,32 @@ namespace UT.Kvasir.Transaction {
             traitsCmd.Connection.Should().Be(fixture.Connection);
             traitsCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered(yogurtCmd, (nutritionCmd, traitsCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleLocalization() {
+        [TestMethod] public async Task SingleLocalization() {
             // Arrange
             var fixture = new TestFixture(typeof(Nickname));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var nicknameCmd = fixture.PrincipalCommands<Nickname>().CreateTableCommand;
 
             // Assert
             nicknameCmd.Connection.Should().Be(fixture.Connection);
             nicknameCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered(nicknameCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleUnrelatedEntities() {
+        [TestMethod] public async Task MultipleUnrelatedEntities() {
             // Arrange
             var fixture = new TestFixture(typeof(Gondola), typeof(Scooter), typeof(Muffin));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var gondolaCmd = fixture.PrincipalCommands<Gondola>().CreateTableCommand;
             var scooterCmd = fixture.PrincipalCommands<Scooter>().CreateTableCommand;
             var muffinCmd = fixture.PrincipalCommands<Muffin>().CreateTableCommand;
@@ -81,15 +83,16 @@ namespace UT.Kvasir.Transaction {
             muffinCmd.Connection.Should().Be(fixture.Connection);
             muffinCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered((gondolaCmd, scooterCmd, muffinCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleUnrelatedLocalizations() {
+        [TestMethod] public async Task MultipleUnrelatedLocalizations() {
             // Arrange
             var fixture = new TestFixture(typeof(Dosage), typeof(GUID));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var dosageCmd = fixture.PrincipalCommands<Dosage>().CreateTableCommand;
             var guidCmd = fixture.PrincipalCommands<GUID>().CreateTableCommand;
 
@@ -99,15 +102,16 @@ namespace UT.Kvasir.Transaction {
             guidCmd.Connection.Should().Be(fixture.Connection);
             guidCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered((dosageCmd, guidCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceChain() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceChain() {
             // Arrange
             var fixture = new TestFixture(typeof(EpicRapBattle), typeof(EpicRapBattle.Rapper), typeof(EpicRapBattle.Actor));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var rapBattleCmd = fixture.PrincipalCommands<EpicRapBattle>().CreateTableCommand;
             var rapperCmd = fixture.PrincipalCommands<EpicRapBattle.Rapper>().CreateTableCommand;
             var actorCmd = fixture.PrincipalCommands<EpicRapBattle.Actor>().CreateTableCommand;
@@ -120,15 +124,16 @@ namespace UT.Kvasir.Transaction {
             actorCmd.Connection.Should().Be(fixture.Connection);
             actorCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered(actorCmd, rapperCmd, rapBattleCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceTree() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceTree() {
             // Arrange
             var fixture = new TestFixture(typeof(JackOLantern), typeof(Farmer.Farm), typeof(Farmer));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var lanternCmd = fixture.PrincipalCommands<JackOLantern>().CreateTableCommand;
             var farmerCmd = fixture.PrincipalCommands<Farmer>().CreateTableCommand;
             var farmCmd = fixture.PrincipalCommands<Farmer.Farm>().CreateTableCommand;
@@ -141,15 +146,16 @@ namespace UT.Kvasir.Transaction {
             farmCmd.Connection.Should().Be(fixture.Connection);
             farmCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered(farmCmd, (lanternCmd, farmerCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByRelation() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByRelation() {
             // Arrange
             var fixture = new TestFixture(typeof(CashRegister), typeof(CashRegister.Item), typeof(CashRegister.Currency));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var registerCmd = fixture.PrincipalCommands<CashRegister>().CreateTableCommand;
             var itemCmd = fixture.PrincipalCommands<CashRegister.Item>().CreateTableCommand;
             var currencyCmd = fixture.PrincipalCommands<CashRegister.Currency>().CreateTableCommand;
@@ -169,15 +175,16 @@ namespace UT.Kvasir.Transaction {
             sellablesCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered((registerCmd, itemCmd), sellablesCmd);
             fixture.ShouldBeOrdered((registerCmd, currencyCmd), cashCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByScalarLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByScalarLocalization() {
             // Arrange
             var fixture = new TestFixture(typeof(Quesadilla), typeof(LocalizedMeasure));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var quesadillaCmd = fixture.PrincipalCommands<Quesadilla>().CreateTableCommand;
             var measureCmd = fixture.PrincipalCommands<LocalizedMeasure>().CreateTableCommand;
 
@@ -187,15 +194,16 @@ namespace UT.Kvasir.Transaction {
             measureCmd.Connection.Should().Be(fixture.Connection);
             measureCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered((quesadillaCmd, measureCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceLocalization() {
             // Arrange
             var fixture = new TestFixture(typeof(Honmoon), typeof(Honmoon.DemonHunter), typeof(Honmoon.LocalizedHunter));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var honmoonCmd = fixture.PrincipalCommands<Honmoon>().CreateTableCommand;
             var hunterCmd = fixture.PrincipalCommands<Honmoon.DemonHunter>().CreateTableCommand;
             var localizationCmd = fixture.PrincipalCommands<Honmoon.LocalizedHunter>().CreateTableCommand;
@@ -212,12 +220,13 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered(hunterCmd, localizationCmd);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByRelationLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByRelationLocalization() {
             // Arrange
             var fixture = new TestFixture(typeof(LocalizedText), typeof(CrownJewel));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var textCmd = fixture.PrincipalCommands<LocalizedText>().CreateTableCommand;
             var jewelCmd = fixture.PrincipalCommands<CrownJewel>().CreateTableCommand;
             var componentsCmd = fixture.RelationCommands<CrownJewel>(0).CreateTableCommand;
@@ -230,15 +239,16 @@ namespace UT.Kvasir.Transaction {
             componentsCmd.Connection.Should().Be(fixture.Connection);
             componentsCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered(jewelCmd, componentsCmd, textCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SelfReferentialEntityViaRelation() {
+        [TestMethod] public async Task SelfReferentialEntityViaRelation() {
             // Arrange
             var fixture = new TestFixture(typeof(Matrix));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var matrixCmd = fixture.PrincipalCommands<Matrix>().CreateTableCommand;
             var eigenvaluesCmd = fixture.RelationCommands<Matrix>(0).CreateTableCommand;
             var inversesCmd = fixture.RelationCommands<Matrix>(1).CreateTableCommand;
@@ -251,15 +261,16 @@ namespace UT.Kvasir.Transaction {
             inversesCmd.Connection.Should().Be(fixture.Connection);
             inversesCmd.Transaction.Should().Be(fixture.Transaction);
             fixture.ShouldBeOrdered(matrixCmd, (eigenvaluesCmd, inversesCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SelfReferentialEntityViaLocalization() {
+        [TestMethod] public async Task SelfReferentialEntityViaLocalization() {
             // Arrange
             var fixture = new TestFixture(typeof(ClassActionLawsuit), typeof(LocalizedDate), typeof(ClassActionLawsuit.LocalizedVerdict));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var lawsuitCmd = fixture.PrincipalCommands<ClassActionLawsuit>().CreateTableCommand;
             var dateCmd = fixture.PrincipalCommands<LocalizedDate>().CreateTableCommand;
             var verdictCmd = fixture.PrincipalCommands<ClassActionLawsuit.LocalizedVerdict>().CreateTableCommand;
@@ -276,12 +287,13 @@ namespace UT.Kvasir.Transaction {
             fixture.ShouldBeOrdered((verdictCmd, dateCmd));
         }
 
-        [TestMethod] public void PreDefinedEntity() {
+        [TestMethod] public async Task PreDefinedEntity() {
             // Arrange
             var fixture = new TestFixture(typeof(Dashavatara));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var createCmd = fixture.PrincipalCommands<Dashavatara>().CreateTableCommand;
             var insertCmd = fixture.PrincipalCommands<Dashavatara>().InsertCommand([]);
             var inserts = fixture.InsertionsFor(insertCmd);
@@ -303,15 +315,16 @@ namespace UT.Kvasir.Transaction {
             inserts.Should().ContainRow(Dashavatara.Buddha.Index, Dashavatara.Buddha.Name, Dashavatara.Buddha.Form);
             inserts.Should().ContainRow(Dashavatara.Kalki.Index, Dashavatara.Kalki.Name, Dashavatara.Kalki.Form);
             fixture.ShouldBeOrdered(createCmd, insertCmd);
-            fixture.Transaction.Received(2).Commit();
+            await fixture.Transaction.Received(2).CommitAsync();
         }
 
-        [TestMethod] public void PreDefinedLocalization() {
+        [TestMethod] public async Task PreDefinedLocalization() {
             // Arrange
             var fixture = new TestFixture(typeof(CivVITerrain));
 
             // Act
-            fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            await fixture.Transactor.CreateTables();
             var createCmd = fixture.PrincipalCommands<CivVITerrain>().CreateTableCommand;
             var insertCmd = fixture.PrincipalCommands<CivVITerrain>().InsertCommand([]);
             var inserts = fixture.InsertionsFor(insertCmd);
@@ -339,33 +352,35 @@ namespace UT.Kvasir.Transaction {
             inserts.Should().ContainRow(CivVITerrain.Ocean.Key, "FULL", CivVITerrain.Ocean["FULL"]);
             inserts.Should().ContainRow(CivVITerrain.Ocean.Key, "SHORT", CivVITerrain.Ocean["SHORT"]);
             fixture.ShouldBeOrdered(createCmd, insertCmd);
-            fixture.Transaction.Received(2).Commit();
+            await fixture.Transaction.Received(2).CommitAsync();
         }
 
-        [TestMethod] public void TransactionRolledBack() {
+        [TestMethod] public async Task TransactionRolledBack() {
             // Arrange
             var fixture = new TestFixture(typeof(Bond)).WithCommitError();
 
             // Act
-            var action = () => fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            var action = async () => await fixture.Transactor.CreateTables();
 
             // Assert
-            action.Should().ThrowExactly<InvalidOperationException>();
-            fixture.Transaction.Received(1).Commit();
-            fixture.Transaction.Received(1).Rollback();
+            await action.Should().ThrowExactlyAsync<InvalidOperationException>();
+            await fixture.Transaction.Received(1).CommitAsync();
+            await fixture.Transaction.Received(1).RollbackAsync();
         }
 
-        [TestMethod] public void RollbackFails() {
+        [TestMethod] public async Task RollbackFails() {
             // Arrange
             var fixture = new TestFixture(typeof(GrilledCheese)).WithRollbackError();
 
             // Act
-            var action = () => fixture.Transactor.CreateTables();
+            await fixture.InitializeSchema();
+            var action = async () => await fixture.Transactor.CreateTables();
 
             // Assert
-            action.Should().ThrowExactly<AggregateException>();
-            fixture.Transaction.Received(1).Commit();
-            fixture.Transaction.Received(1).Rollback();
+            await action.Should().ThrowExactlyAsync<AggregateException>();
+            await fixture.Transaction.Received(1).CommitAsync();
+            await fixture.Transaction.Received(1).RollbackAsync();
         }
     }
 }

--- a/test/UnitTests/Kvasir/Transaction/Update.cs
+++ b/test/UnitTests/Kvasir/Transaction/Update.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading.Tasks;
 
 using static UT.Kvasir.Transaction.Update;
 using static UT.Kvasir.Translation.TestLocalizations;
@@ -14,7 +14,7 @@ using static UT.Kvasir.Translation.TestLocalizations;
 namespace UT.Kvasir.Transaction {
     [TestClass, TestCategory("Modification")]
     public class UpdateTests {
-        [TestMethod] public void SingleInstanceSingleEntityNoRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNoRelations() {
             // Arrange
             var diffEq = new DifferentialEquation() {
                 EquationId = Guid.NewGuid(),
@@ -25,7 +25,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(DifferentialEquation));
 
             // Act
-            fixture.Transactor.Update([diffEq]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([diffEq]);
             var diffEqCmd = fixture.PrincipalCommands<DifferentialEquation>().UpdateCommand(ANY_ROWS);
             var diffEqUpdates = fixture.UpdatesFor(diffEqCmd);
 
@@ -35,10 +36,10 @@ namespace UT.Kvasir.Transaction {
             diffEqUpdates.Should().HaveCount(1);
             diffEqUpdates.Should().ContainRow(diffEq.EquationId, diffEq.Equation, diffEq.IsPartial, diffEq.NumSolutions);
             fixture.ShouldBeOrdered(diffEqCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleInstancesSingleEntityNoRelations() {
+        [TestMethod] public async Task MultipleInstancesSingleEntityNoRelations() {
             // Arrange
             var cortes = new Conquistador() {
                 Name = "Hernán Cortés de Monroy y Pizarro Altamirano",
@@ -55,7 +56,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Conquistador));
 
             // Act
-            fixture.Transactor.Update([cortes, pizarro]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([cortes, pizarro]);
             var conquistadorCmd = fixture.PrincipalCommands<Conquistador>().UpdateCommand(ANY_ROWS);
             var conquistadorUpdates = fixture.UpdatesFor(conquistadorCmd);
 
@@ -66,10 +68,10 @@ namespace UT.Kvasir.Transaction {
             conquistadorUpdates.Should().ContainRow(cortes.Name, ConversionOf(cortes.Conquest), cortes.DateOfBirth, cortes.DateOfDeath);
             conquistadorUpdates.Should().ContainRow(pizarro.Name, ConversionOf(pizarro.Conquest), pizarro.DateOfBirth, pizarro.DateOfDeath);
             fixture.ShouldBeOrdered(conquistadorCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarRelationsSavedElements() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarRelationsSavedElements() {
             // Arrange
             var quiz = new BigFatQuiz() {
                 Airdate = new DateTime(2024, 12, 27),
@@ -86,7 +88,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(BigFatQuiz));
 
             // Act
-            fixture.Transactor.Update([quiz]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([quiz]);
             var quizCmd = fixture.PrincipalCommands<BigFatQuiz>().UpdateCommand(ANY_ROWS);
             var quizUpdates = fixture.UpdatesFor(quizCmd);
             var teamsInsertCmd = fixture.RelationCommands<BigFatQuiz>(0).InsertCommand(ANY_ROWS);
@@ -105,10 +108,10 @@ namespace UT.Kvasir.Transaction {
             teamsDeletions.Should().HaveCount(0);
             teamsUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(quizCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarNonAssociativeRelationsDeletedElements() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarNonAssociativeRelationsDeletedElements() {
             // Arrange
             var guacamole = new Guacamole() {
                 GuacamoleID = Guid.NewGuid(),
@@ -128,7 +131,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Guacamole));
 
             // Act
-            fixture.Transactor.Update([guacamole]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([guacamole]);
             var guacamoleCmd = fixture.PrincipalCommands<Guacamole>().UpdateCommand(ANY_ROWS);
             var guacamoleUpdates = fixture.UpdatesFor(guacamoleCmd);
             var ingredientsInsertCmd = fixture.RelationCommands<Guacamole>(0).InsertCommand(ANY_ROWS);
@@ -154,11 +158,11 @@ namespace UT.Kvasir.Transaction {
             ingredientsDeletions.Should().ContainRow(guacamole.GuacamoleID, "Salt");
             ingredientsUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(guacamoleCmd, ingredientsDeleteCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             guacamole.Ingredients.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarAssociativeRelationsDeletedElements() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarAssociativeRelationsDeletedElements() {
             // Arrange
             var eyeDrops = new EyeDrops() {
                 DropsID = Guid.NewGuid(),
@@ -181,7 +185,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(EyeDrops));
 
             // Act
-            fixture.Transactor.Update([eyeDrops]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([eyeDrops]);
             var eyeDropsCmd = fixture.PrincipalCommands<EyeDrops>().UpdateCommand(ANY_ROWS);
             var eyeDropsUpdates = fixture.UpdatesFor(eyeDropsCmd);
             var treatmentsInsertCmd = fixture.RelationCommands<EyeDrops>(0).InsertCommand(ANY_ROWS);
@@ -208,11 +213,11 @@ namespace UT.Kvasir.Transaction {
             treatmentsDeletions.Should().ContainRow(eyeDrops.DropsID, ConversionOf(EyeDrops.Condition.Glaucoma));
             treatmentsUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(eyeDropsCmd, treatmentsDeleteCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             eyeDrops.TreatmentPlan.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarRelationsNewElements() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarRelationsNewElements() {
             // Arrange
             var statue = new EquestrianStatue() {
                 ArtworkID = Guid.NewGuid(),
@@ -228,7 +233,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(EquestrianStatue));
 
             // Act
-            fixture.Transactor.Update([statue]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([statue]);
             var statueCmd = fixture.PrincipalCommands<EquestrianStatue>().UpdateCommand(ANY_ROWS);
             var statueUpdates = fixture.UpdatesFor(statueCmd);
             var dimensionsInsertCmd = fixture.RelationCommands<EquestrianStatue>(0).InsertCommand(ANY_ROWS);
@@ -251,11 +257,11 @@ namespace UT.Kvasir.Transaction {
             dimensionsDeletions.Should().HaveCount(0);
             dimensionsUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(statueCmd, dimensionsInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             statue.Dimensions.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarRelationsModifiedElements() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarRelationsModifiedElements() {
             // Arrange
             var bibliography = new Bibliography() {
                 ID = Guid.NewGuid(),
@@ -285,7 +291,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Bibliography));
 
             // Act
-            fixture.Transactor.Update([bibliography]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([bibliography]);
             var bibliographyCmd = fixture.PrincipalCommands<Bibliography>().UpdateCommand(ANY_ROWS);
             var bibliographyUpdates = fixture.UpdatesFor(bibliographyCmd);
             var referencesInsertCmd = fixture.RelationCommands<Bibliography>(0).InsertCommand(ANY_ROWS);
@@ -307,11 +314,11 @@ namespace UT.Kvasir.Transaction {
             referencesUpdates.Should().HaveCount(1);
             referencesUpdates.Should().ContainRow(bibliography.ID, 1U, bibliography.References[1].Title, bibliography.References[1].Author, ConversionOf(bibliography.References[1].TypeOfWork));
             fixture.ShouldBeOrdered(bibliographyCmd, referencesUpdateCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             bibliography.References.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityNonEmptyScalarRelationsMixedElements() {
+        [TestMethod] public async Task SingleInstanceSingleEntityNonEmptyScalarRelationsMixedElements() {
             // Arrange
             var akuna = new MarketMaker() {
                 PrimaryMPID = "4619",
@@ -332,7 +339,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(MarketMaker));
 
             // Act
-            fixture.Transactor.Update([akuna]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([akuna]);
             var marketMakerCmd = fixture.PrincipalCommands<MarketMaker>().UpdateCommand(ANY_ROWS);
             var marketMakerUpdates = fixture.UpdatesFor(marketMakerCmd);
             var symbolsInsertCmd = fixture.RelationCommands<MarketMaker>(0).InsertCommand(ANY_ROWS);
@@ -357,11 +365,11 @@ namespace UT.Kvasir.Transaction {
             symbolsUpdates.Should().HaveCount(1);
             symbolsUpdates.Should().ContainRow(akuna.PrimaryMPID, 2U, akuna.Symbols[2]);
             fixture.ShouldBeOrdered(marketMakerCmd, symbolsUpdateCmd, symbolsInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             akuna.Symbols.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleEntityEmptyScalarRelations() {
+        [TestMethod] public async Task SingleInstanceSingleEntityEmptyScalarRelations() {
             // Arrange
             var scroll = new DeadSeaScroll() {
                 Cave = "Qumran Cave 3",
@@ -374,7 +382,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(DeadSeaScroll));
 
             // Act
-            fixture.Transactor.Update([scroll]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([scroll]);
             var scrollCmd = fixture.PrincipalCommands<DeadSeaScroll>().UpdateCommand(ANY_ROWS);
             var scrollUpdates = fixture.UpdatesFor(scrollCmd);
             var authorsInsertCmd = fixture.RelationCommands<DeadSeaScroll>(0).InsertCommand(ANY_ROWS);
@@ -393,10 +402,10 @@ namespace UT.Kvasir.Transaction {
             authorsDeletions.Should().HaveCount(0);
             authorsUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(scrollCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleInstancesSingleEntityScalarRelations() {
+        [TestMethod] public async Task MultipleInstancesSingleEntityScalarRelations() {
             // Arrange
             var chicago = new Diocese() {
                 Name = "Archdiocese of Chicago",
@@ -429,7 +438,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Diocese));
 
             // Act
-            fixture.Transactor.Update([chicago, derby, perth]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([chicago, derby, perth]);
             var dioceseCmd = fixture.PrincipalCommands<Diocese>().UpdateCommand(ANY_ROWS);
             var dioceseUpdates = fixture.UpdatesFor(dioceseCmd);
             var bishopsInsertCmd = fixture.RelationCommands<Diocese>(0).InsertCommand(ANY_ROWS);
@@ -456,13 +466,13 @@ namespace UT.Kvasir.Transaction {
             bishopsDeletions.Should().HaveCount(0);
             bishopsUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(dioceseCmd, bishopsInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             chicago.Bishops.Should().HaveUnsavedEntryCount(0);
             derby.Bishops.Should().HaveUnsavedEntryCount(0);
             perth.Bishops.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleLocalizationSavedValues() {
+        [TestMethod] public async Task SingleInstanceSingleLocalizationSavedValues() {
             // Arrange
             var placement = new Placement("LOC_HORSE_RACING");
             placement[1] = "win";
@@ -472,7 +482,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Placement));
 
             // Act
-            fixture.Transactor.Update([placement]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([placement]);
             var placementInsertCmd = fixture.PrincipalCommands<Placement>().InsertCommand(ANY_ROWS);
             var placementInsertions = fixture.InsertionsFor(placementInsertCmd);
             var placementDeleteCmd = fixture.PrincipalCommands<Placement>().DeleteCommand(ANY_ROWS);
@@ -490,7 +501,7 @@ namespace UT.Kvasir.Transaction {
             placement.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleLocalizationDeletedValues() {
+        [TestMethod] public async Task SingleInstanceSingleLocalizationDeletedValues() {
             // Arrange
             var permissions = new Permissions("LOC_ESTHER_GROENBERGEN");
             permissions["production"] = Operation.CanRead;
@@ -503,7 +514,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Permissions));
 
             // Act
-            fixture.Transactor.Update([permissions]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([permissions]);
             var permissionsInsertCmd = fixture.PrincipalCommands<Permissions>().InsertCommand(ANY_ROWS);
             var permissionsInsertions = fixture.InsertionsFor(permissionsInsertCmd);
             var permissionsDeleteCmd = fixture.PrincipalCommands<Permissions>().DeleteCommand(ANY_ROWS);
@@ -522,11 +534,11 @@ namespace UT.Kvasir.Transaction {
             permissionsDeletions.Should().ContainRow(permissions.Key, "cloud-test");
             permissionsUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(permissionsDeleteCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             permissions.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleLocalizationNewValues() {
+        [TestMethod] public async Task SingleInstanceSingleLocalizationNewValues() {
             // Arrange
             var binary = new BinaryValue("LOC_ON/OFF");
             binary[true] = "on";
@@ -534,7 +546,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(BinaryValue));
 
             // Act
-            fixture.Transactor.Update([binary]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([binary]);
             var binaryInsertCmd = fixture.PrincipalCommands<BinaryValue>().InsertCommand(ANY_ROWS);
             var binaryInsertions = fixture.InsertionsFor(binaryInsertCmd);
             var binaryDeleteCmd = fixture.PrincipalCommands<BinaryValue>().DeleteCommand(ANY_ROWS);
@@ -553,11 +566,11 @@ namespace UT.Kvasir.Transaction {
             binaryDeletions.Should().HaveCount(0);
             binaryUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(binaryInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             binary.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SingleInstanceSingleLocalizationMixedValues() {
+        [TestMethod] public async Task SingleInstanceSingleLocalizationMixedValues() {
             // Arrange
             var bigBad = new BigBad("LOC_BUFFY");
             bigBad[0] = "The Master";
@@ -572,7 +585,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(BigBad));
 
             // Act
-            fixture.Transactor.Update([bigBad]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([bigBad]);
             var bigBadInsertCmd = fixture.PrincipalCommands<BigBad>().InsertCommand(ANY_ROWS);
             var bigBadInsertions = fixture.InsertionsFor(bigBadInsertCmd);
             var bigBadDeleteCmd = fixture.PrincipalCommands<BigBad>().DeleteCommand(ANY_ROWS);
@@ -593,11 +607,11 @@ namespace UT.Kvasir.Transaction {
             bigBadDeletions.Should().ContainRow(bigBad.Key, (sbyte)1);
             bigBadUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(bigBadDeleteCmd, bigBadInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             bigBad.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleInstancesSingleLocalization() {
+        [TestMethod] public async Task MultipleInstancesSingleLocalization() {
             // Arrange
             var illinois = new MinimumWage("LOC_ILLINOIS");
             illinois[1972] = 1.40M;
@@ -617,7 +631,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(MinimumWage));
 
             // Act
-            fixture.Transactor.Update([illinois, federal, hawaii]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([illinois, federal, hawaii]);
             var wageInsertCmd = fixture.PrincipalCommands<MinimumWage>().InsertCommand(ANY_ROWS);
             var wageInsertions = fixture.InsertionsFor(wageInsertCmd);
             var wageDeleteCmd = fixture.PrincipalCommands<MinimumWage>().DeleteCommand(ANY_ROWS);
@@ -646,13 +661,13 @@ namespace UT.Kvasir.Transaction {
             wageDeletions.Should().HaveCount(0);
             wageUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(wageInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             illinois.Relation.Should().HaveUnsavedEntryCount(0);
             federal.Relation.Should().HaveUnsavedEntryCount(0);
             hawaii.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleUnrelatedEntities() {
+        [TestMethod] public async Task MultipleUnrelatedEntities() {
             // Arrange
             var waltz = new Waltz() {
                 PieceTitle = "The Blue Danube",
@@ -680,7 +695,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Waltz), typeof(Pacemaker), typeof(DemigodCamp));
 
             // Act
-            fixture.Transactor.Update([waltz, pacemaker, camp]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([waltz, pacemaker, camp]);
             var waltzCmd = fixture.PrincipalCommands<Waltz>().UpdateCommand(ANY_ROWS);
             var waltzUpdates = fixture.UpdatesFor(waltzCmd);
             var pacemakerCmd = fixture.PrincipalCommands<Pacemaker>().UpdateCommand(ANY_ROWS);
@@ -702,10 +718,10 @@ namespace UT.Kvasir.Transaction {
             campUpdates.Should().HaveCount(1);
             campUpdates.Should().ContainRow(camp.Name, camp.Location, ConversionOf(camp.Mythology), camp.Campers, camp.NumCabins, camp.FirstAppearance);
             fixture.ShouldBeOrdered((waltzCmd, pacemakerCmd, campCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleUnrelatedLocalizations() {
+        [TestMethod] public async Task MultipleUnrelatedLocalizations() {
             // Arrange
             var philosophy = new Philosophy("LOC_EXISTENTIALISM");
             philosophy[Language.English] = "existentialism";
@@ -721,7 +737,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Philosophy), typeof(AlterEgo), typeof(Pain));
 
             // Act
-            fixture.Transactor.Update([philosophy, alterEgo, pain]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([philosophy, alterEgo, pain]);
             var philosophyInsertCmd = fixture.PrincipalCommands<Philosophy>().InsertCommand(ANY_ROWS);
             var philosophyInsertions = fixture.InsertionsFor(philosophyInsertCmd);
             var philosophyDeleteCmd = fixture.PrincipalCommands<Philosophy>().DeleteCommand(ANY_ROWS);
@@ -772,13 +789,13 @@ namespace UT.Kvasir.Transaction {
             painDeletions.Should().HaveCount(0);
             painUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered((philosophyInsertCmd, alterEgoInsertCmd, painInsertCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             philosophy.Relation.Should().HaveUnsavedEntryCount(0);
             alterEgo.Relation.Should().HaveUnsavedEntryCount(0);
             pain.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceChain() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceChain() {
             // Arrange
             var company = new PromoCode.Company() {
                 Name = "Gary's Pizza Emporium of the West",
@@ -802,7 +819,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(PromoCode), typeof(PromoCode.Discout), typeof(PromoCode.Company));
 
             // Act
-            fixture.Transactor.Update([company, discount, promoCode]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([company, discount, promoCode]);
             var promoCodeCmd = fixture.PrincipalCommands<PromoCode>().UpdateCommand(ANY_ROWS);
             var promoCodeUpdates = fixture.UpdatesFor(promoCodeCmd);
             var companyCmd = fixture.PrincipalCommands<PromoCode.Company>().UpdateCommand(ANY_ROWS);
@@ -824,10 +842,10 @@ namespace UT.Kvasir.Transaction {
             discountUpdates.Should().HaveCount(1);
             discountUpdates.Should().ContainRow(discount.ID, discount.Percentage, discount.IsBOGO, discount.ValidAt.Name, discount.ValidAt.Discriminator, discount.Expiration);
             fixture.ShouldBeOrdered(companyCmd, discountCmd, promoCodeCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceTree() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceTree() {
             // Arrange
             var president = new WritOfCertiorari.President() {
                 Number = 37,
@@ -856,7 +874,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(WritOfCertiorari), typeof(WritOfCertiorari.Justice), typeof(WritOfCertiorari.Case), typeof(WritOfCertiorari.President));
 
             // Act
-            fixture.Transactor.Update([writ, justice, courtCase, president]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([writ, justice, courtCase, president]);
             var writeCmd = fixture.PrincipalCommands<WritOfCertiorari>().UpdateCommand(ANY_ROWS);
             var writUpdates = fixture.UpdatesFor(writeCmd);
             var justiceCmd = fixture.PrincipalCommands<WritOfCertiorari.Justice>().UpdateCommand(ANY_ROWS);
@@ -885,10 +904,10 @@ namespace UT.Kvasir.Transaction {
             presidentUpdates.Should().ContainRow(president.Number, president.Name, ConversionOf(president.PoliticalParty));
             fixture.ShouldBeOrdered((caseCmd, justiceCmd), writeCmd);
             fixture.ShouldBeOrdered(presidentCmd, justiceCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByRelation() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByRelation() {
             // Arrange
             var katniss = new HungerGames.PanemCitizen() {
                 Name = "Katniss Everdeen",
@@ -919,7 +938,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(HungerGames), typeof(HungerGames.PanemCitizen));
 
             // Act
-            fixture.Transactor.Update([games, katniss, rue, marvel]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([games, katniss, rue, marvel]);
             var hungerGamesCmd = fixture.PrincipalCommands<HungerGames>().UpdateCommand(ANY_ROWS);
             var hungerGamesUpdates = fixture.UpdatesFor(hungerGamesCmd);
             var citizenCmd = fixture.PrincipalCommands<HungerGames.PanemCitizen>().UpdateCommand(ANY_ROWS);
@@ -951,11 +971,11 @@ namespace UT.Kvasir.Transaction {
             killersDeletions.Should().HaveCount(0);
             killersUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered((citizenCmd, hungerGamesCmd), killersInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             games.Killers.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByScalarLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByScalarLocalization() {
             // Arrange
             var daemon = new Daemon() {
                 Human = "Lyra (Belacqua) Silvertongue",
@@ -969,7 +989,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Daemon), typeof(LocalizedText));
 
             // Act
-            fixture.Transactor.Update([daemon, daemon.Animal]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([daemon, daemon.Animal]);
             var daemonCmd = fixture.PrincipalCommands<Daemon>().UpdateCommand(ANY_ROWS);
             var daemonUpdates = fixture.UpdatesFor(daemonCmd);
             var textInsertCmd = fixture.PrincipalCommands<LocalizedText>().InsertCommand(ANY_ROWS);
@@ -993,11 +1014,11 @@ namespace UT.Kvasir.Transaction {
             textDeletions.Should().HaveCount(0);
             textUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered((daemonCmd, textInsertCmd));
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             daemon.Animal.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByReferenceLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByReferenceLocalization() {
             // Arrange
             var doctor0 = new Vasectomy.Doctor() {
                 MedicalID = Guid.NewGuid(),
@@ -1025,7 +1046,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Vasectomy), typeof(Vasectomy.Doctor), typeof(Vasectomy.LocalizedStage));
 
             // Act
-            fixture.Transactor.Update([doctor0, doctor1, vasectomy, vasectomy.Doctors]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([doctor0, doctor1, vasectomy, vasectomy.Doctors]);
             var doctorUpdateCmd = fixture.PrincipalCommands<Vasectomy.Doctor>().UpdateCommand(ANY_ROWS);
             var doctorUpdates = fixture.UpdatesFor(doctorUpdateCmd);
             var vasectomyUpdateCmd = fixture.PrincipalCommands<Vasectomy>().UpdateCommand(ANY_ROWS);
@@ -1061,11 +1083,11 @@ namespace UT.Kvasir.Transaction {
 
             fixture.ShouldBeOrdered((vasectomyUpdateCmd, stageInsertCmd));
             fixture.ShouldBeOrdered(doctorUpdateCmd, stageInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             vasectomy.Doctors.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void MultipleEntitiesRelatedByRelationLocalization() {
+        [TestMethod] public async Task MultipleEntitiesRelatedByRelationLocalization() {
             // Arrange
             var petapsco = new LocalizedText("LOC_PETAPSCO");
             petapsco[Language.English] = "Petapsco River";
@@ -1083,7 +1105,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Harbor), typeof(LocalizedText));
 
             // Act
-            fixture.Transactor.Update([petapsco, harbor]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([petapsco, harbor]);
             var harborCmd = fixture.PrincipalCommands<Harbor>().UpdateCommand(ANY_ROWS);
             var harborUpdates = fixture.UpdatesFor(harborCmd);
             var textInsertCmd = fixture.PrincipalCommands<LocalizedText>().InsertCommand(ANY_ROWS);
@@ -1122,12 +1145,12 @@ namespace UT.Kvasir.Transaction {
             riversDeletions.Should().HaveCount(0);
             riversUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered((harborCmd, riversInsertCmd), riversInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             petapsco.Relation.Should().HaveUnsavedEntryCount(0);
             harbor.Rivers.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SelfReferentialEntityViaRelation() {
+        [TestMethod] public async Task SelfReferentialEntityViaRelation() {
             // Arrange
             var yudhishthira = new Pandava() {
                 Name = "Yudhishthira",
@@ -1176,7 +1199,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(Pandava));
 
             // Act
-            fixture.Transactor.Update([yudhishthira, arjuna, bhima, nakula, sahadeva]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([yudhishthira, arjuna, bhima, nakula, sahadeva]);
             var pandavaCmd = fixture.PrincipalCommands<Pandava>().UpdateCommand(ANY_ROWS);
             var pandavaUpdates = fixture.UpdatesFor(pandavaCmd);
             var brothersInsertCmd = fixture.RelationCommands<Pandava>(0).InsertCommand(ANY_ROWS);
@@ -1211,14 +1235,14 @@ namespace UT.Kvasir.Transaction {
             brothersDeletions.Should().HaveCount(0);
             brothersUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(pandavaCmd, brothersInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             yudhishthira.Brothers.Should().HaveUnsavedEntryCount(0);
             arjuna.Brothers.Should().HaveUnsavedEntryCount(0);
             bhima.Brothers.Should().HaveUnsavedEntryCount(0);
             nakula.Brothers.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void SelfReferentialEntityViaLocalization() {
+        [TestMethod] public async Task SelfReferentialEntityViaLocalization() {
             // Arrange
             var jasmine = new DisneyPrincess() {
                 Name = "Jasmine",
@@ -1245,7 +1269,8 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(DisneyPrincess), typeof(DisneyPrincess.Opinion));
 
             // Act
-            fixture.Transactor.Update([jasmine, jasmine.ThoughtsOnOthers, nala, nala.ThoughtsOnOthers]);
+            await fixture.InitializeSchema();
+            await fixture.Transactor.Update([jasmine, jasmine.ThoughtsOnOthers, nala, nala.ThoughtsOnOthers]);
             var princessUpdateCmd = fixture.PrincipalCommands<DisneyPrincess>().UpdateCommand(ANY_ROWS);
             var princessUpdates = fixture.UpdatesFor(princessUpdateCmd);
             var opinionInsertCmd = fixture.PrincipalCommands<DisneyPrincess.Opinion>().InsertCommand(ANY_ROWS);
@@ -1273,12 +1298,12 @@ namespace UT.Kvasir.Transaction {
             opinionDeletions.Should().HaveCount(0);
             opinionUpdates.Should().HaveCount(0);
             fixture.ShouldBeOrdered(princessUpdateCmd, opinionInsertCmd);
-            fixture.Transaction.Received(1).Commit();
+            await fixture.Transaction.Received(1).CommitAsync();
             jasmine.ThoughtsOnOthers.Relation.Should().HaveUnsavedEntryCount(0);
             nala.ThoughtsOnOthers.Relation.Should().HaveUnsavedEntryCount(0);
         }
 
-        [TestMethod] public void TransactionRolledBack() {
+        [TestMethod] public async Task TransactionRolledBack() {
             // Arrange
             var chatbot = new ChatBot() {
                 BotID = Guid.NewGuid(),
@@ -1291,15 +1316,16 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(ChatBot)).WithCommitError();
 
             // Act
-            var action = () => fixture.Transactor.Insert([chatbot]);
+            await fixture.InitializeSchema();
+            var action = async () => await fixture.Transactor.Update([chatbot]);
 
             // Assert
-            action.Should().ThrowExactly<InvalidOperationException>();
-            fixture.Transaction.Received(1).Commit();
-            fixture.Transaction.Received(1).Rollback();
+            await action.Should().ThrowExactlyAsync<InvalidOperationException>();
+            await fixture.Transaction.Received(1).CommitAsync();
+            await fixture.Transaction.Received(1).RollbackAsync();
         }
 
-        [TestMethod] public void RollbackFails() {
+        [TestMethod] public async Task RollbackFails() {
             // Arrange
             var surgeonGeneral = new SurgeonGeneral() {
                 Name = "Vivek Murthy",
@@ -1312,12 +1338,13 @@ namespace UT.Kvasir.Transaction {
             var fixture = new TestFixture(typeof(SurgeonGeneral)).WithRollbackError();
 
             // Act
-            var action = () => fixture.Transactor.Update([surgeonGeneral]);
+            await fixture.InitializeSchema();
+            var action = async () => await fixture.Transactor.Update([surgeonGeneral]);
 
             // Assert
-            action.Should().ThrowExactly<AggregateException>();
-            fixture.Transaction.Received(1).Commit();
-            fixture.Transaction.Received(1).Rollback();
+            await action.Should().ThrowExactlyAsync<AggregateException>();
+            await fixture.Transaction.Received(1).CommitAsync();
+            await fixture.Transaction.Received(1).RollbackAsync();
         }
 
 

--- a/test/UnitTests/Kvasir/Transaction/_Fixture.cs
+++ b/test/UnitTests/Kvasir/Transaction/_Fixture.cs
@@ -10,22 +10,22 @@ using NSubstitute;
 using NSubstitute.Core;
 using System;
 using System.Collections.Generic;
-using System.Data;
+using System.Data.Common;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 using Rows = System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyList<Kvasir.Schema.DBValue>>;
 
 namespace UT.Kvasir.Transaction {
     internal sealed class TestFixture {
         public IReadOnlyDictionary<ITable, ICommands> Commands => commands_;
-        public IDbConnection Connection { get; } = Substitute.For<IDbConnection>();
-        public IDbTransaction Transaction { get; }
+        public DbConnection Connection { get; } = Substitute.For<DbConnection>();
+        public DbTransaction Transaction { get; }
         public Dictionary<Type, List<object>> Depot { get; }
         public Transactor Transactor {
             get {
-                EnsureTransactorInitialized();
-                return transactor_!;
+                return transactor_;
             }
         }
 
@@ -36,14 +36,18 @@ namespace UT.Kvasir.Transaction {
             dbRows_ = [];
             connectionPool_ = Substitute.For<IConnectionPool>();
             commandsFactory_ = Substitute.For<ICommandsFactory>();
-            Connection = Substitute.For<IDbConnection>();
-            Transaction = Connection.BeginTransaction();
+            Connection = Substitute.For<DbConnection>();
+            Transaction = Substitute.For<DbTransaction>();
             Depot = types.ToDictionary(t => t, _ => new List<object>());
             translator_ = new Translator(t => Depot[t], NullLogger.Instance);
             ordering_ = [];
             invocationArgs_ = [];
 
-            connectionPool_.MakeConnection().Returns(Connection);
+            withCommitError_ = false;
+            withRollbackError_ = false;
+
+            connectionPool_.MakeConnectionAsync().Returns(Connection);
+            Connection.BeginTransactionAsync().Returns(Transaction);
 
             var adminTypes = new Type[] { typeof(TableHash) };
 
@@ -58,38 +62,38 @@ namespace UT.Kvasir.Transaction {
             foreach (var table in tables) {
                 var commands = Substitute.For<ICommands>();
 
-                var createTable = Substitute.For<IDbCommand>();
+                var createTable = Substitute.For<DbCommand>();
                 createTable.CommandText = $"CREATE TABLE {table.Name}";
-                createTable.When(c => c.ExecuteNonQuery()).Do(_ => ordering_[createTable] = ordering_.Count + 1);
+                createTable.When(c => c.ExecuteNonQueryAsync()).Do(_ => ordering_[createTable] = ordering_.Count + 1);
                 commands.CreateTableCommand.Returns(createTable);
 
-                var reader = Substitute.For<IDataReader>();
+                var reader = Substitute.For<DbDataReader>();
                 reader.Read().Returns(_ => dbRows_[table].MoveNext());
                 reader.FieldCount.Returns(_ => dbRows_[table].Current.Count);
                 reader[Arg.Any<int>()].Returns(args => dbRows_[table].Current[args.ArgAt<int>(0)]);
                 reader.ClearReceivedCalls();
 
-                var selectAll = Substitute.For<IDbCommand>();
+                var selectAll = Substitute.For<DbCommand>();
                 selectAll.CommandText = $"SELECT * FROM {table.Name}";
-                selectAll.ExecuteReader().Returns(reader);
-                selectAll.When(c => c.ExecuteReader()).Do(_ => ordering_[selectAll] = ordering_.Count + 1);
+                selectAll.ExecuteReaderAsync().Returns(reader);
+                selectAll.When(c => c.ExecuteReaderAsync()).Do(_ => ordering_[selectAll] = ordering_.Count + 1);
                 commands.SelectAllQuery.Returns(selectAll);
 
-                var insert = Substitute.For<IDbCommand>();
+                var insert = Substitute.For<DbCommand>();
                 insert.CommandText = $"INSERT INTO {table.Name}";
-                insert.When(c => c.ExecuteNonQuery()).Do(_ => ordering_[insert] = ordering_.Count + 1);
+                insert.When(c => c.ExecuteNonQueryAsync()).Do(_ => ordering_[insert] = ordering_.Count + 1);
                 commands.InsertCommand(Arg.Any<Rows>()).Returns(insert);
                 commands.When(c => c.InsertCommand(Arg.Any<Rows>())).Do(call => SetInvocationArguments(call, insert));
 
-                var delete = Substitute.For<IDbCommand>();
+                var delete = Substitute.For<DbCommand>();
                 delete.CommandText = $"DELETE FROM {table.Name}";
-                delete.When(c => c.ExecuteNonQuery()).Do(_ => ordering_[delete] = ordering_.Count + 1);
+                delete.When(c => c.ExecuteNonQueryAsync()).Do(_ => ordering_[delete] = ordering_.Count + 1);
                 commands.DeleteCommand(Arg.Any<Rows>()).Returns(delete);
                 commands.When(c => c.DeleteCommand(Arg.Any<Rows>())).Do(call => SetInvocationArguments(call, delete));
 
-                var update = Substitute.For<IDbCommand>();
+                var update = Substitute.For<DbCommand>();
                 update.CommandText = $"UPDATE {table.Name}";
-                update.When(c => c.ExecuteNonQuery()).Do(_ => ordering_[update] = ordering_.Count + 1);
+                update.When(c => c.ExecuteNonQueryAsync()).Do(_ => ordering_[update] = ordering_.Count + 1);
                 commands.UpdateCommand(Arg.Any<Rows>()).Returns(update);
                 commands.When(c => c.UpdateCommand(Arg.Any<Rows>())).Do(call => SetInvocationArguments(call, update));
 
@@ -99,15 +103,30 @@ namespace UT.Kvasir.Transaction {
             }
 
             transactor_ = null!;
-            transactorInitializer_ = () => transactor_ = new Transactor(entityTranslations, localizationTranslations, connectionPool_, commandsFactory_, e => Depot[e.GetType()].Add(e), NullLogger.Instance);            
+            transactorInitializer_ = async () => transactor_ = await Transactor.New(entityTranslations, localizationTranslations, connectionPool_, commandsFactory_, e => Depot[e.GetType()].Add(e), NullLogger.Instance);            
         }
+        public async Task InitializeSchema() {
+            if (transactor_ is null) {
+                await transactorInitializer_();
+                AdminCommits = Transaction.ReceivedCalls().Count(c => c.GetMethodInfo().Name == "CommitAsync");
+                Transaction.ClearReceivedCalls();
+
+                if (withCommitError_) {
+                    Transaction.When(x => x.CommitAsync()).Throw<InvalidOperationException>();
+                }
+                if (withRollbackError_) {
+                    Transaction.When(x => x.RollbackAsync()).Throw<InvalidOperationException>();
+                }
+            }
+        }
+
         public TestFixture WithCommitError() {
-            Transaction.When(x => x.Commit()).Throw<InvalidOperationException>();
+            withCommitError_ = true;
             return this;
         }
         public TestFixture WithRollbackError() {
-            WithCommitError();
-            Transaction.When(x => x.Rollback()).Throw<InvalidOperationException>();
+            withCommitError_ = true;
+            withRollbackError_ = true;
             return this;
         }
 
@@ -146,7 +165,6 @@ namespace UT.Kvasir.Transaction {
         }
 
         public ICommands PrincipalCommands<TEntity>() {
-            EnsureTransactorInitialized();
             var type = typeof(TEntity);
 
             if (!Translator.IsLocalizationType(type)) {
@@ -159,24 +177,23 @@ namespace UT.Kvasir.Transaction {
             }
         }
         public ICommands RelationCommands<TEntity>(int index) {
-            EnsureTransactorInitialized();
             var table = translator_[typeof(TEntity)].Relations[index].Table;
             return commands_[table];
         }
 
-        public Rows InsertionsFor(IDbCommand command) {
+        public Rows InsertionsFor(DbCommand command) {
             if (invocationArgs_.TryGetValue(command, out IReadOnlyList<IReadOnlyList<DBValue>>? value)) {
                 return value;
             }
             return [];
         }
-        public Rows UpdatesFor(IDbCommand command) {
+        public Rows UpdatesFor(DbCommand command) {
             if (invocationArgs_.TryGetValue(command, out IReadOnlyList<IReadOnlyList<DBValue>>? value)) {
                 return value;
             }
             return [];
         }
-        public Rows DeletionsFor(IDbCommand command) {
+        public Rows DeletionsFor(DbCommand command) {
             if (invocationArgs_.TryGetValue(command, out IReadOnlyList<IReadOnlyList<DBValue>>? value)) {
                 return value;
             }
@@ -192,7 +209,7 @@ namespace UT.Kvasir.Transaction {
 
         [CustomAssertion]
         public void ShouldBeOrdered(params object[] commands) {
-            int getOrderingOf(IDbCommand cmd) {
+            int getOrderingOf(DbCommand cmd) {
                 if (!ordering_.TryGetValue(cmd, out int order)) {
                     Execute.Assertion
                         .ForCondition(false)
@@ -203,7 +220,7 @@ namespace UT.Kvasir.Transaction {
 
             var previousOrdering = -1;
             foreach (var command in commands) {
-                if (command is IDbCommand cmd) {
+                if (command is DbCommand cmd) {
                     int order = getOrderingOf(cmd);
                     if (order < previousOrdering) {
                         Execute.Assertion
@@ -214,7 +231,7 @@ namespace UT.Kvasir.Transaction {
                 }
                 else {
                     var group = command as ITuple;
-                    var items = Enumerable.Range(0, group!.Length).Select(i => group[i]).Cast<IDbCommand>();
+                    var items = Enumerable.Range(0, group!.Length).Select(i => group[i]).Cast<DbCommand>();
                     var sorted = items.Select(Command => (Command, Order: getOrderingOf(Command))).OrderBy(p => p.Order);
                     if (sorted.First().Order < previousOrdering) {
                         Execute.Assertion
@@ -226,17 +243,10 @@ namespace UT.Kvasir.Transaction {
             }
         }
 
-        private void SetInvocationArguments(CallInfo info, IDbCommand cmd) {
+        private void SetInvocationArguments(CallInfo info, DbCommand cmd) {
             var rows = info.ArgAt<Rows>(0).ToList();
             if (!rows.IsEmpty()) {
                 invocationArgs_[cmd] = rows;
-            }
-        }
-        private void EnsureTransactorInitialized() {
-            if (transactor_ is null) {
-                transactorInitializer_();
-                AdminCommits = Transaction.ReceivedCalls().Count(c => c.GetMethodInfo().Name == "Commit");
-                Transaction.ClearReceivedCalls();
             }
         }
 
@@ -246,12 +256,15 @@ namespace UT.Kvasir.Transaction {
         private readonly Translator translator_;
         private readonly Dictionary<ITable, ICommands> commands_;
         private readonly Dictionary<ITable, IEnumerator<IReadOnlyList<object>>> dbRows_;
-        private readonly Dictionary<IDbCommand, int> ordering_;
-        private readonly Dictionary<IDbCommand, IReadOnlyList<IReadOnlyList<DBValue>>> invocationArgs_;
+        private readonly Dictionary<DbCommand, int> ordering_;
+        private readonly Dictionary<DbCommand, IReadOnlyList<IReadOnlyList<DBValue>>> invocationArgs_;
+
+        private bool withCommitError_;
+        private bool withRollbackError_;
 
         // We need to be able to lazily initialize the Transactor so that we can set up the contents of administrative
         // tables. This is a little janky, but I don't care at this point.
         private Transactor transactor_;
-        private readonly Action transactorInitializer_;
+        private readonly Func<Task> transactorInitializer_;
     }
 }

--- a/test/UnitTests/_FluentExtensions/ExceptionAssertions.cs
+++ b/test/UnitTests/_FluentExtensions/ExceptionAssertions.cs
@@ -19,9 +19,6 @@ namespace FluentAssertions {
         public static LocalizationTranslationAssertions Should(this Func<LocalizationTranslation> self) {
             return new LocalizationTranslationAssertions(self);
         }
-        public static TransactorAssertions Should(this Func<Transactor> self) {
-            return new TransactorAssertions(self);
-        }
 
 
         public class EntityTranslationAssertions : FunctionAssertions<EntityTranslation> {
@@ -38,24 +35,9 @@ namespace FluentAssertions {
             }
         }
 
-
         public class LocalizationTranslationAssertions : FunctionAssertions<LocalizationTranslation> {
             public new Func<LocalizationTranslation> Subject { get; }
             public LocalizationTranslationAssertions(Func<LocalizationTranslation> subject)
-                : base(subject, new AggregateExceptionExtractor()) {
-
-                Subject = subject;
-            }
-
-            public TranslationExceptionAssertions<TEx> FailWith<TEx>() where TEx : TranslationException {
-                var caught = this.ThrowExactly<TEx>();
-                return new TranslationExceptionAssertions<TEx>(caught.Subject.First());
-            }
-        }
-
-        public class TransactorAssertions : FunctionAssertions<Transactor> {
-            public new Func<Transactor> Subject { get; }
-            public TransactorAssertions(Func<Transactor> subject)
                 : base(subject, new AggregateExceptionExtractor()) {
 
                 Subject = subject;


### PR DESCRIPTION
This commit changes all of the code in the Transaction layer to operate asynchronously. In particular, all of the query-executing operations are now async/await. This necessitated some small changes, such as abandoning the true interfaces (such as IDbCommand) in favor of the top-level abstract base class (DbCommand), which has no functional impact on anything. All of the transaction unit tests had to be updated as well to properly await and handle the asynchronous nature of the execution mocks.