### PR TITLE
Harden Rules About Read-Only-ness of Pre-Defined Entities

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -9832,6 +9832,32 @@
               The actual number of pre-defined instances that were exposed.
             </param>
         </member>
+        <member name="T:Kvasir.Translation.NotReadOnlyException">
+            <summary>
+              An exception that is raised when a Relation or Localization that should be read-only (because it is part of a
+              Pre-Defined Entity) but is not.
+            </summary>
+        </member>
+        <member name="M:Kvasir.Translation.NotReadOnlyException.#ctor(Kvasir.Translation.Context)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.NotReadOnlyException"/> for a Relation on a Pre-Defined Entity that is not
+              read-only.
+            </summary>
+            <param name="context">
+              The <see cref="T:Kvasir.Translation.Context"/> at which the problematic Relation was encountered.
+            </param>
+        </member>
+        <member name="M:Kvasir.Translation.NotReadOnlyException.#ctor(Kvasir.Translation.Context,System.Type)">
+            <summary>
+              Constructs a new <see cref="T:Kvasir.Translation.NotReadOnlyException"/> for a Pre-Defined Localization taht is not read-only.
+            </summary>
+            <param name="context">
+              The <see cref="T:Kvasir.Translation.Context"/> at which the problematic Localization type was encountered.
+            </param>
+            <param name="_">
+              [tag dispatch]
+            </param>
+        </member>
         <member name="T:Kvasir.Translation.NotRelationException">
             <summary>
               An exception that is raised when an annotation that is only applicable to Relations is applied to a property

