### PR TITLE
Allow Closed Generics as Entity Types

### DIFF
--- a/src/Kvasir/Annotations/PathingAttributes.cs
+++ b/src/Kvasir/Annotations/PathingAttributes.cs
@@ -10,7 +10,7 @@ namespace Kvasir.Annotations {
     ///   and name of the POCO. The namespace is included to ensure uniqueness among all Tables, since different C#
     ///   namespaces can define classes with the same name. The <see cref="ExcludeNamespaceFromNameAttribute"/> directs
     ///   Kvasir to ignore the POCO's namespace entirely, making a promise that the POCO's name is globally unique among
-    ///   types being treated by the framework.
+    ///   types being treated by the framework. Nested class names are <b>not</b> excluded by this annotation.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public sealed class ExcludeNamespaceFromNameAttribute : Attribute {}

--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -891,7 +891,7 @@
               and name of the POCO. The namespace is included to ensure uniqueness among all Tables, since different C#
               namespaces can define classes with the same name. The <see cref="T:Kvasir.Annotations.ExcludeNamespaceFromNameAttribute"/> directs
               Kvasir to ignore the POCO's namespace entirely, making a promise that the POCO's name is globally unique among
-              types being treated by the framework.
+              types being treated by the framework. Nested class names are <b>not</b> excluded by this annotation.
             </remarks>
         </member>
         <member name="T:Kvasir.Annotations.PreDefinedAttribute">

--- a/src/Kvasir/Translation/Categorization.cs
+++ b/src/Kvasir/Translation/Categorization.cs
@@ -39,10 +39,6 @@ namespace Kvasir.Translation {
             else if (self.IsGenericTypeDefinition) {
                 return TypeCategory.OpenGeneric;
             }
-            else if (self.IsGenericType) {
-                // Relation containers (e.g. `RelationList`) are closed generics, so this has to come later
-                return TypeCategory.ClosedGeneric;
-            }
             else if (self == typeof(object)) {
                 return TypeCategory.Object;
             }
@@ -133,7 +129,6 @@ namespace Kvasir.Translation {
         public static TypeCategory Array { get; } = new TypeCategory("an array (even of an otherwise supported type)");
         public static TypeCategory ByRef { get; } = new TypeCategory("a type by-ref");
         public static TypeCategory Class { get; } = new TypeCategory("a class or a record class");
-        public static TypeCategory ClosedGeneric { get; } = new TypeCategory("a closed generic type");
         public static TypeCategory Delegate { get; } = new TypeCategory("a delegate");
         public static TypeCategory Enumeration { get; } = new TypeCategory("an enumeration type");
         public static TypeCategory Interface { get; } = new TypeCategory("an interface");

--- a/src/Kvasir/Translation/FieldDescriptors/OrderableFieldDescriptor.cs
+++ b/src/Kvasir/Translation/FieldDescriptors/OrderableFieldDescriptor.cs
@@ -27,7 +27,7 @@ namespace Kvasir.Translation {
         }
 
         protected OrderableFieldDescriptor(Context context, PropertyInfo source)
-            : base(context,source) {
+            : base(context, source) {
 
             comparisonConstraint_ = new Interval(Option.None<Bound>(), Option.None<Bound>());
         }

--- a/src/Kvasir/Translation/TranslateEntity.cs
+++ b/src/Kvasir/Translation/TranslateEntity.cs
@@ -439,8 +439,29 @@ namespace Kvasir.Translation {
                 }
             }
 
+            // For closed generic types, we want to enclose the generic parameters in angle brackets. We have to do this
+            // recursively, because the generic parameters themselves could be closed generics. We also have to apply
+            // the rules to enclosing types, in the event of a nested type definition.
+            static string typenameContribution(Type type) {
+                string result = "";
+                if (type.DeclaringType is not null) {
+                    result = typenameContribution(type.DeclaringType) + "+";
+                }
+
+                if (!type.IsGenericType) {
+                    return result + type.Name;
+                }
+                else {
+                    var genericParams = type.GetGenericArguments();
+                    var genericParamNames = genericParams.Select(p => typenameContribution(p));
+                    return $"{result}{type.Name[..type.Name.IndexOf("`")]}<{string.Join(',', genericParamNames)}>";
+                }
+            };
+
             if (annotation is null) {
-                return new TableName((excludeNS ? source.Name : source.FullName!) + "Table");
+                var ns = source.Namespace;
+                var typename = typenameContribution(source);
+                return new TableName((excludeNS ? typename : $"{ns}.{typename}") + "Table");
             }
             else if (!excludeNS) {
                 return new TableName(annotation.Name);

--- a/test/UnitTests/Kvasir/Translation/EntityShapes.cs
+++ b/test/UnitTests/Kvasir/Translation/EntityShapes.cs
@@ -246,19 +246,23 @@ namespace UT.Kvasir.Translation {
                 .EndMessage();
         }
 
-        [TestMethod] public void EntityTypeIsClosedGeneric_IsError() {
+        [TestMethod] public void EntityTypeIsClosedGeneric() {
             // Arrange
             var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
             var source = typeof(Speedometer<double>);
 
             // Act
-            var translate = () => translator[source];
+            var translation = translator[source];
 
             // Assert
-            translate.Should().FailWith<InvalidEntityTypeException>()
-                .WithLocation("`Speedometer<double>`")
-                .WithProblem("a closed generic type cannot be an Entity type")
-                .EndMessage();
+            translation.CLRSource.Should().Be(source);
+            translation.Principal.Table.Name.Should().Be("UT.Kvasir.Translation.EntityShapes+Speedometer<Double>Table");
+            translation.Principal.Table.Should()
+                .HaveField("MinSpeed").OfTypeDouble().BeingNonNullable().And
+                .HaveField("MaxSpeed").OfTypeDouble().BeingNonNullable().And
+                .HaveField("Brand").OfTypeText().BeingNonNullable().And
+                .HaveNoOtherFields();
+            translation.Principal.PreDefinedInstances.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsInterface_IsError() {

--- a/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
+++ b/test/UnitTests/Kvasir/Translation/PropertyTypes.cs
@@ -244,13 +244,18 @@ namespace UT.Kvasir.Translation {
             var source = typeof(SlackChannel);
 
             // Act
-            var translate = () => translator[source];
+            var translation = translator[source];
 
             // Assert
-            translate.Should().FailWith<InvalidPropertyInDataModelException>()
-                .WithLocation("`SlackChannel` → NumMessages")
-                .WithProblem("type `MessageCount<short>` is a closed generic type and cannot be the backing type of a property")
-                .EndMessage();
+            translation.Relations.Should().BeEmpty();
+            translation.Principal.Table.Should()
+                .HaveField("ID").OfTypeGuid().BeingNonNullable().And
+                .HaveField("ChannelName").OfTypeText().BeingNonNullable().And
+                .HaveField("Members").OfTypeInt64().BeingNonNullable().And
+                .HaveField("IsPrivate").OfTypeBoolean().BeingNonNullable().And
+                .HaveField("NumMessages.Count").OfTypeInt16().BeingNullable().And
+                .HaveNoOtherFields().And
+                .HaveNoOtherForeignKeys();
         }
 
         [TestMethod] public void PropertyTypeIsAbstractClass_IsError() {
@@ -959,7 +964,7 @@ namespace UT.Kvasir.Translation {
             // Assert
             translate.Should().FailWith<InvalidPropertyInDataModelException>()
                 .WithLocation("`Caricature` → <synthetic> `SaleHistory` → Item")
-                .WithProblem("type `KeyValuePair<DateTime, decimal>` is a closed generic type and cannot be the backing type of a property")
+                .WithProblem("type `KeyValuePair<DateTime, decimal>` comes from assembly *, not from user assembly*")
                 .EndMessage();
         }
 

--- a/test/UnitTests/Kvasir/Translation/TableNaming.cs
+++ b/test/UnitTests/Kvasir/Translation/TableNaming.cs
@@ -42,7 +42,7 @@ namespace UT.Kvasir.Translation {
             var translation = translator[source];
 
             // Assert
-            translation.Principal.Table.Name.Should().Be("PokemonTable");
+            translation.Principal.Table.Name.Should().Be("TableNaming+PokemonTable");
         }
 
         [TestMethod] public void NamespaceExcludedFromRelationTableName() {

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -118,7 +118,7 @@ namespace UT.Kvasir.Translation {
             public ArrayList Vector { get; set; } = [];
         }
 
-        // Test Scenario: Struct Type from the C# Standard Library (✓recognized✓)
+        // Test Scenario: Struct Type from the C# Standard Library (✗not permitted✗)
         public class Emoji {
             [Flags] public enum Platform { iOS = 1, Android = 2, Slack = 4, Facebook = 8 }
 
@@ -149,8 +149,10 @@ namespace UT.Kvasir.Translation {
             public short Year { get; set; }
         }
 
-        // Test Scenario: User-Defined Closed Generic (✗not permitted✗)
-        public class MessageCount<T> {}
+        // Test Scenario: User-Defined Closed Generic (✓recognized✓)
+        public struct MessageCount<T> {
+            public T Count { get; set; }
+        }
         public class SlackChannel {
             [PrimaryKey] public Guid ID { get; set; }
             public string ChannelName { get; set; } = "";
@@ -911,14 +913,14 @@ namespace UT.Kvasir.Translation {
             protected Trademark(int key) : base(key) {}
         }
 
-        // Test Scenario: Generic Type (✗not permitted✗)
+        // Test Scenario: Generic Type (✓✗allowed if closed✗✓)
         public class Speedometer<TUnit> {
-            [PrimaryKey] public long MinSpeed { get; set; }
-            [PrimaryKey] public long MaxSpeed { get; set; }
+            [PrimaryKey] public required TUnit MinSpeed { get; set; }
+            [PrimaryKey] public required TUnit MaxSpeed { get; set; }
             public string Brand { get; set; } = "";
         }
 
-        // Test Scenario: Generic Localization (✗not permitted✗)
+        // Test Scenario: Generic Localization (✓✗allowed if closed✗✓)
         public class Emoticon<TChar> : Localization<TChar, double, ulong> where TChar : notnull {
             public Emoticon(TChar key) : base(key) {}
         }


### PR DESCRIPTION
This commit loosens the requirements for an Entity Type to allow closed generics to serve in that role. Because each closed generic type is its own type, the unique mappings across the framework are maintained. Some small changes have been made to the table-naming algorithm to render generic types appropriately (i.e. Foo<int>). Closed generics must still be non-abstract and meet all the other restrictions.

A minor change was made to facilitate some of the naming here. The [ExcludeNamespaceFromName] annotation no longer strips any nesting classes from the default name, only the namespace. This is arguably fixing a bug.