### PR TITLE
Expose All Translations from Translator

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -8804,6 +8804,36 @@
               us to provide customization of behaviors in the future without necessitating a significant redesign.
             </remarks>
         </member>
+        <member name="M:Kvasir.Translation.Translator.GetEntityTranslations">
+            <summary>
+              Exposes all of the <see cref="T:Kvasir.Translation.EntityTranslation">translations of non-Localization Entities</see> that
+              have been made.
+            </summary>
+            <returns>
+              A collection of <see cref="T:Kvasir.Translation.EntityTranslation"/> instances, in no particular order, for all translations
+              made by this <see cref="T:Kvasir.Translation.Translator"/>.
+            </returns>
+            <remarks>
+              The returned enumerable does not just contain the set of all translations returned by <c>this[...]</c>.
+              Any Entity types that are translated after being encountered as references, or within Relations, will be
+              exposed as well.
+            </remarks>
+        </member>
+        <member name="M:Kvasir.Translation.Translator.GetLocalizationTranslations">
+            <summary>
+              Exposes all of the <see cref="T:Kvasir.Translation.EntityTranslation">translations of Localization Entities</see> that have
+              been made.
+            </summary>
+            <returns>
+              A collection of <see cref="T:Kvasir.Translation.EntityTranslation"/> instances, in no particular order, for all translations
+              made by this <see cref="T:Kvasir.Translation.Translator"/>.
+            </returns>
+            <remarks>
+              The returned enumerable does not just contain the set of all translations returned by <c>this[...]</c>.
+              Any Localization types that are translated after being encountered as references, or within Relations,
+              will be exposed as well.
+            </remarks>
+        </member>
         <member name="T:Kvasir.Translation.Categorization">
             <summary>
               A collection of extension methods for categorizing various CLR components during translation.

--- a/src/Kvasir/Translation/Translator.cs
+++ b/src/Kvasir/Translation/Translator.cs
@@ -184,6 +184,40 @@ namespace Kvasir.Translation {
             Debug.Assert(callingAssembly_ is not null, "the user must have been involved somewhere!");
         }
 
+        /// <summary>
+        ///   Exposes all of the <see cref="EntityTranslation">translations of non-Localization Entities</see> that
+        ///   have been made.
+        /// </summary>
+        /// <returns>
+        ///   A collection of <see cref="EntityTranslation"/> instances, in no particular order, for all translations
+        ///   made by this <see cref="Translator"/>.
+        /// </returns>
+        /// <remarks>
+        ///   The returned enumerable does not just contain the set of all translations returned by <c>this[...]</c>.
+        ///   Any Entity types that are translated after being encountered as references, or within Relations, will be
+        ///   exposed as well.
+        /// </remarks>
+        public IEnumerable<EntityTranslation> GetEntityTranslations() {
+            return translationCache_.Values;
+        }
+
+        /// <summary>
+        ///   Exposes all of the <see cref="EntityTranslation">translations of Localization Entities</see> that have
+        ///   been made.
+        /// </summary>
+        /// <returns>
+        ///   A collection of <see cref="EntityTranslation"/> instances, in no particular order, for all translations
+        ///   made by this <see cref="Translator"/>.
+        /// </returns>
+        /// <remarks>
+        ///   The returned enumerable does not just contain the set of all translations returned by <c>this[...]</c>.
+        ///   Any Localization types that are translated after being encountered as references, or within Relations,
+        ///   will be exposed as well.
+        /// </remarks>
+        public IEnumerable<LocalizationTranslation> GetLocalizationTranslations() {
+            return localizationCache_.Values;
+        }
+
 
         private readonly Settings settings_;
         private readonly Assembly callingAssembly_;


### PR DESCRIPTION
Translating an Entity can result in multiple translations being produced, thanks to references. To create a Transactor, we need to know the full set of all translations, even the ones that we didn't explicitly ask for. This commit adds accessors for the collection of regular and Localization translations for this purpose.