--- a/src/Kvasir/Translation/Categorization.cs
+++ b/src/Kvasir/Translation/Categorization.cs
@@ -34,7 +34,12 @@ namespace Kvasir.Translation {
             }
             else if (self.IsInstanceOf(typeof(IRelation))) {
                 // `IRelation` is an instance of itself, so this must come later
-                return TypeCategory.Relation;
+                if (self.Name.Contains("ReadOnly")) {
+                    return TypeCategory.ReadOnlyRelation;
+                }
+                else {
+                    return TypeCategory.Relation;
+                }
             }
             else if (self.IsGenericTypeDefinition) {
                 return TypeCategory.OpenGeneric;
@@ -137,6 +142,7 @@ namespace Kvasir.Translation {
         public static TypeCategory Object { get; set; } = new TypeCategory("`object` (or `dynamic`)");
         public static TypeCategory OpenGeneric { get; set; } = new TypeCategory("an open generic type");
         public static TypeCategory Pointer { get; } = new TypeCategory("a pointer type");
+        public static TypeCategory ReadOnlyRelation { get; } = new TypeCategory("a read-only implementation of the `IRelation` interface");
         public static TypeCategory Relation { get; } = new TypeCategory("an implementation of the `IRelation` interface");
         public static TypeCategory Supported { get; } = new TypeCategory("a primitive type, `string`, `DateOnly`, `DateTime`, or `Guid`");
         public static TypeCategory StaticClass { get; } = new TypeCategory("a static class");

--- a/src/Kvasir/Translation/Exceptions/NotReadOnlyException.cs
+++ b/src/Kvasir/Translation/Exceptions/NotReadOnlyException.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Kvasir.Translation {
+    /// <summary>
+    ///   An exception that is raised when a Relation or Localization that should be read-only (because it is part of a
+    ///   Pre-Defined Entity) but is not.
+    /// </summary>
+    internal sealed class NotReadOnlyException : TranslationException {
+        /// <summary>
+        ///   Constructs a new <see cref="NotReadOnlyException"/> for a Relation on a Pre-Defined Entity that is not
+        ///   read-only.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="Context"/> at which the problematic Relation was encountered.
+        /// </param>
+        public NotReadOnlyException(Context context)
+            : base(
+                new Location(context.ToString()),
+                new Problem("a Relation on a Pre-Defined Entity must be read-only")
+              )
+        {}
+
+        /// <summary>
+        ///   Constructs a new <see cref="NotReadOnlyException"/> for a Pre-Defined Localization taht is not read-only.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="Context"/> at which the problematic Localization type was encountered.
+        /// </param>
+        /// <param name="_">
+        ///   [tag dispatch]
+        /// </param>
+        public NotReadOnlyException(Context context, Type _)
+            : base(
+                new Location(context.ToString()),
+                new Problem("a Pre-Defined Localization must be read-only")
+              )
+        {}
+    }
+}

--- a/src/Kvasir/Translation/TranslateEntity.cs
+++ b/src/Kvasir/Translation/TranslateEntity.cs
@@ -332,6 +332,12 @@ namespace Kvasir.Translation {
 
             var traits = TranslationTraits.None;
             if (IsPreDefined(source)) {
+                var indexer = source.GetProperties().FirstOrDefault(p => !p.GetIndexParameters().IsEmpty());
+                var setter = indexer?.GetSetMethod()!;
+                if (setter is not null && setter.IsPublic) {
+                    throw new NotReadOnlyException(context, source);
+                }
+
                 traits |= TranslationTraits.RequirePreDefined;
             }
 

--- a/src/Kvasir/Translation/TranslateType.cs
+++ b/src/Kvasir/Translation/TranslateType.cs
@@ -144,9 +144,12 @@ namespace Kvasir.Translation {
                     if (typeCategory.Equals(TypeCategory.Enumeration) || typeCategory.Equals(TypeCategory.Supported)) {
                         translation.Add(new SingleFieldGroup(context, property));
                     }
-                    else if (typeCategory.Equals(TypeCategory.Relation)) {
+                    else if (typeCategory.Equals(TypeCategory.Relation) || typeCategory.Equals(TypeCategory.ReadOnlyRelation)) {
                         if (!allowRelations) {
                             throw new NestedRelationException(context);
+                        }
+                        else if (requirePreDefined && !typeCategory.Equals(TypeCategory.ReadOnlyRelation)) {
+                            throw new NotReadOnlyException(context);
                         }
                         else if (property.CanWrite && !property.IsInitOnly()) {
                             throw new WriteableRelationException(context);

--- a/test/UnitTests/Kvasir/Translation/PreDefinedEntities.cs
+++ b/test/UnitTests/Kvasir/Translation/PreDefinedEntities.cs
@@ -581,5 +581,35 @@ namespace UT.Kvasir.Translation {
                 .WithProblem("a Pre-Defined Entity cannot contain a Relation or a Localization involving non-Pre-Defined Entity type `Deity`")
                 .EndMessage();
         }
+
+        [TestMethod] public void PreDefinedEntityWithNonReadOnlyRelation_IsError() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
+            var source = typeof(EgyptianKingdom);
+
+            // Act
+            var translate = () => translator[source];
+
+            // Assert
+            translate.Should().FailWith<NotReadOnlyException>()
+                .WithLocation("`EgyptianKingdom` → Pharaohs")
+                .WithProblem("a Relation on a Pre-Defined Entity must be read-only")
+                .EndMessage();
+        }
+
+        [TestMethod] public void NonReadOnlyPreDefinedLocalization() {
+            // Arrange
+            var translator = new Translator(NO_ENTITIES, NullLogger.Instance);
+            var source = typeof(Woodwind);
+
+            // Act
+            var translate = () => translator[source, Translator.AsLocalzation];
+
+            // Assert
+            translate.Should().FailWith<NotReadOnlyException>()
+                .WithLocation("`Woodwind`")
+                .WithProblem("a Pre-Defined Localization must be read-only")
+                .EndMessage();
+        }
     }
 }

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -1274,7 +1274,7 @@ namespace UT.Kvasir.Translation {
             [PrimaryKey] public ulong GameID { get; private init; }
             public string Title { get; private init; }
             public DateTime ReleaseDate { get; private init; }
-            public RelationSet<GamingMode> Modes { get; }
+            public IReadOnlyRelationSet<GamingMode> Modes { get; }
 
             public static ResidentEvil Original { get; } = new ResidentEvil(41099, "Resident Evil", new DateTime(1996, 3, 22));
             public static ResidentEvil Two { get; } = new ResidentEvil(875, "Resident Evil 2", new DateTime(1998, 1, 21));
@@ -1291,7 +1291,7 @@ namespace UT.Kvasir.Translation {
                 GameID = id;
                 Title = title;
                 ReleaseDate = release;
-                Modes = [GamingMode.SinglePlayer, GamingMode.MultiPlayer];
+                Modes = new RelationSet<GamingMode>() { GamingMode.SinglePlayer, GamingMode.MultiPlayer };
             }
         }
 
@@ -1639,7 +1639,7 @@ namespace UT.Kvasir.Translation {
             public record struct Theory {
                 public string? Name { get; set; }
                 public DateTime FirstProposed { get; set; }
-                public RelationSet<Scientist> Namesakes { get; }
+                public IReadOnlyRelationSet<Scientist> Namesakes { get; }
             }
 
             [PrimaryKey] public string Name { get; private init; }
@@ -1870,6 +1870,57 @@ namespace UT.Kvasir.Translation {
                 Domain = domain;
                 Parents = new RelationList<LocalizedGod>();
             }
+        }
+
+        // Test Scenario: Pre-Defined Entity with Non-Read-Only Relation (✗not permitted✗)
+        [PreDefined] public class EgyptianKingdom {
+            public record struct Dynasty(sbyte Index, ushort Year);
+
+            [PrimaryKey] public string Title { get; init; } = "";
+            public Dynasty FirstDynasty { get; init; }
+            public Dynasty LastDynasty { get; init; }
+            public RelationOrderedList<string> Pharaohs { get; init; } = new();
+
+            public static EgyptianKingdom EarlyDynastic { get; } = new EgyptianKingdom("Early");
+            public static EgyptianKingdom OldKingdom { get; } = new EgyptianKingdom("Old");
+            public static EgyptianKingdom FirstIntermediate { get; } = new EgyptianKingdom("First Intermediate");
+            public static EgyptianKingdom MiddleKingdom { get; } = new EgyptianKingdom("Middle");
+            public static EgyptianKingdom SecondIntermediate { get; } = new EgyptianKingdom("Second Intermediate");
+            public static EgyptianKingdom Hyksos { get; } = new EgyptianKingdom("Hyksos");
+            public static EgyptianKingdom NewKingdom { get; } = new EgyptianKingdom("New");
+            public static EgyptianKingdom ThirdIntermediate { get; } = new EgyptianKingdom("Third Intermediate");
+            public static EgyptianKingdom LatePeriod { get; } = new EgyptianKingdom("Late");
+
+            private EgyptianKingdom(string title) {
+                Title = title;
+                FirstDynasty = new Dynasty();
+                LastDynasty = new Dynasty();
+            }
+        }
+
+        // Test Scenario: Non-Read-Only Pre-Defined Localization (✗not permitted✗)
+        [PreDefined] public class Woodwind : Localization<string, char, bool> {
+            public static Woodwind Flute { get; } = new Woodwind("LOC_FLUTE_NAME");
+            public static Woodwind Piccolo { get; } = new Woodwind("LOC_PICCOLO_NAME");
+            public static Woodwind Bagpipes { get; } = new Woodwind("LOC_BAGPIPES_NAME");
+            public static Woodwind Oboe { get; } = new Woodwind("LOC_OBOE_NAME");
+            public static Woodwind Bassoon { get; } = new Woodwind("LOC_BASSOON_NAME");
+            public static Woodwind CorAnglais { get; } = new Woodwind("LOC_COR_ANGLAIS_NAME");
+            public static Woodwind Saxophone { get; } = new Woodwind("LOC_SAXOPHONE_NAME");
+            public static Woodwind Clarinet { get; } = new Woodwind("LOC_CLARINET_NAME");
+            public static Woodwind Harmonica { get; } = new Woodwind("LOC_HARMONICA_NAME");
+            public static Woodwind Recorder { get; } = new Woodwind("LOC_RECORDER_NAME");
+            public static Woodwind Contrabassoon { get; } = new Woodwind("LOC_CONTRABASSOON_NAME");
+            public static Woodwind Fife { get; } = new Woodwind("LOC_FIFE_NAME");
+            public static Woodwind Ocarina { get; } = new Woodwind("LOC_OCARINA_NAME");
+            public static Woodwind Aulos { get; } = new Woodwind("LOC_AULOS_NAME");
+
+            public new bool this[char locale] {
+                get { return base[locale]; }
+                set { base[locale] = value; }
+            }
+
+            private Woodwind(string key) : base(key) {}
         }
     }
 

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -481,6 +481,7 @@ Ecumenical Council
 Edible Arrangement
 Egg Roll
 Egyptian God
+Egyptian Kingdom
 Egyptian Pyramid
 Eigenvector
 Elegy
@@ -1520,6 +1521,7 @@ Wiretap
 Witch Hunt
 Wizard
 Woodshop
+Woodwind
 Word of the Day
 Word Search
 Wordle


### PR DESCRIPTION
This commit adds two new restrictions:

   1) Pre-Defined Entities cannot have Relation-type properties that are not read-only Relations
   2) Pre-Defined Localizations must have a non-writeable indexer

This is commensurate with the requirement that a Read-Only Entity's properties are all non-writeable.