### PR TITLE
Fix BUg with Localizations Referenced by Pre-Defined and Regular Enti…

### DIFF
--- a/src/Kvasir/Intellisense.xml
+++ b/src/Kvasir/Intellisense.xml
@@ -11826,6 +11826,18 @@
               <see cref="T:Kvasir.Translation.LocalizationTracker"/> when starting from <paramref name="source"/>.
             </returns>
         </member>
+        <member name="M:Kvasir.Translation.LocalizationTracker.AsChainFrom(System.Type)">
+            <summary>
+              Creates a <see cref="T:Cybele.Core.PropertyChain"/> reflecting the access path to the <see cref="T:Kvasir.Translation.LocalizationTracker"/>.
+            </summary>
+            <param name="source">
+              The starting Entity type.
+            </param>
+            <returns>
+              A <see cref="T:Cybele.Core.PropertyChain"/> reflecting the translation state of the Localiaztion represented by the
+              <see cref="T:Kvasir.Translation.LocalizationTracker"/> when starting from <paramref name="source"/>.
+            </returns>
+        </member>
         <member name="T:Kvasir.Translation.ReconstitutionHelper">
             <summary>
               A helper class for evaluating a type's constructors for usability in Reconstitution.
@@ -12391,8 +12403,9 @@
             <param name="Reconstitutor">The plan that can recreate a CLR object from a row of data stored in the Principal Table.</param>
             <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitutes the Primary Key in the Principal Table.</param>
             <param name="PreDefinedInstances">The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</param>
+            <param name="Localizations">The Localiaztions referenced by the <see cref="P:Kvasir.Translation.PrincipalTableDef.PreDefinedInstances"/> of the Entity.</param>
         </member>
-        <member name="M:Kvasir.Translation.PrincipalTableDef.#ctor(Kvasir.Schema.ITable,Kvasir.Extraction.DataExtractionPlan,Kvasir.Reconstitution.DataReconstitutionPlan,Kvasir.Extraction.DataExtractionPlan,System.Collections.Generic.IReadOnlyList{System.Object})">
+        <member name="M:Kvasir.Translation.PrincipalTableDef.#ctor(Kvasir.Schema.ITable,Kvasir.Extraction.DataExtractionPlan,Kvasir.Reconstitution.DataReconstitutionPlan,Kvasir.Extraction.DataExtractionPlan,System.Collections.Generic.IReadOnlyList{System.Object},System.Collections.Generic.IReadOnlySet{System.Object})">
             <summary>
               The definition of a Principal Table.
             </summary>
@@ -12402,6 +12415,7 @@
             <param name="Reconstitutor">The plan that can recreate a CLR object from a row of data stored in the Principal Table.</param>
             <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitutes the Primary Key in the Principal Table.</param>
             <param name="PreDefinedInstances">The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</param>
+            <param name="Localizations">The Localiaztions referenced by the <see cref="P:Kvasir.Translation.PrincipalTableDef.PreDefinedInstances"/> of the Entity.</param>
         </member>
         <member name="P:Kvasir.Translation.PrincipalTableDef.Table">
             <summary>The schema model for the Principal Table.</summary>
@@ -12418,6 +12432,9 @@
         <member name="P:Kvasir.Translation.PrincipalTableDef.PreDefinedInstances">
             <summary>The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</summary>
         </member>
+        <member name="P:Kvasir.Translation.PrincipalTableDef.Localizations">
+            <summary>The Localiaztions referenced by the <see cref="P:Kvasir.Translation.PrincipalTableDef.PreDefinedInstances"/> of the Entity.</summary>
+        </member>
         <member name="T:Kvasir.Translation.LocalizationTableDef">
             <summary>
               The definition of a Localization Table.
@@ -12427,7 +12444,7 @@
             <param name="Extractor">The plan that can extract the rows of data to be stored into the Localization Table.</param>
             <param name="Reconstitutor">The plan that can rercreate a CLR object from the key of a Localization Table.</param>
             <param name="Repopulator">The plan that can populate elements into a CLR Relation from a row of data stored in the Localization Table</param>
-            /// <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitutes the Primary Key in the Localization Table.</param>
+            <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitutes the Primary Key in the Localization Table.</param>
             <param name="PreDefinedInstances">The pre-defined instances to be populated into the Localization Table; empty for regular Localizations.</param>
         </member>
         <member name="M:Kvasir.Translation.LocalizationTableDef.#ctor(Kvasir.Schema.ITable,Kvasir.Extraction.LocalizationExtractionPlan,Kvasir.Reconstitution.DataReconstitutionPlan,Kvasir.Reconstitution.RelationRepopulationPlan,Kvasir.Extraction.DataExtractionPlan,System.Collections.Generic.IReadOnlyList{System.Object})">
@@ -12439,7 +12456,7 @@
             <param name="Extractor">The plan that can extract the rows of data to be stored into the Localization Table.</param>
             <param name="Reconstitutor">The plan that can rercreate a CLR object from the key of a Localization Table.</param>
             <param name="Repopulator">The plan that can populate elements into a CLR Relation from a row of data stored in the Localization Table</param>
