### PR TITLE
Canonicalize Relations on Load from Database

### DIFF
--- a/src/Kvasir/Transaction/Transactor.cs
+++ b/src/Kvasir/Transaction/Transactor.cs
@@ -255,7 +255,13 @@ namespace Kvasir.Transaction {
                     }
 
                     foreach (var (owningEntity, relationRows) in rows) {
+                        // Pre-Defined Entities are not loaded from the database, and their Relations are not
+                        // repopulated. This means that all the values hard-coded into the Relations are still in the
+                        // 'NEW' state, but we don't want that. This really shouldn't be a problem, because Pre-Defined
+                        // Entities cannot be changed, so there's never a reason to save them. But we may as well ensure
+                        // that the data model is internally consistent.
                         relation.Repopulator.Repopulate(owningEntity, relationRows);
+                        relation.Extractor.Canonicalize(owningEntity);
                     }
                 }
             }
@@ -265,6 +271,7 @@ namespace Kvasir.Transaction {
                 foreach (var (key, rows) in locRowsByKey[idx].OrderBy(kvp => kvp.Key.Datum)) {
                     var instance = locInstByKey[idx][key];
                     localizationTranslations[idx].Principal.Repopulator.Repopulate(instance, rows);
+                    localizationTranslations[idx].Principal.Extractor.Canonicalize(instance);
                 }
             }
         }


### PR DESCRIPTION
This commit ensures that all Relations are canonicalized upon load from database. This is not an issue for most Relations, because repopulation puts all elements into the SAVED state. However, repopulation is skipped for Relations on Pre-Defined Entities, since their state is hard-coded and required to be read-only. This means that those Relations' elements will all be in the NEW state. While this shouldn't be a problem (we'll never need to save them), we should make sure that the internal data model is consistent.