-            /// <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitutes the Primary Key in the Localization Table.</param>
+            <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitutes the Primary Key in the Localization Table.</param>
             <param name="PreDefinedInstances">The pre-defined instances to be populated into the Localization Table; empty for regular Localizations.</param>
         </member>
         <member name="P:Kvasir.Translation.LocalizationTableDef.Table">
@@ -12455,7 +12472,7 @@
             <summary>The plan that can populate elements into a CLR Relation from a row of data stored in the Localization Table</summary>
         </member>
         <member name="P:Kvasir.Translation.LocalizationTableDef.KeyExtractor">
-            /// <summary>The plan that can extract the subset of a row of data that constitutes the Primary Key in the Localization Table.</summary>
+            <summary>The plan that can extract the subset of a row of data that constitutes the Primary Key in the Localization Table.</summary>
         </member>
         <member name="P:Kvasir.Translation.LocalizationTableDef.PreDefinedInstances">
             <summary>The pre-defined instances to be populated into the Localization Table; empty for regular Localizations.</summary>

--- a/src/Kvasir/Reconstitution/DirectRepopulator.cs
+++ b/src/Kvasir/Reconstitution/DirectRepopulator.cs
@@ -10,7 +10,7 @@ namespace Kvasir.Reconstitution {
     internal sealed class DirectRepopulator : IRepopulator {
         /// <inheritdoc/>
         public void Repopulate(IRelation relation, IEnumerable<object> elements) {
-            Debug.Assert(relation is not null && !relation.GetEnumerator().MoveNext());
+            Debug.Assert(relation is not null);
             Debug.Assert(elements is not null);
 
             foreach (var element in elements) {

--- a/src/Kvasir/Relations/RelationMap.cs
+++ b/src/Kvasir/Relations/RelationMap.cs
@@ -569,11 +569,9 @@ namespace Kvasir.Relations {
         void IRelation.Repopulate(object item) {
             Debug.Assert(item.GetType() == typeof(KeyValuePair<TKey, TValue>));
             Debug.Assert(deletions_.Count == 0);
-            Debug.Assert(statuses_.Values.All(v => v == Status.Saved));
+            Debug.Assert(statuses_.Values.All(v => v == Status.Saved || v == Status.New));
 
             var castedItem = (KeyValuePair<TKey, TValue>)item;
-            Debug.Assert(!impl_.ContainsKey(castedItem.Key));
-
             impl_[castedItem.Key] = castedItem.Value;
             statuses_[castedItem.Key] = Status.Saved;
         }

--- a/src/Kvasir/Transaction/Transactor.cs
+++ b/src/Kvasir/Transaction/Transactor.cs
@@ -159,6 +159,27 @@ namespace Kvasir.Transaction {
             int numLocalizationTypes = localizationTranslations_.Count;
             var allEntities = new Dictionary<int, List<object>>();
 
+            // Before doing any actual loads, we need to track all Localizations present on Pre-Defined Entities so that
+            // we can find them when performing Reconstitution later. We won't put them into the Entity storage yet, as
+            // that will happen during the Localizations' load step.
+            var preDefinedLocalizations = new Dictionary<Type, HashSet<object>>();
+            var preDefinedLocInstanceByKey = new Dictionary<Type, Dictionary<DBValue, object>>();
+            foreach (var translation in entityTranslations) {
+                foreach (var localization in translation.Principal.Localizations) {
+                    preDefinedLocalizations.TryAdd(localization.GetType(), []);
+                    preDefinedLocalizations[localization.GetType()].Add(localization);
+                }
+            }
+            foreach (var (type, localizations) in preDefinedLocalizations) {
+                var mapping = new Dictionary<DBValue, object>();
+                var translation = localizationTranslations.First(t => t.CLRSource == type);
+                var extractor = translation.Principal.KeyExtractor;
+                foreach (var localization in localizations) {
+                    mapping[extractor.ExtractFrom(localization)[0]] = localization;
+                }
+                preDefinedLocInstanceByKey[type] = mapping;
+            }
+
             // Load all the data from Localization Tables and create the Localization instances first
             var locRowsByKey = new List<Dictionary<DBValue, List<List<DBValue>>>>();
             var locInstByKey = new List<Dictionary<DBValue, object>>();
@@ -169,15 +190,17 @@ namespace Kvasir.Transaction {
                 var reader = await query.ExecuteReaderAsync();
 
                 var rows = new Dictionary<DBValue, List<List<DBValue>>>();
-                var instances = new Dictionary<DBValue, object>();
+                var instances = preDefinedLocInstanceByKey.GetValueOrDefault(localizationTranslations[idx].CLRSource, []);
 
                 while (reader.Read()) {
                     var fields = Enumerable.Range(0, reader.FieldCount).Select(i => DBValue.Create(reader[i])).ToList();
                     if (!rows.TryGetValue(fields[0], out List<List<DBValue>>? currentRows)) {
                         currentRows = [];
-                        var instance = localizationTranslations[idx].Principal.Reconstitutor.ReconstituteFrom([..fields.Take(1)]);
+                        var instance = localizationTranslations[idx].Principal.Reconstitutor.ReconstituteFrom([fields[0]]);
                         rows[fields[0]] = currentRows;
-                        instances[fields[0]] = instance;
+                        if (!instances.ContainsKey(fields[0])) {
+                            instances[fields[0]] = instance;
+                        }
                     }
                     currentRows.Add(fields);
                 }
@@ -206,7 +229,7 @@ namespace Kvasir.Transaction {
                     entityStorage_(entity);
                     creations.Add(entity);
                 }
-                
+
                 allEntities[idx] = creations;
                 logger_.LogDebug("{} instances of {} loaded", creations.Count, entityTranslations[idx].Principal.Reconstitutor.ResultType.Name);
             }

--- a/src/Kvasir/Translation/LocalizationTracker.cs
+++ b/src/Kvasir/Translation/LocalizationTracker.cs
@@ -1,7 +1,9 @@
-﻿using Cybele.Extensions;
+﻿using Cybele.Core;
+using Cybele.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 
 namespace Kvasir.Translation {
@@ -90,6 +92,24 @@ namespace Kvasir.Translation {
             }
             context.Push(Property.PropertyType);
             return context;
+        }
+
+        /// <summary>
+        ///   Creates a <see cref="PropertyChain"/> reflecting the access path to the <see cref="LocalizationTracker"/>.
+        /// </summary>
+        /// <param name="source">
+        ///   The starting Entity type.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="PropertyChain"/> reflecting the translation state of the Localiaztion represented by the
+        ///   <see cref="LocalizationTracker"/> when starting from <paramref name="source"/>.
+        /// </returns>
+        public PropertyChain AsChainFrom(Type source) {
+            var chain = new PropertyChain(source, decontextualizedAccessPath_[0]);
+            foreach (var propertyName in decontextualizedAccessPath_.Skip(1)) {
+                chain = chain.Append(propertyName);
+            }
+            return chain;
         }
 
 

--- a/src/Kvasir/Translation/TableDefs.cs
+++ b/src/Kvasir/Translation/TableDefs.cs
@@ -13,12 +13,14 @@ namespace Kvasir.Translation {
     /// <param name="Reconstitutor">The plan that can recreate a CLR object from a row of data stored in the Principal Table.</param>
     /// <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitutes the Primary Key in the Principal Table.</param>
     /// <param name="PreDefinedInstances">The pre-defined instances to be populated into the Principal Table; empty for regular Entities.</param>
+    /// <param name="Localizations">The Localiaztions referenced by the <see cref="PreDefinedInstances"/> of the Entity.</param>
     internal sealed record class PrincipalTableDef(
         ITable Table,
         DataExtractionPlan Extractor,
         DataReconstitutionPlan Reconstitutor,
         DataExtractionPlan KeyExtractor,
-        IReadOnlyList<object> PreDefinedInstances
+        IReadOnlyList<object> PreDefinedInstances,
+        IReadOnlySet<object> Localizations
     );
 
     /// <summary>
@@ -29,7 +31,7 @@ namespace Kvasir.Translation {
     /// <param name="Extractor">The plan that can extract the rows of data to be stored into the Localization Table.</param>
     /// <param name="Reconstitutor">The plan that can rercreate a CLR object from the key of a Localization Table.</param>
     /// <param name="Repopulator">The plan that can populate elements into a CLR Relation from a row of data stored in the Localization Table</param>
-    /// /// <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitutes the Primary Key in the Localization Table.</param>
+    /// <param name="KeyExtractor">The plan that can extract the subset of a row of data that constitutes the Primary Key in the Localization Table.</param>
     /// <param name="PreDefinedInstances">The pre-defined instances to be populated into the Localization Table; empty for regular Localizations.</param>
     internal sealed record class LocalizationTableDef(
         ITable Table,

--- a/src/Kvasir/Translation/TranslateEntity.cs
+++ b/src/Kvasir/Translation/TranslateEntity.cs
@@ -10,8 +10,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Kvasir.Relations;
 using System.Reflection;
-using System.Xml.Linq;
 
 namespace Kvasir.Translation {
     internal sealed partial class Translator {
@@ -130,13 +130,27 @@ namespace Kvasir.Translation {
             if (!IsPreDefined(source)) {
                 var reconstitutor = ReconstitutionHelper.MakeCreator(context, source, fieldGroups, false, false);
                 var creator = new DataReconstitutionPlan(reconstitutor);
-                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor, []);
+                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor, [], new HashSet<object>());
             }
             else {
                 var instances = GetPreDefinedInstances(context, source);
+                var localizationChains = localizationTrackersCache_[source].Select(t => t.AsChainFrom(source));
                 var matcher = new KeyMatcher(() => instances, pkExtractor);
                 var creator = MakePreDefinedReconstitutionPlan(context, table, matcher, source);
-                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor, [..instances]);
+
+                // put the chains on the outside of the double loop because they will most often be empty, so the entire
+                // thing can be quickly short-circuited
+                var localizations = new HashSet<object>();
+                foreach (var chain in localizationChains) {
+                    foreach (var instance in instances) {
+                        var localization = chain.GetValue(instance);
+                        if (localization is not null) {
+                            localizations.Add(localization);
+                        }
+                    }
+                }
+
+                principal = new PrincipalTableDef(table, extractor, creator, pkExtractor, [..instances], localizations);
             }
 
             principalTableCache_.Add(source, principal);
@@ -246,6 +260,30 @@ namespace Kvasir.Translation {
                 var elementExtractor = new DataExtractionPlan(Enumerable.Repeat(relationGroup.Extractor, 1));
                 var table = new Table(tableName, fields, primaryKey, candidateKeys, foreignKeys, constraints);
                 var extractor = new RelationExtractionPlan(extractRelationProperty, elementExtractor);
+
+                if (IsPreDefined(source)) {
+                    var localizationChains = localizationTrackersCache_[syntheticType].Select(t => t.AsChainFrom(syntheticType));
+                    var instances = principalTableCache_[source].PreDefinedInstances;
+
+                    var localizations = new HashSet<object>(principalTableCache_[source].Localizations);
+                    foreach (var chain in localizationChains) {
+                        foreach (var instance in instances) {
+                            var relation = (IRelation?)extractRelationProperty.ExtractFrom(instance);
+                            if (relation is not null) {
+                                var iter = relation.GetEnumerator();
+                                while (iter.MoveNext()) {
+                                    Debug.Assert(iter.Current.Status == Status.New);
+                                    var localization = chain.GetValue(iter.Current.Item);
+                                    if (localization is not null) {
+                                        localizations.Add(localization);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    principalTableCache_[source] = principalTableCache_[source] with { Localizations = localizations };
+                }
 
                 RelationRepopulationPlan? repopulationPlan = null;
                 if (relationGroup.Creator.HasValue) {

--- a/src/Kvasir/Translation/Translator.cs
+++ b/src/Kvasir/Translation/Translator.cs
@@ -44,8 +44,12 @@ namespace Kvasir.Translation {
                 }
 
                 var context = new Context(source);
-                var principal = TranslatePrincipalTable(context, source);
+                TranslatePrincipalTable(context, source);
                 var relations = TranslateRelationTables(source);
+
+                // translating the Relation Tables can cause the principal translation to change because of the
+                // discovery of Relation-nested Localizations
+                var principal = principalTableCache_[source];
 
                 var traits = IsPreDefined(source) ? TranslationTraits.RequirePreDefined : TranslationTraits.None;
                 var sourceTypes = Enumerable.Repeat(source, 1).Concat(relationTypesFromEntity_[source]);

--- a/test/UnitTests/Kvasir/Transaction/Selection.cs
+++ b/test/UnitTests/Kvasir/Transaction/Selection.cs
@@ -846,6 +846,71 @@ namespace UT.Kvasir.Transaction {
             localizedCell[2].Should().Be(localizedCells[0][true].CellID);
         }
 
+        [TestMethod] public async Task LocalizationReferencedByPreDefinedEntityAndRegularEntity() {
+            // Arrange
+            var laxative = new object[] { Guid.NewGuid(), "Poo-Max", false, Cervid.Moose.CommonName.Key, 3U };
+            var moose = new object[] { Cervid.Moose.CommonName.Key, Cervid.Moose.Genus, Cervid.Moose.Species };
+            var reindeer = new object[] { Cervid.Reindeer.CommonName.Key, Cervid.Reindeer.Genus, Cervid.Reindeer.Species };
+            var elk = new object[] { Cervid.Elk.CommonName.Key, Cervid.Elk.Genus, Cervid.Elk.Species };
+            var deer = new object[] { Cervid.Deer.CommonName.Key, Cervid.Deer.Genus, Cervid.Deer.Species };
+            var muntjac = new object[] { Cervid.Muntjac.CommonName.Key, Cervid.Muntjac.Genus, Cervid.Muntjac.Species };
+            var sambar = new object[] { Cervid.Sambar.CommonName.Key, Cervid.Sambar.Genus, Cervid.Sambar.Species };
+            var barasingha = new object[] { Cervid.Barasingha.CommonName.Key, Cervid.Barasingha.Genus, Cervid.Barasingha.Species };
+            var chital = new object[] { Cervid.Chital.CommonName.Key, Cervid.Chital.Genus, Cervid.Chital.Species };
+            var taruca = new object[] { Cervid.Taruca.CommonName.Key, Cervid.Taruca.Genus, Cervid.Taruca.Species };
+            var pudu = new object[] { Cervid.Pudu.CommonName.Key, Cervid.Pudu.Genus, Cervid.Pudu.Species };
+            var loc0a = new object[] { Cervid.Moose.CommonName.Key, ConversionOf(Language.English), Cervid.Moose.CommonName[Language.English] };
+            var loc0b = new object[] { Cervid.Moose.CommonName.Key, ConversionOf(Language.German), "Elch" };
+            var loc0c = new object[] { Cervid.Moose.CommonName.Key, ConversionOf(Language.Italian), "Alce" };
+            var loc1 = new object[] { Cervid.Reindeer.CommonName.Key, ConversionOf(Language.English), Cervid.Reindeer.CommonName[Language.English] };
+            var loc2 = new object[] { Cervid.Elk.CommonName.Key, ConversionOf(Language.English), Cervid.Elk.CommonName[Language.English] };
+            var loc3 = new object[] { Cervid.Deer.CommonName.Key, ConversionOf(Language.English), Cervid.Deer.CommonName[Language.English] };
+            var loc4 = new object[] { Cervid.Muntjac.CommonName.Key, ConversionOf(Language.English), Cervid.Muntjac.CommonName[Language.English] };
+            var loc5 = new object[] { Cervid.Sambar.CommonName.Key, ConversionOf(Language.English), Cervid.Sambar.CommonName[Language.English] };
+            var loc6 = new object[] { Cervid.Barasingha.CommonName.Key, ConversionOf(Language.English), Cervid.Barasingha.CommonName[Language.English] };
+            var loc7 = new object[] { Cervid.Chital.CommonName.Key, ConversionOf(Language.English), Cervid.Chital.CommonName[Language.English] };
+            var loc8 = new object[] { Cervid.Taruca.CommonName.Key, ConversionOf(Language.English), Cervid.Taruca.CommonName[Language.English] };
+            var loc9 = new object[] { Cervid.Pudu.CommonName.Key, ConversionOf(Language.English), Cervid.Pudu.CommonName[Language.English] };
+            var fixture = new TestFixture(typeof(LocalizedText), typeof(Cervid), typeof(Laxative))
+                .WithEntityRow<Laxative>(laxative)
+                .WithEntityRow<Cervid>(moose)
+                .WithEntityRow<Cervid>(reindeer)
+                .WithEntityRow<Cervid>(elk)
+                .WithEntityRow<Cervid>(deer)
+                .WithEntityRow<Cervid>(muntjac)
+                .WithEntityRow<Cervid>(sambar)
+                .WithEntityRow<Cervid>(barasingha)
+                .WithEntityRow<Cervid>(chital)
+                .WithEntityRow<Cervid>(taruca)
+                .WithEntityRow<Cervid>(pudu)
+                .WithLocalizationRow<LocalizedText>(loc0a)
+                .WithLocalizationRow<LocalizedText>(loc0b)
+                .WithLocalizationRow<LocalizedText>(loc0c)
+                .WithLocalizationRow<LocalizedText>(loc1)
+                .WithLocalizationRow<LocalizedText>(loc2)
+                .WithLocalizationRow<LocalizedText>(loc3)
+                .WithLocalizationRow<LocalizedText>(loc4)
+                .WithLocalizationRow<LocalizedText>(loc5)
+                .WithLocalizationRow<LocalizedText>(loc6)
+                .WithLocalizationRow<LocalizedText>(loc7)
+                .WithLocalizationRow<LocalizedText>(loc8)
+                .WithLocalizationRow<LocalizedText>(loc9);
+
+            // Act
+            await fixture.InitializeSchema();
+            await fixture.Transactor.SelectAll();
+            var laxatives = fixture.Depot[typeof(Laxative)].Cast<Laxative>().ToList();
+
+            // Assert
+            loc0b[2].Should().Be(Cervid.Moose.CommonName[Language.German]);
+            loc0c[2].Should().Be(Cervid.Moose.CommonName[Language.Italian]);
+            laxative[0].Should().Be(laxatives[0].ProductID);
+            laxative[1].Should().Be(laxatives[0].Name);
+            laxative[2].Should().Be(laxatives[0].IsNatural);
+            laxatives[0].Keyword.Should().BeSameAs(Cervid.Moose.CommonName);
+            laxative[4].Should().Be(laxatives[0].ActionTime);
+        }
+
 
         private static string ConversionOf<T>(T enumerator) where T : Enum {
             var converter = new EnumToStringConverter(typeof(T)).ConverterImpl;

--- a/test/UnitTests/Kvasir/Transaction/_Entities.cs
+++ b/test/UnitTests/Kvasir/Transaction/_Entities.cs
@@ -542,6 +542,38 @@ namespace UT.Kvasir.Transaction {
             [Column(3)] public bool IsPluripotent { get; set; }
             [Column(4)] public string Owner { get; set; } = "";
         }
+
+        // Test Scenario: Localization on Pre-Defined Entity and Regular Entity
+        public class Laxative {
+            [PrimaryKey, Column(0)] public Guid ProductID { get; set; }
+            [Column(1)] public string Name { get; set; } = "";
+            [Column(2)] public bool IsNatural { get; set; }
+            [Column(3)] public LocalizedText Keyword { get; set; } = new("");
+            [Column(4)] public uint ActionTime { get; set; }
+        }
+        [PreDefined] public class Cervid {
+            [PrimaryKey, Column(0)] public LocalizedText CommonName { get; init; } = new("");
+            [Column(1)] public string Genus { get; init; } = "";
+            [Column(2)] public string Species { get; init; } = "";
+
+            public static Cervid Moose { get; } = new Cervid("Moose", "Alces", "alces");
+            public static Cervid Reindeer { get; } = new Cervid("Reindeer", "Rangifer", "tarandus");
+            public static Cervid Elk { get; } = new Cervid("Elk", "Cervus", "canadensis");
+            public static Cervid Deer { get; } = new Cervid("Deer", "Dama", "dama");
+            public static Cervid Muntjac { get; } = new Cervid("Muntjac", "Cervus", "muntjak");
+            public static Cervid Sambar { get; } = new Cervid("Sambar", "Rusa", "unicolor");
+            public static Cervid Barasingha { get; } = new Cervid("Barasingha", "Rucervus", "duvaucelli");
+            public static Cervid Chital { get; } = new Cervid("Chital", "Axis", "axis");
+            public static Cervid Taruca { get; } = new Cervid("Tarcua", "Hippocamelus", "antisensis");
+            public static Cervid Pudu { get; } = new Cervid("Pudu", "Pudu", "puda");
+
+            private Cervid(string name, string genus, string species) {
+                CommonName = new LocalizedText($"LOC_{name.ToUpper()}_NAME");
+                CommonName[Language.English] = name;
+                Genus = genus;
+                Species = species;
+            }
+        }
     }
 
     internal static class Insertion {

--- a/test/UnitTests/Kvasir/Translation/EntityShapes.cs
+++ b/test/UnitTests/Kvasir/Translation/EntityShapes.cs
@@ -27,6 +27,7 @@ namespace UT.Kvasir.Translation {
                 .HaveField("Hash").OfTypeInt32().BeingNonNullable().And
                 .HaveNoOtherFields();
             translation.Principal.PreDefinedInstances.Should().BeEmpty();
+            translation.Principal.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsRecordClass() {
@@ -46,6 +47,7 @@ namespace UT.Kvasir.Translation {
                 .HaveField("Blue").OfTypeUInt8().BeingNonNullable().And
                 .HaveNoOtherFields();
             translation.Principal.PreDefinedInstances.Should().BeEmpty();
+            translation.Principal.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsPartialClass() {
@@ -69,6 +71,7 @@ namespace UT.Kvasir.Translation {
                 .HaveField("RepublicanEVs").OfTypeUInt16().BeingNonNullable().And
                 .HaveNoOtherFields();
             translation.Principal.PreDefinedInstances.Should().BeEmpty();
+            translation.Principal.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsStaticClass_IsError() {
@@ -104,6 +107,7 @@ namespace UT.Kvasir.Translation {
                 .HaveField("Timestamp").OfTypeDateTime().BeingNonNullable().And
                 .HaveNoOtherFields();
             translation.Principal.PreDefinedInstances.Should().BeEmpty();
+            translation.Principal.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsInternal() {
@@ -124,6 +128,7 @@ namespace UT.Kvasir.Translation {
                 .HaveField("IsBuckled").OfTypeBoolean().BeingNonNullable().And
                 .HaveNoOtherFields();
             translation.Principal.PreDefinedInstances.Should().BeEmpty();
+            translation.Principal.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsLocalization() {
@@ -263,6 +268,7 @@ namespace UT.Kvasir.Translation {
                 .HaveField("Brand").OfTypeText().BeingNonNullable().And
                 .HaveNoOtherFields();
             translation.Principal.PreDefinedInstances.Should().BeEmpty();
+            translation.Principal.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void EntityTypeIsClosedGenericLocalization() {

--- a/test/UnitTests/Kvasir/Translation/PreDefinedEntities.cs
+++ b/test/UnitTests/Kvasir/Translation/PreDefinedEntities.cs
@@ -3,6 +3,7 @@ using Kvasir.Schema;
 using Kvasir.Translation;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
 
 using static UT.Kvasir.Translation.Globals;
 using static UT.Kvasir.Translation.PreDefinedEntities;
@@ -72,6 +73,7 @@ namespace UT.Kvasir.Translation {
             translation.Principal.PreDefinedInstances.Should().Contain(Disciple.Thaddeus);
             translation.Principal.PreDefinedInstances.Should().Contain(Disciple.SimonII);
             translation.Principal.PreDefinedInstances.Should().Contain(Disciple.Judas);
+            translation.Principal.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void Localization() {
@@ -126,6 +128,11 @@ namespace UT.Kvasir.Translation {
             translation.Principal.PreDefinedInstances.Should().Contain(BrainLobe.Parietal);
             translation.Principal.PreDefinedInstances.Should().Contain(BrainLobe.Temporal);
             translation.Principal.PreDefinedInstances.Should().Contain(BrainLobe.Frontal);
+            translation.Principal.Localizations.Should().HaveCount(4);
+            translation.Principal.Localizations.Should().Contain(BrainLobe.Occipital.Name);
+            translation.Principal.Localizations.Should().Contain(BrainLobe.Parietal.Name);
+            translation.Principal.Localizations.Should().Contain(BrainLobe.Temporal.Name);
+            translation.Principal.Localizations.Should().Contain(BrainLobe.Frontal.Name);
         }
 
         [TestMethod] public void PubliclyWriteableFieldProperty_IsError() {
@@ -202,6 +209,7 @@ namespace UT.Kvasir.Translation {
             translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.Hyphen);
             translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.OpenParenthesis);
             translation.Principal.PreDefinedInstances.Should().Contain(PunctuationMark.CloseParenthesis);
+            translation.Principal.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void PublicConstructor_IsError() {
@@ -259,6 +267,7 @@ namespace UT.Kvasir.Translation {
             translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Golgari);
             translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Boros);
             translation.Principal.PreDefinedInstances.Should().Contain(RavnicaGuild.Simic);
+            translation.Principal.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void AggregateNestedReferenceToPreDefinedEntity() {
@@ -292,6 +301,7 @@ namespace UT.Kvasir.Translation {
             translation.Principal.PreDefinedInstances.Should().Contain(MarxBrother.Groucho);
             translation.Principal.PreDefinedInstances.Should().Contain(MarxBrother.Gummo);
             translation.Principal.PreDefinedInstances.Should().Contain(MarxBrother.Zeppo);
+            translation.Principal.Localizations.Should().BeEmpty();
         }
 
         [TestMethod] public void RelationToPreDefinedEntity() {
@@ -367,6 +377,7 @@ namespace UT.Kvasir.Translation {
                 .HavePrimaryKey().OfFields("Index").And
                 .HaveNoOtherCandidateKeys().And
                 .HaveNoOtherForeignKeys();
+            translation.Principal.PreDefinedInstances.Should().HaveCount(7);
             translation.Principal.PreDefinedInstances.Should().Contain(DeadlySin.Lust);
             translation.Principal.PreDefinedInstances.Should().Contain(DeadlySin.Greed);
             translation.Principal.PreDefinedInstances.Should().Contain(DeadlySin.Gluttony);
@@ -374,6 +385,14 @@ namespace UT.Kvasir.Translation {
             translation.Principal.PreDefinedInstances.Should().Contain(DeadlySin.Pride);
             translation.Principal.PreDefinedInstances.Should().Contain(DeadlySin.Envy);
             translation.Principal.PreDefinedInstances.Should().Contain(DeadlySin.Wrath);
+            translation.Principal.Localizations.Should().HaveCount(7);
+            translation.Principal.Localizations.Should().Contain(DeadlySin.Lust.AssociatedColor);
+            translation.Principal.Localizations.Should().Contain(DeadlySin.Greed.AssociatedColor);
+            translation.Principal.Localizations.Should().Contain(DeadlySin.Gluttony.AssociatedColor);
+            translation.Principal.Localizations.Should().Contain(DeadlySin.Sloth.AssociatedColor);
+            translation.Principal.Localizations.Should().Contain(DeadlySin.Pride.AssociatedColor);
+            translation.Principal.Localizations.Should().Contain(DeadlySin.Envy.AssociatedColor);
+            translation.Principal.Localizations.Should().Contain(DeadlySin.Wrath.AssociatedColor);
         }
 
         [TestMethod] public void AggregateLocalizationToPreDefinedEntity() {
@@ -396,6 +415,7 @@ namespace UT.Kvasir.Translation {
                 .HavePrimaryKey().OfFields("Phase").And
                 .HaveNoOtherCandidateKeys().And
                 .HaveNoOtherForeignKeys();
+            translation.Principal.PreDefinedInstances.Should().HaveCount(8);
             translation.Principal.PreDefinedInstances.Should().Contain(LunarPhase.New);
             translation.Principal.PreDefinedInstances.Should().Contain(LunarPhase.WaxingCrescent);
             translation.Principal.PreDefinedInstances.Should().Contain(LunarPhase.FirstQuarter);
@@ -404,7 +424,8 @@ namespace UT.Kvasir.Translation {
             translation.Principal.PreDefinedInstances.Should().Contain(LunarPhase.WaningGibbous);
             translation.Principal.PreDefinedInstances.Should().Contain(LunarPhase.LastQuarter);
             translation.Principal.PreDefinedInstances.Should().Contain(LunarPhase.WaningCrescent);
-            translation.Principal.PreDefinedInstances.Should().Contain(LunarPhase.New);
+            translation.Principal.Localizations.Should().HaveCount(1);
+            translation.Principal.Localizations.Should().Contain(LunarPhase.New.Visibility.Hemisphere);
         }
 
         [TestMethod] public void RelationNestedLocalizationToPreDefinedEntity() {
@@ -427,6 +448,35 @@ namespace UT.Kvasir.Translation {
                     .WithOnDeleteBehavior(OnDelete.Cascade)
                     .WithOnUpdateBehavior(OnUpdate.Cascade).And
                 .HaveNoOtherForeignKeys();
+            translation.Principal.PreDefinedInstances.Should().HaveCount(9);
+            translation.Principal.PreDefinedInstances.Should().Contain(Cyclade.Syros);
+            translation.Principal.PreDefinedInstances.Should().Contain(Cyclade.Santorini);
+            translation.Principal.PreDefinedInstances.Should().Contain(Cyclade.Mykonos);
+            translation.Principal.PreDefinedInstances.Should().Contain(Cyclade.Naxos);
+            translation.Principal.PreDefinedInstances.Should().Contain(Cyclade.Folegandros);
+            translation.Principal.PreDefinedInstances.Should().Contain(Cyclade.Milos);
+            translation.Principal.PreDefinedInstances.Should().Contain(Cyclade.Irakleia);
+            translation.Principal.PreDefinedInstances.Should().Contain(Cyclade.Rineia);
+            translation.Principal.PreDefinedInstances.Should().Contain(Cyclade.Koufonisia);
+            translation.Principal.Localizations.Should().HaveCount(18);
+            translation.Principal.Localizations.Should().Contain(Cyclade.Syros.MentionedBy.First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Syros.MentionedBy.Skip(1).First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Santorini.MentionedBy.First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Santorini.MentionedBy.Skip(1).First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Mykonos.MentionedBy.First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Mykonos.MentionedBy.Skip(1).First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Naxos.MentionedBy.First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Naxos.MentionedBy.Skip(1).First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Folegandros.MentionedBy.First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Folegandros.MentionedBy.Skip(1).First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Milos.MentionedBy.First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Milos.MentionedBy.Skip(1).First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Irakleia.MentionedBy.First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Irakleia.MentionedBy.Skip(1).First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Rineia.MentionedBy.First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Rineia.MentionedBy.Skip(1).First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Koufonisia.MentionedBy.First());
+            translation.Principal.Localizations.Should().Contain(Cyclade.Koufonisia.MentionedBy.Skip(1).First());
         }
 
         [TestMethod] public void ReferenceToNonPreDefinedEntity_IsError() {

--- a/test/UnitTests/Kvasir/Translation/_Entities.cs
+++ b/test/UnitTests/Kvasir/Translation/_Entities.cs
@@ -1448,7 +1448,7 @@ namespace UT.Kvasir.Translation {
 
             private LunarPhase(string phase, ushort moonrise) {
                 Phase = phase;
-                Visibility = new Illumination();
+                Visibility = new Illumination() { Hemisphere = new LocalizedHemisphere("LOC_NORTHERN_HEMI") } ;
                 AverageMoonriseTime = moonrise;
             }
         }
@@ -1499,7 +1499,10 @@ namespace UT.Kvasir.Translation {
                 Name = name;
                 Population = population;
                 LandArea = area;
-                MentionedBy = new RelationSet<LocalizedGeographer>();
+                MentionedBy = new RelationSet<LocalizedGeographer>() {
+                    new LocalizedGeographer(islandNumber),
+                    new LocalizedGeographer(islandNumber * 100)
+                };
             }
         }
 

--- a/test/UnitTests/_TestEntities.txt
+++ b/test/UnitTests/_TestEntities.txt
@@ -252,6 +252,7 @@ Cenote
 Census
 Cepheid Variable
 Cereal
+Cervid
 Ceviche
 Chainsaw
 Chakra
@@ -795,6 +796,7 @@ Law Firm
 Lawn Gnome
 Lawn Mower
 Lawyer
+Laxative
 Layer of Skin
 Lazarus Pit
 Lease


### PR DESCRIPTION
…ties

This commit fixes a bug that manifests when a Localization instance is referenced by both a Pre-Defined Entity and a regular Entity. Pre-Defined Entities are not actually reconstituted (we use a SkipReconstitutor to simply leave the compile-time values as-are), but non-Pre-Defined Localizations are reconstituted. This means that we'll end up with two copies of the same platonic object: one referenced by the Pre-Defined Entity (hard-coded in the source) and one created by the Transactor from database values. Furthermore, they may have different localized values if the database has more entires.

To solve this, we have to record all the Localization instances that are referenced by Pre-Defined Entities. Pre-Defined Localizations cannot reference other Localizations, so that is not a problem. Then, when executing a Select-All query, we have to pre-load the referenced Localizations such that we do not reconstitute them. This results in a single instance per Localization key, either from the comile-time code or from the database.

A debug assertions had to be lifted, because we had assumptions that a Relation being repopulated was empty and that a RelationMap being repopulated had only saved items that are unique. Relaxing these constraints did not affect correctness of the code.